### PR TITLE
feat: import SSH profiles from ~/.ssh/config

### DIFF
--- a/src/settings/ProfileForm.ts
+++ b/src/settings/ProfileForm.ts
@@ -2,6 +2,7 @@ import { Modal, App, Setting, Notice } from 'obsidian';
 import type { SshProfile, AuthMethod } from '../types';
 import { DEFAULT_PROFILE } from '../constants';
 import { expandHome } from '../util/pathUtils';
+import { readSshConfig, type SshConfigEntry } from '../ssh/SshConfigReader';
 import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
@@ -31,6 +32,25 @@ export class ProfileForm extends Modal {
     const { contentEl } = this;
     contentEl.empty();
     contentEl.createEl('h2', { text: this.isNew ? 'Add SSH Profile' : 'Edit Profile' });
+
+    // Import from ~/.ssh/config
+    const sshEntries = readSshConfig();
+    if (sshEntries.length > 0) {
+      new Setting(contentEl)
+        .setName('Import from SSH config')
+        .setDesc('Pre-fill fields from ~/.ssh/config')
+        .addDropdown(d => {
+          d.addOption('', '— select host —');
+          for (const e of sshEntries) d.addOption(e.alias, e.alias);
+          d.onChange(alias => {
+            if (!alias) return;
+            const e = sshEntries.find(x => x.alias === alias)!;
+            this.applyConfigEntry(e);
+            this.close();
+            new ProfileForm(this.app, this.profile, this.onSave).open();
+          });
+        });
+    }
 
     new Setting(contentEl)
       .setName('Profile name')
@@ -107,6 +127,21 @@ export class ProfileForm extends Modal {
       this.onSave(this.profile);
       this.close();
     };
+  }
+
+  private applyConfigEntry(e: SshConfigEntry) {
+    this.profile.name            = e.alias;
+    this.profile.host            = e.hostname;
+    this.profile.port            = e.port;
+    this.profile.username        = e.user;
+    if (e.identityFile) {
+      this.profile.authMethod    = 'privateKey';
+      this.profile.privateKeyPath = e.identityFile;
+    }
+    if (e.proxyJump) {
+      this.profile.jumpHost = { host: e.proxyJump, port: 22, username: e.user, authMethod: 'privateKey' };
+    }
+    this.profile.localCachePath  = path.join(os.homedir(), '.obsidian-remote', e.alias);
   }
 
   private validate(): boolean {

--- a/src/ssh/SshConfigReader.ts
+++ b/src/ssh/SshConfigReader.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+export interface SshConfigEntry {
+  alias: string;
+  hostname: string;
+  user: string;
+  port: number;
+  identityFile?: string;
+  proxyJump?: string;
+}
+
+export function readSshConfig(configPath?: string): SshConfigEntry[] {
+  const filePath = configPath ?? path.join(os.homedir(), '.ssh', 'config');
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+
+  const entries: SshConfigEntry[] = [];
+  let alias: string | null = null;
+  let current: Partial<SshConfigEntry> = {};
+
+  const flush = () => {
+    if (alias && current.hostname) {
+      entries.push(finalize(alias, current));
+    }
+  };
+
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const spaceIdx = line.indexOf(' ');
+    if (spaceIdx === -1) continue;
+    const key = line.slice(0, spaceIdx).toLowerCase();
+    const value = line.slice(spaceIdx + 1).trim();
+
+    if (key === 'host') {
+      flush();
+      if (value.includes('*') || value.includes('?')) {
+        alias = null;
+      } else {
+        alias = value;
+        current = {};
+      }
+      continue;
+    }
+
+    if (!alias) continue;
+
+    switch (key) {
+      case 'hostname':     current.hostname = value; break;
+      case 'user':         current.user = value; break;
+      case 'port':         current.port = parseInt(value) || 22; break;
+      case 'identityfile': current.identityFile = value.replace('~', os.homedir()); break;
+      case 'proxyjump':    current.proxyJump = value; break;
+    }
+  }
+
+  flush();
+
+  return entries;
+}
+
+function finalize(alias: string, e: Partial<SshConfigEntry>): SshConfigEntry {
+  return {
+    alias,
+    hostname:     e.hostname ?? alias,
+    user:         e.user ?? os.userInfo().username,
+    port:         e.port ?? 22,
+    identityFile: e.identityFile,
+    proxyJump:    e.proxyJump,
+  };
+}


### PR DESCRIPTION
## Summary

- `SshConfigReader.ts` を新規追加 — `~/.ssh/config` をパースして Host/HostName/User/Port/IdentityFile/ProxyJump を読み込む
- ProfileForm の「Add SSH Profile」にドロップダウンを追加 — ホストを選ぶだけで各フィールドが自動入力される
- `ProxyJump` は jumpHost に自動マップ

## Test plan

- [ ] `~/.ssh/config` にホストが複数ある状態で「Add SSH Profile」を開き、ドロップダウンにホスト一覧が表示されることを確認
- [ ] ホストを選択後、Host / Port / Username / Private key path が正しく入力されることを確認
- [ ] `ProxyJump` を持つホストを選択し、jumpHost に反映されることを確認
- [ ] `Host *` などワイルドカードエントリが一覧に出ないことを確認
- [ ] `~/.ssh/config` が存在しない場合はドロップダウンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)