### PR TITLE
feat: v0.3 — Pro gates, JumpHostTunnel, multi-profile ConnectModal

### DIFF
--- a/scripts/mint-license.mjs
+++ b/scripts/mint-license.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+/**
+ * Mint a Pro license key (JWT HS256).
+ *
+ * Usage:
+ *   HMAC_SECRET=<secret> node scripts/mint-license.mjs <email> [github-username] [days]
+ *
+ * Output:
+ *   JWT token (print to stdout, redirect to clipboard or email)
+ *
+ * Examples:
+ *   HMAC_SECRET=mysecret node scripts/mint-license.mjs sponsor@example.com gh-user 365
+ *   HMAC_SECRET=mysecret node scripts/mint-license.mjs sponsor@example.com          # 365 days default
+ */
+
+import { createHmac } from 'crypto';
+
+const [,, email, sub = '', daysStr = '365'] = process.argv;
+
+if (!email) {
+  console.error('Usage: HMAC_SECRET=<secret> node scripts/mint-license.mjs <email> [github-username] [days]');
+  process.exit(1);
+}
+
+const secret = process.env.HMAC_SECRET;
+if (!secret) {
+  console.error('Error: HMAC_SECRET env var is not set');
+  process.exit(1);
+}
+
+const days  = parseInt(daysStr, 10);
+const now   = Math.floor(Date.now() / 1000);
+const exp   = now + days * 86400;
+
+const payload = { email, tier: 'pro', iat: now, exp, sub: sub || email };
+
+const header  = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+const body    = b64url(JSON.stringify(payload));
+const sig     = createHmac('sha256', secret).update(`${header}.${body}`).digest('base64url');
+const token   = `${header}.${body}.${sig}`;
+
+console.log(token);
+console.error(`\nMinted Pro license for ${email} (expires ${new Date(exp * 1000).toISOString().slice(0, 10)})`);
+
+function b64url(str) {
+  return Buffer.from(str).toString('base64url');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,8 +28,8 @@ export default class RemoteSshPlugin extends Plugin {
   async onload() {
     await this.loadSettings();
 
-    this.pool   = new ConnectionPool(this.authResolver, this.hostKeyStore);
-    this.engine = new SyncEngine(this.pool, this.app, this);
+    this.pool   = new ConnectionPool(this.authResolver, this.hostKeyStore, this.gate);
+    this.engine = new SyncEngine(this.pool, this.app, this, this.gate);
 
     logger.setDebug(this.settings.enableDebugLog);
     logger.setMaxLines(this.settings.maxLogLines);
@@ -128,7 +128,7 @@ export default class RemoteSshPlugin extends Plugin {
     );
 
     if (needsInteractive) {
-      new ConnectModal(this.app, profile, this.authResolver, doConnect).open();
+      new ConnectModal(this.app, [profile], this.authResolver, doConnect).open();
     } else {
       await doConnect().catch(e => new Notice(`Connect failed: ${e.message}`));
     }
@@ -157,13 +157,14 @@ export default class RemoteSshPlugin extends Plugin {
       new Notice('Remote SSH: No profiles configured. Add one in Settings → Remote SSH.');
       return;
     }
-    if (profiles.length === 1) {
-      this.connectProfile(profiles[0]);
-    } else {
-      // Multiple profiles — show picker (simple: use ConnectModal extended)
-      // For v0.1, just connect the first one; multi-profile picker is v0.3
-      this.connectProfile(profiles[0]);
-    }
+    // Show ConnectModal for both single and multi-profile cases
+    // Single profile: skips picker and goes straight to auth step
+    new ConnectModal(
+      this.app,
+      profiles,
+      this.authResolver,
+      profile => this.connectProfile(profile),
+    ).open();
   }
 
   private onStatusBarClick() {

--- a/src/ssh/ConnectionPool.ts
+++ b/src/ssh/ConnectionPool.ts
@@ -4,6 +4,8 @@ import type { SshProfile } from '../types';
 import { SftpSession } from './SftpSession';
 import { AuthResolver } from './AuthResolver';
 import { HostKeyStore } from './HostKeyStore';
+import { createJumpTunnel } from './JumpHostTunnel';
+import type { LicenseGate } from '../license/LicenseGate';
 import { logger } from '../util/logger';
 import { withRetry } from '../util/retry';
 
@@ -14,11 +16,17 @@ export class ConnectionPool {
   constructor(
     private authResolver: AuthResolver,
     private hostKeyStore: HostKeyStore,
+    private gate: LicenseGate,
   ) {}
 
   async getOrCreate(profile: SshProfile): Promise<SftpSession> {
     const existing = this.sessions.get(profile.id);
     if (existing && existing.isAlive) return existing;
+
+    // Pro gate: jump host requires Pro license
+    if (profile.jumpHost) {
+      this.gate.requirePro('Jump host');
+    }
 
     logger.info(`Connecting to ${profile.host}:${profile.port} as ${profile.username}`);
     const session = await withRetry(
@@ -36,7 +44,26 @@ export class ConnectionPool {
     return new SftpSession(sftp, client);
   }
 
-  private connectClient(profile: SshProfile): Promise<Client> {
+  private async connectClient(profile: SshProfile): Promise<Client> {
+    // Pro gate: SSH agent requires Pro license
+    if (profile.authMethod === 'agent') {
+      this.gate.requirePro('SSH agent authentication');
+    }
+
+    const authConfig = this.authResolver.buildAuthConfig(profile);
+
+    // Jump host tunnel (Pro): open the channel first, pass as `sock`
+    let sock: import('stream').Duplex | undefined;
+    if (profile.jumpHost) {
+      logger.info(`Opening jump tunnel via ${profile.jumpHost.host}`);
+      sock = await createJumpTunnel(
+        profile.jumpHost,
+        profile.host,
+        profile.port,
+        this.authResolver,
+      );
+    }
+
     return new Promise((resolve, reject) => {
       const client = new Client();
 
@@ -62,7 +89,6 @@ export class ConnectionPool {
         logger.warn(`SSH connection to ${profile.host} closed`);
       });
 
-      const authConfig = this.authResolver.buildAuthConfig(profile);
       const config: ConnectConfig = {
         host: profile.host,
         port: profile.port,
@@ -74,6 +100,7 @@ export class ConnectionPool {
           const keyBuf = Buffer.isBuffer(key) ? key : Buffer.from(key as string, 'base64');
           return this.hostKeyStore.verify(profile.host, profile.port, keyBuf);
         },
+        ...(sock ? { sock } : {}),
         ...authConfig,
       };
 

--- a/src/ssh/JumpHostTunnel.ts
+++ b/src/ssh/JumpHostTunnel.ts
@@ -1,0 +1,85 @@
+import { Client } from 'ssh2';
+import type { ConnectConfig } from 'ssh2';
+import type { JumpHostConfig } from '../types';
+import type { AuthResolver } from './AuthResolver';
+import { logger } from '../util/logger';
+
+/**
+ * Opens a direct-tcpip channel through a jump host and returns it as a
+ * duplex stream.  The stream is passed as `sock` to the main Client so the
+ * primary connection tunnels through without an intermediate local port.
+ */
+export async function createJumpTunnel(
+  jump: JumpHostConfig,
+  targetHost: string,
+  targetPort: number,
+  authResolver: AuthResolver,
+): Promise<import('stream').Duplex> {
+  const jumpClient = new Client();
+
+  const authConfig = buildJumpAuthConfig(jump, authResolver);
+
+  const config: ConnectConfig = {
+    host: jump.host,
+    port: jump.port,
+    username: jump.username,
+    readyTimeout: 15000,
+    ...authConfig,
+  };
+
+  await new Promise<void>((resolve, reject) => {
+    jumpClient.on('ready', () => {
+      logger.info(`Jump host ${jump.host} ready`);
+      resolve();
+    });
+    jumpClient.on('error', reject);
+    jumpClient.connect(config);
+  });
+
+  return new Promise((resolve, reject) => {
+    jumpClient.forwardOut(
+      '127.0.0.1', 0,
+      targetHost, targetPort,
+      (err, stream) => {
+        if (err) {
+          jumpClient.end();
+          reject(new Error(`Jump tunnel to ${targetHost}:${targetPort} failed: ${err.message}`));
+          return;
+        }
+        // Clean up jump client when the tunnel stream closes
+        stream.on('close', () => {
+          logger.info(`Jump tunnel closed, ending jump client`);
+          jumpClient.end();
+        });
+        resolve(stream as unknown as import('stream').Duplex);
+      },
+    );
+  });
+}
+
+function buildJumpAuthConfig(
+  jump: JumpHostConfig,
+  authResolver: AuthResolver,
+): Partial<ConnectConfig> {
+  switch (jump.authMethod) {
+    case 'password': {
+      const password = jump.passwordRef
+        ? authResolver.getSecret(jump.passwordRef)
+        : undefined;
+      if (!password) throw new Error(`No password in memory for jump host "${jump.host}"`);
+      return { password };
+    }
+    case 'privateKey': {
+      if (!jump.privateKeyPath) throw new Error(`No private key path for jump host "${jump.host}"`);
+      const fs = require('fs') as typeof import('fs');
+      return { privateKey: fs.readFileSync(jump.privateKeyPath) };
+    }
+    case 'agent': {
+      const socket = process.env.SSH_AUTH_SOCK;
+      if (!socket) throw new Error('SSH_AUTH_SOCK not set for jump host agent auth');
+      return { agent: socket };
+    }
+    default:
+      throw new Error(`Unknown jump host auth method: ${(jump as JumpHostConfig).authMethod}`);
+  }
+}

--- a/src/sync/SyncEngine.ts
+++ b/src/sync/SyncEngine.ts
@@ -12,6 +12,8 @@ import { IgnoreFilter } from './IgnoreFilter';
 import { WatcherBridge } from './WatcherBridge';
 import { toLocalPath, toRemotePath } from '../util/pathUtils';
 import { logger } from '../util/logger';
+import type { LicenseGate } from '../license/LicenseGate';
+import { FREE_POLL_INTERVAL_SEC } from '../constants';
 
 type StateListener = (state: SyncState) => void;
 
@@ -31,6 +33,7 @@ export class SyncEngine {
     private pool: ConnectionPool,
     private app: App,
     private plugin: Plugin,
+    private gate: LicenseGate,
   ) {
     this.filter = new IgnoreFilter([]);
     this.watcher = new WatcherBridge(this.queue, this.index);
@@ -77,7 +80,12 @@ export class SyncEngine {
     this.registerVaultEvents(profile);
 
     if (profile.autoSync && profile.pollIntervalSec > 0) {
-      this.startPolling(profile);
+      // Pro gate: auto-sync polling is a Pro feature
+      if (this.gate.isPro) {
+        this.startPolling(profile);
+      } else {
+        logger.info('Auto-sync requires Pro license — skipping poll timer');
+      }
     }
 
     this.setState(SyncState.WATCHING);
@@ -276,6 +284,10 @@ export class SyncEngine {
   }
 
   private startPolling(profile: SshProfile) {
+    const intervalSec = this.gate.effectivePollInterval(profile.pollIntervalSec);
+    if (intervalSec !== profile.pollIntervalSec) {
+      logger.info(`Poll interval clamped to ${intervalSec}s (Free tier minimum)`);
+    }
     this.pollTimer = setInterval(async () => {
       if (this.state !== SyncState.WATCHING) return;
       this.setState(SyncState.SYNCING);
@@ -286,7 +298,7 @@ export class SyncEngine {
       } finally {
         if ((this.state as SyncState) === SyncState.SYNCING) this.setState(SyncState.WATCHING);
       }
-    }, profile.pollIntervalSec * 1000);
+    }, intervalSec * 1000);
   }
 
   private stopPolling() {

--- a/src/ui/ConnectModal.ts
+++ b/src/ui/ConnectModal.ts
@@ -1,11 +1,15 @@
-import { Modal, App, Notice } from 'obsidian';
+import { Modal, App, Notice, Setting } from 'obsidian';
 import type { SshProfile } from '../types';
 import type { AuthResolver } from '../ssh/AuthResolver';
 
+/**
+ * Step 1 (multi-profile): choose which profile to connect.
+ * Step 2: enter any required secret (password / passphrase).
+ */
 export class ConnectModal extends Modal {
   constructor(
     app: App,
-    private profile: SshProfile,
+    private profiles: SshProfile[],
     private authResolver: AuthResolver,
     private onConnect: (profile: SshProfile) => Promise<void>,
   ) {
@@ -13,85 +17,118 @@ export class ConnectModal extends Modal {
   }
 
   onOpen() {
+    if (this.profiles.length === 0) {
+      this.renderEmpty();
+    } else if (this.profiles.length === 1) {
+      this.renderAuth(this.profiles[0]);
+    } else {
+      this.renderPicker();
+    }
+  }
+
+  // ─── No profiles ───────────────────────────────────────────────────────────
+
+  private renderEmpty() {
     const { contentEl } = this;
     contentEl.empty();
-    contentEl.createEl('h2', { text: `Connect: ${this.profile.name}` });
+    contentEl.createEl('h2', { text: 'Remote SSH' });
+    contentEl.createEl('p', { text: 'No SSH profiles configured.' });
+    contentEl.createEl('button', { text: 'Open Settings', cls: 'mod-cta' })
+      .onclick = () => this.close();
+  }
 
-    if (this.profile.authMethod === 'password') {
-      contentEl.createEl('label', { text: 'Password' });
-      const input = contentEl.createEl('input', { type: 'password', cls: 'remote-ssh-input' });
-      input.style.width = '100%';
-      input.style.marginBottom = '12px';
+  // ─── Profile picker ────────────────────────────────────────────────────────
 
-      const btn = contentEl.createEl('button', { text: 'Connect', cls: 'mod-cta' });
-      btn.style.width = '100%';
+  private renderPicker() {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl('h2', { text: 'Connect to remote vault' });
+    contentEl.createEl('p', { text: 'Select a profile:', cls: 'setting-item-description' });
 
-      const connect = async () => {
-        if (!input.value) { new Notice('Password required'); return; }
-        const ref = `${this.profile.id}:password`;
-        this.authResolver.storeSecret(ref, input.value);
-        this.profile.passwordRef = ref;
-        btn.disabled = true;
-        btn.setText('Connecting…');
-        try {
-          await this.onConnect(this.profile);
-          this.close();
-        } catch (e) {
-          btn.disabled = false;
-          btn.setText('Connect');
-          new Notice(`Connection failed: ${(e as Error).message}`);
-        }
-      };
-
-      input.addEventListener('keydown', e => { if (e.key === 'Enter') connect(); });
-      btn.onclick = connect;
-
-    } else if (this.profile.authMethod === 'privateKey' && this.profile.passphraseRef !== undefined) {
-      contentEl.createEl('label', { text: 'Key passphrase (leave blank if none)' });
-      const input = contentEl.createEl('input', { type: 'password', cls: 'remote-ssh-input' });
-      input.style.width = '100%';
-      input.style.marginBottom = '12px';
-
-      const btn = contentEl.createEl('button', { text: 'Connect', cls: 'mod-cta' });
-      btn.style.width = '100%';
-
-      const connect = async () => {
-        if (input.value) {
-          const ref = `${this.profile.id}:passphrase`;
-          this.authResolver.storeSecret(ref, input.value);
-          this.profile.passphraseRef = ref;
-        }
-        btn.disabled = true;
-        btn.setText('Connecting…');
-        try {
-          await this.onConnect(this.profile);
-          this.close();
-        } catch (e) {
-          btn.disabled = false;
-          btn.setText('Connect');
-          new Notice(`Connection failed: ${(e as Error).message}`);
-        }
-      };
-
-      btn.onclick = connect;
-
-    } else {
-      // No secrets needed
-      const btn = contentEl.createEl('button', { text: 'Connect', cls: 'mod-cta' });
-      btn.style.width = '100%';
-      btn.onclick = async () => {
-        btn.disabled = true;
-        btn.setText('Connecting…');
-        try {
-          await this.onConnect(this.profile);
-          this.close();
-        } catch (e) {
-          btn.disabled = false;
-          btn.setText('Connect');
-          new Notice(`Connection failed: ${(e as Error).message}`);
-        }
-      };
+    for (const profile of this.profiles) {
+      new Setting(contentEl)
+        .setName(profile.name)
+        .setDesc(`${profile.username}@${profile.host}:${profile.port}  →  ${profile.remotePath}`)
+        .addButton(btn => btn
+          .setButtonText('Connect')
+          .setCta()
+          .onClick(() => this.renderAuth(profile)));
     }
+  }
+
+  // ─── Auth step ─────────────────────────────────────────────────────────────
+
+  private renderAuth(profile: SshProfile) {
+    const { contentEl } = this;
+    contentEl.empty();
+    contentEl.createEl('h2', { text: `Connect: ${profile.name}` });
+    contentEl.createEl('p', {
+      text: `${profile.username}@${profile.host}:${profile.port}`,
+      cls: 'setting-item-description',
+    });
+
+    const needsPassword   = profile.authMethod === 'password';
+    const needsPassphrase = profile.authMethod === 'privateKey'; // optional but offer it
+
+    if (!needsPassword && !needsPassphrase) {
+      this.renderConnectButton(profile, contentEl);
+      return;
+    }
+
+    const label = needsPassword ? 'Password' : 'Key passphrase (leave blank if none)';
+    contentEl.createEl('label', { text: label });
+
+    const input = contentEl.createEl('input', { type: 'password' });
+    input.style.cssText = 'width:100%;margin:8px 0 16px;';
+
+    const btn = this.renderConnectButton(profile, contentEl, async () => {
+      const secret = input.value;
+      if (needsPassword && !secret) { new Notice('Password is required'); return false; }
+      if (secret) {
+        const ref = `${profile.id}:${needsPassword ? 'password' : 'passphrase'}`;
+        this.authResolver.storeSecret(ref, secret);
+        if (needsPassword) profile.passwordRef = ref;
+        else profile.passphraseRef = ref;
+      }
+      return true;
+    });
+
+    input.addEventListener('keydown', e => { if (e.key === 'Enter') btn.click(); });
+
+    // Back button when multiple profiles available
+    if (this.profiles.length > 1) {
+      const back = contentEl.createEl('button', { text: '← Back' });
+      back.style.marginTop = '8px';
+      back.onclick = () => this.renderPicker();
+    }
+  }
+
+  private renderConnectButton(
+    profile: SshProfile,
+    container: HTMLElement,
+    preConnect?: () => Promise<boolean>,
+  ): HTMLButtonElement {
+    const btn = container.createEl('button', { text: 'Connect', cls: 'mod-cta' });
+    btn.style.width = '100%';
+
+    btn.onclick = async () => {
+      if (preConnect) {
+        const ok = await preConnect();
+        if (!ok) return;
+      }
+      btn.disabled = true;
+      btn.setText('Connecting…');
+      try {
+        await this.onConnect(profile);
+        this.close();
+      } catch (e) {
+        btn.disabled = false;
+        btn.setText('Connect');
+        new Notice(`Connection failed: ${(e as Error).message}`);
+      }
+    };
+
+    return btn;
   }
 
   onClose() { this.contentEl.empty(); }


### PR DESCRIPTION
## Summary

- **Pro gate を全箇所に配線** — SSH agent / jump host / auto-sync polling
- **JumpHostTunnel** 実装 — 二段ホップ SSH (Client.forwardOut → sock)
- **ConnectModal をマルチプロファイル対応に** — プロファイル選択 → 認証の2ステップ UI
- **scripts/mint-license.mjs** — スポンサー向け JWT Pro キー発行 CLI

## Pro 機能ゲート一覧

| 機能 | ゲート箇所 | Free 動作 |
|---|---|---|
| SSH agent 認証 | `ConnectionPool.connectClient()` | `requirePro()` で Notice + 例外 |
| Jump host | `ConnectionPool.getOrCreate()` | 同上 |
| Auto-sync polling | `SyncEngine.connect()` | 無効化（upload-on-save は動作） |
| Poll 間隔 < 30s | `SyncEngine.startPolling()` | 30s にクランプ |
| プロファイル追加 2個目以降 | `SettingsTab` (v0.1 から実装済) | "Add" ボタン disabled |

## ライセンスキー発行

```bash
HMAC_SECRET=<your-secret> node scripts/mint-license.mjs sponsor@example.com gh-username 365
```

`HMAC_SECRET` は esbuild の `--define` で本番ビルドに埋め込む（secrets に設定）。

## Test plan

- [ ] `npm test` 30/30 pass
- [ ] `tsc --noEmit` エラーなし
- [ ] `npm run build` bundle < 600KB