### PR TITLE
fix: normalize ~/ in remote paths before sending to SFTP

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { ConnectModal } from './ui/ConnectModal';
 import { SettingsTab } from './settings/SettingsTab';
 import { logger } from './util/logger';
 import { installErrorHook, uninstallErrorHook } from './util/errorHook';
+import { normalizeRemotePath } from './util/pathUtils';
 import * as path from 'path';
 
 export default class RemoteSshPlugin extends Plugin {
@@ -112,11 +113,15 @@ export default class RemoteSshPlugin extends Plugin {
       return;
     }
     this.setState(SyncState.CONNECTING);
+    const effectivePath = normalizeRemotePath(profile.remotePath);
+    if (effectivePath !== profile.remotePath) {
+      logger.info(`remotePath normalized: "${profile.remotePath}" → "${effectivePath}"`);
+    }
     try {
       await this.client.connect(profile);
       // Smoke test: list the remote vault path so we surface auth/path errors immediately.
-      const entries = await this.client.list(profile.remotePath);
-      logger.info(`Smoke test: list ${profile.remotePath} returned ${entries.length} entries`);
+      const entries = await this.client.list(effectivePath);
+      logger.info(`Smoke test: list ${effectivePath} returned ${entries.length} entries`);
     } catch (e) {
       this.setState(SyncState.ERROR);
       const msg = (e as Error).message;

--- a/src/util/pathUtils.ts
+++ b/src/util/pathUtils.ts
@@ -28,3 +28,20 @@ export function expandHome(p: string): string {
   }
   return p;
 }
+
+/**
+ * Normalize a remote path before sending it to SFTP.
+ * - SFTP servers (OpenSSH) do not expand `~`; the SFTP working directory at
+ *   session start is already the user's home, so `~/foo/bar` is rewritten as
+ *   the home-relative `foo/bar`.
+ * - A bare `~` is rewritten as `.` (current dir = home).
+ * - Trailing slashes are trimmed (except for the root `/`) so that joining
+ *   the base with vault-relative subpaths produces a single separator.
+ */
+export function normalizeRemotePath(p: string): string {
+  let r = p.trim();
+  if (r.startsWith('~/')) r = r.slice(2);
+  else if (r === '~') r = '.';
+  while (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
+  return r;
+}

--- a/tests/pathUtils.test.ts
+++ b/tests/pathUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeRemotePath } from '../src/util/pathUtils';
+
+describe('normalizeRemotePath', () => {
+  it('strips a leading "~/" so the path becomes home-relative for SFTP', () => {
+    expect(normalizeRemotePath('~/work/VaultDev/')).toBe('work/VaultDev');
+    expect(normalizeRemotePath('~/.config')).toBe('.config');
+  });
+
+  it('rewrites a bare "~" as "."', () => {
+    expect(normalizeRemotePath('~')).toBe('.');
+  });
+
+  it('leaves absolute paths untouched aside from trailing slashes', () => {
+    expect(normalizeRemotePath('/home/souta/work/VaultDev/')).toBe('/home/souta/work/VaultDev');
+    expect(normalizeRemotePath('/srv/vault')).toBe('/srv/vault');
+  });
+
+  it('trims trailing slashes but preserves the root "/"', () => {
+    expect(normalizeRemotePath('foo/bar///')).toBe('foo/bar');
+    expect(normalizeRemotePath('/')).toBe('/');
+  });
+
+  it('does not touch paths that contain "~" mid-string', () => {
+    expect(normalizeRemotePath('/home/~weird/stuff')).toBe('/home/~weird/stuff');
+  });
+
+  it('trims surrounding whitespace from user input', () => {
+    expect(normalizeRemotePath('  ~/work/VaultDev  ')).toBe('work/VaultDev');
+  });
+});


### PR DESCRIPTION
## Summary
A profile with \`remotePath = ~/work/VaultDev/\` produced \`Connect failed: No such file\` because OpenSSH's SFTP server treats \`~\` as a literal path component, not a shell expansion. Strip the leading \`~/\` (the SFTP working directory at session start is already the user's home, so what is left is correctly home-relative), rewrite a bare \`~\` as \`.\`, and trim trailing slashes so later path joins do not introduce double separators. Root \`/\` is preserved.

\`normalizeRemotePath\` is applied in \`connectProfile\` and covered by tests. The original \`profile.remotePath\` is left untouched on disk; when normalization rewrites the value the effective path is logged so it is visible in \`console.log\`.

## Reproducer
With \`profile.remotePath = ~/work/VaultDev/\`:

\`\`\`
[info] SftpClient: SFTP channel open
[error] Connect failed: No such file
\`\`\`

## After
\`\`\`
[info] remotePath normalized: "~/work/VaultDev/" → "work/VaultDev"
[info] SftpClient: SFTP channel open
[info] Smoke test: list work/VaultDev returned N entries
\`\`\`

## Test plan
- [x] \`npm test\` — 15 tests pass (6 new \`normalizeRemotePath\` cases)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build:install\` succeeds
- [ ] After plugin reload, connecting to a profile with \`~/work/VaultDev/\` succeeds and shows the normalized path in \`console.log\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)