### PR TITLE
feat: add ReadCache and DirCache for the upcoming adapter

### DIFF
--- a/src/cache/DirCache.ts
+++ b/src/cache/DirCache.ts
@@ -1,0 +1,72 @@
+import type { RemoteEntry } from '../types';
+
+interface DirCacheEntry {
+  entries: RemoteEntry[];
+  expiresAt: number;
+}
+
+export interface DirCacheOptions {
+  /** TTL in milliseconds. Default: 3000 (3 seconds). */
+  ttlMs?: number;
+  /** Optional injection point for tests; defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Time-bounded cache of `list(path)` results. Designed to absorb bursts of
+ * directory listings during the same render pass without serving stale
+ * results across user-visible time scales. Combine with explicit
+ * invalidation (e.g. after a write or rename) for correctness.
+ */
+export class DirCache {
+  private map = new Map<string, DirCacheEntry>();
+  private readonly ttlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: DirCacheOptions = {}) {
+    this.ttlMs = options.ttlMs ?? 3000;
+    this.now = options.now ?? Date.now;
+  }
+
+  get(path: string): RemoteEntry[] | null {
+    const entry = this.map.get(path);
+    if (!entry) return null;
+    if (entry.expiresAt <= this.now()) {
+      this.map.delete(path);
+      return null;
+    }
+    return entry.entries;
+  }
+
+  put(path: string, entries: RemoteEntry[]): void {
+    this.map.set(path, {
+      entries,
+      expiresAt: this.now() + this.ttlMs,
+    });
+  }
+
+  invalidate(path: string): void {
+    this.map.delete(path);
+  }
+
+  /** Drop entries for `prefix` and any descendant directory. */
+  invalidatePrefix(prefix: string): number {
+    const slash = prefix.endsWith('/') ? prefix : prefix + '/';
+    let removed = 0;
+    for (const path of this.map.keys()) {
+      if (path === prefix || path.startsWith(slash)) {
+        this.map.delete(path);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+
+  size(): number {
+    return this.map.size;
+  }
+}

--- a/src/cache/ReadCache.ts
+++ b/src/cache/ReadCache.ts
@@ -1,0 +1,136 @@
+export interface ReadCacheEntry {
+  data: Buffer;
+  /** Modification time in unix milliseconds, used to detect staleness against a fresh stat. */
+  mtime: number;
+  /** Cached byte size of `data`; precomputed so eviction does not have to recount. */
+  byteSize: number;
+}
+
+export interface ReadCacheStats {
+  entries: number;
+  bytes: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+}
+
+export interface ReadCacheOptions {
+  /** Soft cap on the cumulative byte size of cached values. Default: 64 MiB. */
+  maxBytes?: number;
+}
+
+/**
+ * LRU + mtime-keyed file content cache.
+ *
+ * Policy:
+ * - `put` overwrites the existing entry for a path.
+ * - When the total bytes exceed `maxBytes`, the least-recently-used
+ *   entries are evicted until the budget fits again.
+ * - Staleness is the caller's responsibility: read fresh `mtime`
+ *   from the remote (or from a bookkeeping channel like WatchPoller),
+ *   compare with the entry returned by `peek`/`get`, and call
+ *   `invalidate` when they diverge.
+ */
+export class ReadCache {
+  private map = new Map<string, ReadCacheEntry>();
+  private bytes = 0;
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+  private readonly maxBytes: number;
+
+  constructor(options: ReadCacheOptions = {}) {
+    this.maxBytes = options.maxBytes ?? 64 * 1024 * 1024;
+  }
+
+  /** LRU read: marks the entry as most-recently-used and returns it. */
+  get(path: string): ReadCacheEntry | null {
+    const entry = this.map.get(path);
+    if (!entry) {
+      this.misses += 1;
+      return null;
+    }
+    // Re-insert to move to the most-recent position in the Map's iteration order.
+    this.map.delete(path);
+    this.map.set(path, entry);
+    this.hits += 1;
+    return entry;
+  }
+
+  /** Read without touching LRU order. Useful for staleness checks before a refresh. */
+  peek(path: string): ReadCacheEntry | null {
+    return this.map.get(path) ?? null;
+  }
+
+  has(path: string): boolean {
+    return this.map.has(path);
+  }
+
+  put(path: string, data: Buffer, mtime: number): void {
+    const existing = this.map.get(path);
+    if (existing) {
+      this.bytes -= existing.byteSize;
+      this.map.delete(path);
+    }
+    const byteSize = data.byteLength;
+    const entry: ReadCacheEntry = { data, mtime, byteSize };
+    this.map.set(path, entry);
+    this.bytes += byteSize;
+    this.evictIfOverBudget();
+  }
+
+  invalidate(path: string): void {
+    const existing = this.map.get(path);
+    if (!existing) return;
+    this.bytes -= existing.byteSize;
+    this.map.delete(path);
+  }
+
+  /**
+   * Evict every entry whose path is exactly `prefix` or starts with `prefix + "/"`.
+   * Useful after a directory was renamed/deleted upstream.
+   */
+  invalidatePrefix(prefix: string): number {
+    const slash = prefix.endsWith('/') ? prefix : prefix + '/';
+    let removed = 0;
+    for (const path of this.map.keys()) {
+      if (path === prefix || path.startsWith(slash)) {
+        const e = this.map.get(path)!;
+        this.bytes -= e.byteSize;
+        this.map.delete(path);
+        removed += 1;
+      }
+    }
+    return removed;
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.bytes = 0;
+  }
+
+  stats(): ReadCacheStats {
+    return {
+      entries: this.map.size,
+      bytes: this.bytes,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    };
+  }
+
+  private evictIfOverBudget(): void {
+    if (this.bytes <= this.maxBytes) return;
+    // Map iteration order is insertion order; the oldest (least-recently-used) is first.
+    const it = this.map.entries();
+    while (this.bytes > this.maxBytes) {
+      const next = it.next();
+      if (next.done) break;
+      const [path, entry] = next.value;
+      this.bytes -= entry.byteSize;
+      this.map.delete(path);
+      this.evictions += 1;
+    }
+  }
+}
+

--- a/tests/DirCache.test.ts
+++ b/tests/DirCache.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { DirCache } from '../src/cache/DirCache';
+import type { RemoteEntry } from '../src/types';
+
+const e = (name: string, isDirectory = false): RemoteEntry => ({
+  name,
+  isDirectory,
+  isFile: !isDirectory,
+  isSymbolicLink: false,
+  mtime: 0,
+  size: 0,
+});
+
+describe('DirCache', () => {
+  it('returns null when the path was never put', () => {
+    const cache = new DirCache();
+    expect(cache.get('docs')).toBeNull();
+  });
+
+  it('returns the cached entries within TTL', () => {
+    let now = 1000;
+    const cache = new DirCache({ ttlMs: 100, now: () => now });
+    cache.put('docs', [e('a.md'), e('b.md')]);
+    now = 1099; // still within TTL
+    expect(cache.get('docs')?.length).toBe(2);
+  });
+
+  it('returns null and drops the entry once TTL expires', () => {
+    let now = 1000;
+    const cache = new DirCache({ ttlMs: 100, now: () => now });
+    cache.put('docs', [e('a.md')]);
+    now = 1100; // exactly at TTL boundary; treat as expired
+    expect(cache.get('docs')).toBeNull();
+    expect(cache.size()).toBe(0);
+  });
+
+  it('put refreshes the TTL when re-cached', () => {
+    let now = 1000;
+    const cache = new DirCache({ ttlMs: 100, now: () => now });
+    cache.put('docs', [e('a.md')]);
+    now = 1090;
+    cache.put('docs', [e('a.md'), e('b.md')]); // refresh
+    now = 1180; // would have expired against the original
+    expect(cache.get('docs')?.length).toBe(2);
+  });
+
+  it('invalidate removes a single path', () => {
+    const cache = new DirCache();
+    cache.put('docs', [e('a.md')]);
+    cache.invalidate('docs');
+    expect(cache.get('docs')).toBeNull();
+  });
+
+  it('invalidatePrefix drops the dir and its descendants', () => {
+    const cache = new DirCache();
+    cache.put('docs', [e('a.md')]);
+    cache.put('docs/sub', [e('b.md')]);
+    cache.put('docs/sub/deep', [e('c.md')]);
+    cache.put('other', [e('x.md')]);
+    const removed = cache.invalidatePrefix('docs');
+    expect(removed).toBe(3);
+    expect(cache.get('docs')).toBeNull();
+    expect(cache.get('docs/sub')).toBeNull();
+    expect(cache.get('docs/sub/deep')).toBeNull();
+    expect(cache.get('other')).not.toBeNull();
+  });
+
+  it('invalidatePrefix does not match unrelated keys with shared prefix', () => {
+    const cache = new DirCache();
+    cache.put('docs', [e('a.md')]);
+    cache.put('docs2', [e('b.md')]);
+    cache.invalidatePrefix('docs');
+    expect(cache.get('docs')).toBeNull();
+    expect(cache.get('docs2')).not.toBeNull();
+  });
+
+  it('clear empties the cache', () => {
+    const cache = new DirCache();
+    cache.put('a', [e('x')]);
+    cache.put('b', [e('y')]);
+    cache.clear();
+    expect(cache.size()).toBe(0);
+  });
+});

--- a/tests/ReadCache.test.ts
+++ b/tests/ReadCache.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ReadCache } from '../src/cache/ReadCache';
+
+const buf = (s: string) => Buffer.from(s, 'utf8');
+
+describe('ReadCache', () => {
+  let cache: ReadCache;
+
+  beforeEach(() => {
+    cache = new ReadCache({ maxBytes: 1024 });
+  });
+
+  it('returns null on miss and bumps the misses counter', () => {
+    expect(cache.get('foo.md')).toBeNull();
+    expect(cache.stats().misses).toBe(1);
+    expect(cache.stats().hits).toBe(0);
+  });
+
+  it('round-trips data and mtime through put/get', () => {
+    cache.put('foo.md', buf('hello'), 1000);
+    const got = cache.get('foo.md');
+    expect(got?.data.toString('utf8')).toBe('hello');
+    expect(got?.mtime).toBe(1000);
+    expect(got?.byteSize).toBe(5);
+    expect(cache.stats().hits).toBe(1);
+  });
+
+  it('peek does not change LRU order', () => {
+    const lru = new ReadCache({ maxBytes: 10 });
+    lru.put('a', Buffer.alloc(4), 1);
+    lru.put('b', Buffer.alloc(4), 1); // 8 bytes, fits
+    lru.peek('a'); // peek "a" but do not bump
+    lru.put('c', Buffer.alloc(4), 1); // 12 bytes → evict oldest "a"
+    expect(lru.has('a')).toBe(false); // evicted because peek did not refresh order
+    expect(lru.has('b')).toBe(true);
+    expect(lru.has('c')).toBe(true);
+  });
+
+  it('get() bumps an entry to most-recently-used', () => {
+    const lru = new ReadCache({ maxBytes: 10 });
+    lru.put('a', Buffer.alloc(4), 1);
+    lru.put('b', Buffer.alloc(4), 1);
+    lru.get('a'); // refresh "a" → "b" is now LRU
+    lru.put('c', Buffer.alloc(4), 1); // evicts "b"
+    expect(lru.has('a')).toBe(true);
+    expect(lru.has('b')).toBe(false);
+    expect(lru.has('c')).toBe(true);
+  });
+
+  it('put() overwrites the existing entry and adjusts byte accounting', () => {
+    cache.put('foo', buf('short'), 1);
+    cache.put('foo', buf('a much longer payload'), 2);
+    const entry = cache.peek('foo');
+    expect(entry?.mtime).toBe(2);
+    expect(entry?.data.toString('utf8')).toBe('a much longer payload');
+    expect(cache.stats().bytes).toBe(entry!.byteSize);
+  });
+
+  it('invalidate removes the entry and refunds its bytes', () => {
+    cache.put('foo', buf('hello'), 1);
+    cache.invalidate('foo');
+    expect(cache.has('foo')).toBe(false);
+    expect(cache.stats().bytes).toBe(0);
+  });
+
+  it('invalidate is a no-op for an unknown key', () => {
+    cache.put('foo', buf('hello'), 1);
+    cache.invalidate('bar');
+    expect(cache.has('foo')).toBe(true);
+    expect(cache.stats().bytes).toBe(5);
+  });
+
+  it('invalidatePrefix removes the directory and its descendants', () => {
+    cache.put('docs/a.md', buf('a'), 1);
+    cache.put('docs/sub/b.md', buf('b'), 1);
+    cache.put('docs', buf('dir-marker'), 1);
+    cache.put('other.md', buf('o'), 1);
+    const removed = cache.invalidatePrefix('docs');
+    expect(removed).toBe(3);
+    expect(cache.has('docs/a.md')).toBe(false);
+    expect(cache.has('docs/sub/b.md')).toBe(false);
+    expect(cache.has('docs')).toBe(false);
+    expect(cache.has('other.md')).toBe(true);
+  });
+
+  it('invalidatePrefix does not match unrelated paths that share a prefix', () => {
+    cache.put('docs', buf('a'), 1);
+    cache.put('docs2', buf('b'), 1);
+    cache.invalidatePrefix('docs');
+    expect(cache.has('docs')).toBe(false);
+    expect(cache.has('docs2')).toBe(true);
+  });
+
+  it('evicts least-recently-used entries to stay under the byte budget', () => {
+    const small = new ReadCache({ maxBytes: 16 });
+    small.put('a', Buffer.alloc(8), 1); // 8 bytes
+    small.put('b', Buffer.alloc(8), 1); // 16 bytes total
+    small.put('c', Buffer.alloc(8), 1); // would be 24 → evict "a"
+    expect(small.has('a')).toBe(false);
+    expect(small.has('b')).toBe(true);
+    expect(small.has('c')).toBe(true);
+    expect(small.stats().evictions).toBe(1);
+    expect(small.stats().bytes).toBe(16);
+  });
+
+  it('evicts multiple entries when a single put busts the budget by a lot', () => {
+    const small = new ReadCache({ maxBytes: 16 });
+    small.put('a', Buffer.alloc(4), 1);
+    small.put('b', Buffer.alloc(4), 1);
+    small.put('c', Buffer.alloc(4), 1);
+    small.put('big', Buffer.alloc(16), 1); // forces eviction of a, b, c
+    expect(small.has('a')).toBe(false);
+    expect(small.has('b')).toBe(false);
+    expect(small.has('c')).toBe(false);
+    expect(small.has('big')).toBe(true);
+    expect(small.stats().bytes).toBe(16);
+  });
+
+  it('clear empties the cache and resets byte accounting', () => {
+    cache.put('a', buf('hi'), 1);
+    cache.put('b', buf('there'), 1);
+    cache.clear();
+    expect(cache.has('a')).toBe(false);
+    expect(cache.has('b')).toBe(false);
+    expect(cache.stats().entries).toBe(0);
+    expect(cache.stats().bytes).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
Two small caches that the next phase (read-side \`SftpDataAdapter\`) will sit on top of. Neither is wired into the plugin yet.

### \`src/cache/ReadCache.ts\`
Byte-budgeted LRU keyed by remote path. Stores the file's \`Buffer\` and the \`mtime\` it was last read at, so the caller can detect a stale entry by comparing against a fresh \`stat\`. Insertion order in a \`Map\` is the LRU axis; \`get()\` refreshes order, \`peek()\` does not. Default budget: 64 MiB.

API: \`get / peek / has / put / invalidate / invalidatePrefix / clear / stats\`. Prefix invalidation (\`path === prefix\` or \`path.startsWith(prefix + "/")\`) is for after a remote rename or rmdir.

### \`src/cache/DirCache.ts\`
Short-TTL cache of \`list(path)\` results. Designed to absorb bursts of \`readdir\`s during a single render pass without serving across user-visible time scales. Default TTL: 3 s. \`now\` is injectable for tests. Same single-path and prefix invalidation shape as \`ReadCache\`.

## Why
Without caching, every adapter \`read\` becomes an SFTP round trip and every \`list\` triggers a \`readdir\`. A 64 MiB byte budget keeps note bodies hot while leaving room for binaries, and a 3 s directory TTL is long enough to catch the rapid sequential \`list\` calls Obsidian fires when expanding the file explorer but short enough that out-of-band changes (a poller tick, a manual refresh) don't see stale listings for long.

\`mtime\`-keyed staleness lives in the caller because the adapter already has to \`stat\` to discover the current mtime; doing the comparison there avoids a redundant fetch.

## Test plan
- [x] \`npm test\` — 35 tests pass (20 new across the two caches)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` succeeds (bundle size unchanged at 361KB; the new modules are tree-shaken until Phase 4-E imports them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)