### PR TITLE
feat: add observability infra and dev tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -853,8 +853,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1261,6 +1260,7 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1337,6 +1337,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -1541,6 +1542,7 @@
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.5",
@@ -1685,6 +1687,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1904,8 +1907,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2015,6 +2017,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2825,6 +2828,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3044,8 +3048,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -3142,6 +3145,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3173,6 +3177,7 @@
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3732,6 +3737,7 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",
@@ -3821,8 +3827,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "node esbuild.config.mjs",
     "build": "node esbuild.config.mjs production",
+    "dev:install": "node scripts/dev-install.mjs",
+    "build:install": "node esbuild.config.mjs production && node scripts/dev-install.mjs",
+    "cdp:tail": "node scripts/cdp-tail.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "lint": "eslint src --ext .ts",

--- a/scripts/cdp-tail.mjs
+++ b/scripts/cdp-tail.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/*
+ * CDP tail — connect to Obsidian's Chrome DevTools Protocol endpoint
+ * and stream Runtime.consoleAPICalled / Runtime.exceptionThrown events
+ * to stdout AND to ./cdp-console.log.
+ *
+ * Usage:
+ *   1. Launch Obsidian with `--remote-debugging-port=9222`
+ *      (Windows: edit the shortcut "Target" field; macOS/Linux: pass via argv)
+ *   2. node scripts/cdp-tail.mjs
+ *
+ * Requires Node 22+ (built-in WebSocket).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const CDP_HOST = process.env.CDP_HOST ?? '127.0.0.1';
+const CDP_PORT = process.env.CDP_PORT ?? '9222';
+const OUT_FILE = path.resolve(process.cwd(), 'cdp-console.log');
+
+if (typeof globalThis.WebSocket !== 'function') {
+  console.error('Node 22+ is required (built-in WebSocket). Current:', process.version);
+  process.exit(1);
+}
+
+async function fetchTargets() {
+  const res = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json`);
+  if (!res.ok) throw new Error(`CDP /json returned ${res.status}`);
+  return res.json();
+}
+
+function pickTarget(targets) {
+  // Prefer "page" type targets that are obsidian app windows; skip extensions.
+  const pages = targets.filter(t => t.type === 'page' && !/^chrome-extension:/.test(t.url));
+  if (pages.length === 0) {
+    throw new Error('No suitable CDP target found. Make sure Obsidian is running with --remote-debugging-port=' + CDP_PORT);
+  }
+  return pages[0];
+}
+
+function appendOut(line) {
+  fs.appendFile(OUT_FILE, line + '\n', () => {});
+}
+
+function fmtArg(arg) {
+  if (arg.value !== undefined) return JSON.stringify(arg.value);
+  if (arg.unserializableValue !== undefined) return arg.unserializableValue;
+  if (arg.description) return arg.description;
+  return arg.type ?? '<unknown>';
+}
+
+async function main() {
+  const targets = await fetchTargets();
+  const target = pickTarget(targets);
+  const wsUrl = target.webSocketDebuggerUrl;
+  console.error(`[cdp-tail] connecting to ${target.title || target.url}`);
+  console.error(`[cdp-tail] writing to ${OUT_FILE}`);
+
+  const ws = new WebSocket(wsUrl);
+  let nextId = 1;
+
+  ws.addEventListener('open', () => {
+    ws.send(JSON.stringify({ id: nextId++, method: 'Runtime.enable' }));
+    console.error('[cdp-tail] connected');
+  });
+
+  ws.addEventListener('message', (ev) => {
+    let msg;
+    try { msg = JSON.parse(typeof ev.data === 'string' ? ev.data : ev.data.toString()); }
+    catch { return; }
+
+    if (msg.method === 'Runtime.consoleAPICalled') {
+      const { type, args, timestamp } = msg.params;
+      const ts = new Date(timestamp).toISOString();
+      const text = (args ?? []).map(fmtArg).join(' ');
+      const line = `[${ts}] [console.${type}] ${text}`;
+      console.log(line);
+      appendOut(line);
+    } else if (msg.method === 'Runtime.exceptionThrown') {
+      const e = msg.params.exceptionDetails;
+      const ts = new Date(msg.params.timestamp).toISOString();
+      const desc = e?.exception?.description ?? e?.text ?? '<unknown exception>';
+      const line = `[${ts}] [exception] ${desc}`;
+      console.log(line);
+      appendOut(line);
+    }
+  });
+
+  ws.addEventListener('close', () => {
+    console.error('[cdp-tail] connection closed');
+    process.exit(0);
+  });
+
+  ws.addEventListener('error', (e) => {
+    console.error('[cdp-tail] websocket error:', e.message ?? e);
+  });
+}
+
+main().catch(err => {
+  console.error('[cdp-tail] fatal:', err.message ?? err);
+  process.exit(1);
+});

--- a/scripts/dev-install.mjs
+++ b/scripts/dev-install.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/*
+ * dev-install — copy build artifacts (main.js, manifest.json, styles.css)
+ * into the dev vault's plugins folder.
+ *
+ * Usage:
+ *   node scripts/dev-install.mjs
+ *   node scripts/dev-install.mjs <vault-root>
+ *
+ * The default vault root is read from the `REMOTE_SSH_DEV_VAULT` env var
+ * or falls back to `../SelfArchive-dev` relative to this script.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const vaultRoot = process.argv[2]
+  ?? process.env.REMOTE_SSH_DEV_VAULT
+  ?? path.resolve(repoRoot, '..', 'SelfArchive-dev');
+
+const manifestPath = path.join(repoRoot, 'manifest.json');
+if (!fs.existsSync(manifestPath)) {
+  console.error(`manifest.json not found at ${manifestPath}`);
+  process.exit(1);
+}
+const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+const targetDir = path.join(vaultRoot, '.obsidian', 'plugins', manifest.id);
+if (!fs.existsSync(path.join(vaultRoot, '.obsidian'))) {
+  console.error(`Vault root does not look like an Obsidian vault: ${vaultRoot}`);
+  console.error(`(no .obsidian directory found)`);
+  process.exit(1);
+}
+
+fs.mkdirSync(targetDir, { recursive: true });
+
+const files = ['main.js', 'manifest.json', 'styles.css'];
+for (const f of files) {
+  const src = path.join(repoRoot, f);
+  if (!fs.existsSync(src)) {
+    console.error(`missing build artifact: ${src} (run npm run build first)`);
+    process.exit(1);
+  }
+  const dst = path.join(targetDir, f);
+  fs.copyFileSync(src, dst);
+  console.log(`copied ${f} -> ${dst}`);
+}
+
+console.log(`\nplugin '${manifest.id}' v${manifest.version} installed to ${targetDir}`);
+console.log('Reload the plugin in Obsidian (Settings → Community plugins → toggle off/on).');

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, Notice, WorkspaceLeaf } from 'obsidian';
+import { Plugin, Notice, WorkspaceLeaf, FileSystemAdapter } from 'obsidian';
 import type { PluginSettings, SshProfile } from './types';
 import { DEFAULT_SETTINGS, PLUGIN_ID } from './constants';
 import { ConnectionPool } from './ssh/ConnectionPool';
@@ -13,6 +13,7 @@ import { SyncLogView, SYNC_LOG_VIEW_TYPE } from './ui/SyncLogView';
 import { SettingsTab } from './settings/SettingsTab';
 import { LicenseGate } from './license/LicenseGate';
 import { logger } from './util/logger';
+import { installErrorHook, uninstallErrorHook } from './util/errorHook';
 import * as path from 'path';
 import * as os from 'os';
 
@@ -30,11 +31,12 @@ export default class RemoteSshPlugin extends Plugin {
   async onload() {
     await this.loadSettings();
 
-    this.pool   = new ConnectionPool(this.authResolver, this.hostKeyStore, this.gate);
-    this.engine = new SyncEngine(this.pool, this.app, this, this.gate);
-
     logger.setDebug(this.settings.enableDebugLog);
     logger.setMaxLines(this.settings.maxLogLines);
+    this.installObservability();
+
+    this.pool   = new ConnectionPool(this.authResolver, this.hostKeyStore, this.gate);
+    this.engine = new SyncEngine(this.pool, this.app, this, this.gate);
 
     await this.gate.initialize(this.settings.licenseKey);
 
@@ -91,6 +93,32 @@ export default class RemoteSshPlugin extends Plugin {
     await this.engine.disconnect().catch(() => {});
     this.pool.destroyAll();
     this.statusBar.remove();
+    this.uninstallObservability();
+  }
+
+  private installObservability(): void {
+    try {
+      const adapter = this.app.vault.adapter;
+      if (adapter instanceof FileSystemAdapter) {
+        const base = adapter.getBasePath();
+        const logPath = path.join(base, '.obsidian', 'plugins', this.manifest.id, 'console.log');
+        logger.installFileSink(logPath);
+      } else {
+        logger.warn('vault.adapter is not FileSystemAdapter; file sink disabled');
+      }
+    } catch (e) {
+      logger.warn(`installFileSink failed: ${(e as Error).message}`);
+    }
+    logger.wrapConsole();
+    installErrorHook();
+    logger.info(`Plugin ${this.manifest.id} v${this.manifest.version} loaded`);
+  }
+
+  private uninstallObservability(): void {
+    logger.info(`Plugin ${this.manifest.id} unloading`);
+    uninstallErrorHook();
+    logger.unwrapConsole();
+    logger.uninstallFileSink();
   }
 
   async loadSettings() {

--- a/src/util/errorHook.ts
+++ b/src/util/errorHook.ts
@@ -1,0 +1,46 @@
+import { logger } from './logger';
+
+let installed = false;
+let onUnhandledRejection: ((e: PromiseRejectionEvent) => void) | null = null;
+let onError: ((e: ErrorEvent) => void) | null = null;
+
+export function installErrorHook(): void {
+  if (installed) return;
+  installed = true;
+
+  onUnhandledRejection = (e) => {
+    const reason = (e as PromiseRejectionEvent).reason;
+    let msg: string;
+    if (reason instanceof Error) {
+      msg = `unhandledrejection: ${reason.message}\n${reason.stack ?? ''}`;
+    } else {
+      try { msg = `unhandledrejection: ${JSON.stringify(reason)}`; }
+      catch { msg = `unhandledrejection: ${String(reason)}`; }
+    }
+    logger.error(msg);
+  };
+
+  onError = (e) => {
+    const stack = e.error instanceof Error ? e.error.stack : undefined;
+    logger.error(
+      `window.onerror: ${e.message} at ${e.filename}:${e.lineno}:${e.colno}` +
+      (stack ? `\n${stack}` : '')
+    );
+  };
+
+  window.addEventListener('unhandledrejection', onUnhandledRejection);
+  window.addEventListener('error', onError);
+}
+
+export function uninstallErrorHook(): void {
+  if (!installed) return;
+  installed = false;
+  if (onUnhandledRejection) {
+    window.removeEventListener('unhandledrejection', onUnhandledRejection);
+    onUnhandledRejection = null;
+  }
+  if (onError) {
+    window.removeEventListener('error', onError);
+    onError = null;
+  }
+}

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -1,12 +1,30 @@
+import * as fs from 'fs';
+import * as path from 'path';
 import type { LogLine } from '../types';
 
 type Level = LogLine['level'];
 
 const LEVELS: Record<Level, number> = { debug: 0, info: 1, warn: 2, error: 3 };
 
+const MAX_LOG_SIZE_BYTES = 5 * 1024 * 1024;
+const MAX_GENERATIONS = 3;
+
+type ConsoleFn = (...args: unknown[]) => void;
+interface ConsoleSnapshot {
+  log: ConsoleFn;
+  warn: ConsoleFn;
+  error: ConsoleFn;
+}
+
 export class Logger {
   private lines: LogLine[] = [];
   private listeners: Array<(line: LogLine) => void> = [];
+
+  private fileSink: fs.WriteStream | null = null;
+  private fileSinkPath: string | null = null;
+  private bytesWritten = 0;
+
+  private originalConsole: ConsoleSnapshot | null = null;
 
   constructor(
     private maxLines: number,
@@ -22,9 +40,11 @@ export class Logger {
     this.lines.push(line);
     if (this.lines.length > this.maxLines) this.lines.shift();
     this.listeners.forEach(fn => fn(line));
-    if (level === 'error') console.error(`[RemoteSSH] ${message}`);
-    else if (level === 'warn') console.warn(`[RemoteSSH] ${message}`);
-    else if (this.debug) console.log(`[RemoteSSH][${level}] ${message}`);
+    this.writeToFile(line);
+    const echo = this.originalConsole ?? console;
+    if (level === 'error') echo.error(`[RemoteSSH] ${message}`);
+    else if (level === 'warn') echo.warn(`[RemoteSSH] ${message}`);
+    else if (this.debug) echo.log(`[RemoteSSH][${level}] ${message}`);
   }
 
   debug_(msg: string) { this.emit('debug', msg); }
@@ -38,6 +58,140 @@ export class Logger {
   onLine(fn: (line: LogLine) => void): () => void {
     this.listeners.push(fn);
     return () => { this.listeners = this.listeners.filter(l => l !== fn); };
+  }
+
+  installFileSink(filePath: string): void {
+    if (this.fileSink) this.uninstallFileSink();
+    this.fileSinkPath = filePath;
+    try {
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    } catch (e) {
+      this.fallbackError(`installFileSink mkdir failed: ${(e as Error).message}`);
+      return;
+    }
+    this.maybeRotateOnOpen();
+    this.openSinkStream();
+  }
+
+  uninstallFileSink(): void {
+    if (this.fileSink) {
+      try { this.fileSink.end(); } catch { /* ignore */ }
+    }
+    this.fileSink = null;
+    this.fileSinkPath = null;
+    this.bytesWritten = 0;
+  }
+
+  wrapConsole(): void {
+    if (this.originalConsole) return;
+    const snapshot: ConsoleSnapshot = {
+      log: console.log.bind(console),
+      warn: console.warn.bind(console),
+      error: console.error.bind(console),
+    };
+    this.originalConsole = snapshot;
+    console.log = (...args: unknown[]) => {
+      snapshot.log(...args);
+      this.captureExternal('debug', args);
+    };
+    console.warn = (...args: unknown[]) => {
+      snapshot.warn(...args);
+      this.captureExternal('warn', args);
+    };
+    console.error = (...args: unknown[]) => {
+      snapshot.error(...args);
+      this.captureExternal('error', args);
+    };
+  }
+
+  unwrapConsole(): void {
+    if (!this.originalConsole) return;
+    console.log = this.originalConsole.log;
+    console.warn = this.originalConsole.warn;
+    console.error = this.originalConsole.error;
+    this.originalConsole = null;
+  }
+
+  private captureExternal(level: Level, args: unknown[]): void {
+    if (!this.fileSink) return;
+    const msg = args.map(a => this.formatArg(a)).join(' ');
+    if (msg.startsWith('[RemoteSSH]')) return;
+    const line: LogLine = { level, timestamp: Date.now(), message: `[external] ${msg}` };
+    this.writeToFile(line);
+  }
+
+  private formatArg(a: unknown): string {
+    if (a instanceof Error) return a.stack ?? a.message;
+    if (typeof a === 'string') return a;
+    try { return JSON.stringify(a); } catch { return String(a); }
+  }
+
+  private writeToFile(line: LogLine): void {
+    if (!this.fileSink) return;
+    const ts = new Date(line.timestamp).toISOString();
+    const text = `[${ts}] [${line.level}] ${line.message}\n`;
+    try {
+      this.fileSink.write(text);
+      this.bytesWritten += Buffer.byteLength(text);
+      if (this.bytesWritten >= MAX_LOG_SIZE_BYTES) this.rotateNow();
+    } catch (e) {
+      this.fallbackError(`logger writeToFile failed: ${(e as Error).message}`);
+    }
+  }
+
+  private maybeRotateOnOpen(): void {
+    if (!this.fileSinkPath) return;
+    try {
+      const stat = fs.statSync(this.fileSinkPath);
+      if (stat.size >= MAX_LOG_SIZE_BYTES) this.cascadeRotate();
+    } catch { /* file does not exist yet */ }
+  }
+
+  private rotateNow(): void {
+    if (!this.fileSinkPath) return;
+    if (this.fileSink) {
+      try { this.fileSink.end(); } catch { /* ignore */ }
+      this.fileSink = null;
+    }
+    this.cascadeRotate();
+    this.bytesWritten = 0;
+    this.openSinkStream();
+  }
+
+  private cascadeRotate(): void {
+    if (!this.fileSinkPath) return;
+    const oldest = `${this.fileSinkPath}.${MAX_GENERATIONS}`;
+    if (fs.existsSync(oldest)) {
+      try { fs.unlinkSync(oldest); } catch { /* ignore */ }
+    }
+    for (let i = MAX_GENERATIONS - 1; i >= 1; i--) {
+      const src = `${this.fileSinkPath}.${i}`;
+      const dst = `${this.fileSinkPath}.${i + 1}`;
+      if (fs.existsSync(src)) {
+        try { fs.renameSync(src, dst); } catch { /* ignore */ }
+      }
+    }
+    if (fs.existsSync(this.fileSinkPath)) {
+      try { fs.renameSync(this.fileSinkPath, `${this.fileSinkPath}.1`); } catch { /* ignore */ }
+    }
+  }
+
+  private openSinkStream(): void {
+    if (!this.fileSinkPath) return;
+    try {
+      this.fileSink = fs.createWriteStream(this.fileSinkPath, { flags: 'a' });
+      this.fileSink.on('error', (err) => {
+        this.fallbackError(`fileSink stream error: ${err.message}`);
+      });
+    } catch (e) {
+      this.fallbackError(`openSinkStream failed: ${(e as Error).message}`);
+      this.fileSink = null;
+    }
+  }
+
+  private fallbackError(msg: string): void {
+    const echo = this.originalConsole?.error ?? console.error;
+    echo(`[RemoteSSH:logger-fallback] ${msg}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a file sink to the logger that writes plugin and external console output to `<vault>/.obsidian/plugins/remote-ssh/console.log` (5MB rolling, 3 generations).
- Wrap `window.console.{log,warn,error}` so other plugins' output is captured as `[external]` lines in the file sink.
- Hook `unhandledrejection` and `window.onerror` to the logger to surface otherwise-silent failures.
- Add `scripts/cdp-tail.mjs` (Chrome DevTools Protocol → `cdp-console.log`, requires Node 22+ and Obsidian launched with `--remote-debugging-port=9222`).
- Add `scripts/dev-install.mjs` to copy build artifacts into a dev vault, and expose `dev:install`, `build:install`, `cdp:tail` as npm scripts.

## Why
This is groundwork for an upcoming refactor. Diagnostics that currently disappear into the DevTools console will now be persisted to disk, making it easier to investigate behavior across plugin reloads without keeping DevTools open.

## Test plan
- [x] \`npm run build\` produces \`main.js\` without errors
- [x] After plugin reload, \`<vault>/.obsidian/plugins/remote-ssh/console.log\` is created
- [x] File contains both this plugin's own log lines and \`[external]\` lines from other plugins (Dataview, Excalidraw, etc.)
- [ ] Rolling rotation at 5MB (not yet exercised; deferred to a later PR with a dedicated test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)