### PR TITLE
feat: add AdapterPatcher and opt-in adapter swap (read-side)

### DIFF
--- a/src/adapter/AdapterPatcher.ts
+++ b/src/adapter/AdapterPatcher.ts
@@ -1,0 +1,67 @@
+/**
+ * Method-level monkey-patch with snapshot-and-restore semantics.
+ *
+ * `patch(methodNames)` replaces each named method on `target` with the
+ * matching method from `replacement`, after binding it to `replacement`
+ * so its `this` is correct. The original value (which may be a function,
+ * `undefined`, or even something exotic if the host did funny things) is
+ * captured first; `restore()` puts back exactly what was there.
+ *
+ * If `patch` throws partway through, every swap that succeeded is rolled
+ * back atomically so the target is never left in a half-patched state.
+ */
+export class AdapterPatcher<T extends object> {
+  private originals = new Map<string, unknown>();
+  private patched = false;
+
+  constructor(
+    private target: T,
+    private replacement: object,
+  ) {}
+
+  isPatched(): boolean {
+    return this.patched;
+  }
+
+  /**
+   * Replace the named methods on `target` with bound versions from `replacement`.
+   * Calling twice without `restore()` between is an error.
+   */
+  patch(methodNames: ReadonlyArray<keyof T & string>): void {
+    if (this.patched) {
+      throw new Error('AdapterPatcher: already patched (call restore first)');
+    }
+
+    const swapped: string[] = [];
+    try {
+      for (const name of methodNames) {
+        const candidate = (this.replacement as Record<string, unknown>)[name];
+        if (typeof candidate !== 'function') {
+          throw new Error(`AdapterPatcher: replacement for "${name}" is not a function`);
+        }
+        const original = (this.target as Record<string, unknown>)[name];
+        this.originals.set(name, original);
+        (this.target as Record<string, unknown>)[name] = (candidate as (...args: unknown[]) => unknown).bind(this.replacement);
+        swapped.push(name);
+      }
+      this.patched = true;
+    } catch (e) {
+      for (const name of swapped) {
+        const original = this.originals.get(name);
+        (this.target as Record<string, unknown>)[name] = original;
+      }
+      this.originals.clear();
+      throw e;
+    }
+  }
+
+  /** Put back the originals captured by `patch`. Safe to call when not patched. */
+  restore(): void {
+    if (!this.patched) return;
+    for (const [name, original] of this.originals) {
+      (this.target as Record<string, unknown>)[name] = original;
+    }
+    this.originals.clear();
+    this.patched = false;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,10 @@ import { SftpClient } from './ssh/SftpClient';
 import { AuthResolver } from './ssh/AuthResolver';
 import { HostKeyStore } from './ssh/HostKeyStore';
 import { SecretStore } from './ssh/SecretStore';
+import { ReadCache } from './cache/ReadCache';
+import { DirCache } from './cache/DirCache';
+import { SftpDataAdapter } from './adapter/SftpDataAdapter';
+import { AdapterPatcher } from './adapter/AdapterPatcher';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
 import { SettingsTab } from './settings/SettingsTab';
@@ -13,6 +17,8 @@ import { logger } from './util/logger';
 import { installErrorHook, uninstallErrorHook } from './util/errorHook';
 import { normalizeRemotePath } from './util/pathUtils';
 import * as path from 'path';
+
+const PATCHED_METHODS = ['exists', 'stat', 'list', 'read', 'readBinary', 'getName'] as const;
 
 export default class RemoteSshPlugin extends Plugin {
   settings: PluginSettings = DEFAULT_SETTINGS;
@@ -23,6 +29,11 @@ export default class RemoteSshPlugin extends Plugin {
   private client!: SftpClient;
   private statusBar!: StatusBar;
   private state: SyncState = SyncState.IDLE;
+  private patcher: AdapterPatcher<object> | null = null;
+  private dataAdapter: SftpDataAdapter | null = null;
+  private readCache: ReadCache | null = null;
+  private dirCache: DirCache | null = null;
+  private activeRemoteBasePath: string | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -34,10 +45,12 @@ export default class RemoteSshPlugin extends Plugin {
     this.client = new SftpClient(this.authResolver, this.hostKeyStore);
     this.client.onClose(({ unexpected }) => {
       if (unexpected) {
+        this.restoreAdapter();
         this.setState(SyncState.ERROR);
         new Notice('Remote SSH: Connection lost');
       }
     });
+    this.activeRemoteBasePath = null;
 
     this.addSettingTab(new SettingsTab(this.app, this));
 
@@ -55,9 +68,30 @@ export default class RemoteSshPlugin extends Plugin {
       name: 'Disconnect from remote vault',
       callback: () => this.disconnect(),
     });
+
+    this.addCommand({
+      id: 'debug-patch-adapter',
+      name: 'Debug: patch app.vault.adapter onto SFTP (read-side only)',
+      callback: () => this.debugPatchAdapter(),
+    });
+
+    this.addCommand({
+      id: 'debug-restore-adapter',
+      name: 'Debug: restore app.vault.adapter to its original',
+      callback: () => this.debugRestoreAdapter(),
+    });
+
+    this.addCommand({
+      id: 'debug-list-root',
+      name: 'Debug: list vault root via current adapter',
+      callback: () => this.debugListRoot(),
+    });
   }
 
   async onunload() {
+    // Restore adapter first so any in-flight Obsidian read calls see the
+    // original FileSystemAdapter again before we tear down the SSH session.
+    this.restoreAdapter();
     await this.disconnect().catch(() => {});
     this.statusBar?.remove();
     this.uninstallObservability();
@@ -119,7 +153,6 @@ export default class RemoteSshPlugin extends Plugin {
     }
     try {
       await this.client.connect(profile);
-      // Smoke test: list the remote vault path so we surface auth/path errors immediately.
       const entries = await this.client.list(effectivePath);
       logger.info(`Smoke test: list ${effectivePath} returned ${entries.length} entries`);
     } catch (e) {
@@ -130,14 +163,22 @@ export default class RemoteSshPlugin extends Plugin {
       try { await this.client.disconnect(); } catch { /* ignore */ }
       return;
     }
+
+    // Adapter is NOT patched on connect: Obsidian still has paths it expects
+    // to read locally (`.obsidian/workspace.json`, plugin data, etc.) until
+    // PathMapper (Phase 4-J0) can redirect those to a per-client subtree.
+    // Use the "Debug: patch adapter" command to opt in for now.
+    this.activeRemoteBasePath = effectivePath;
     this.setState(SyncState.CONNECTED);
     this.settings.activeProfileId = profile.id;
     await this.saveSettings();
-    new Notice(`Remote SSH: Connected to ${profile.name} (adapter wiring pending — Phase 4-E onward)`);
+    new Notice(`Remote SSH: Connected to ${profile.name} (adapter NOT patched — use "Debug: patch adapter" to opt in)`);
   }
 
   async disconnect() {
     if (this.state === SyncState.IDLE) return;
+    this.restoreAdapter();
+    this.activeRemoteBasePath = null;
     try {
       await this.client.disconnect();
     } catch (e) {
@@ -147,6 +188,78 @@ export default class RemoteSshPlugin extends Plugin {
     this.settings.activeProfileId = null;
     await this.saveSettings();
     new Notice('Remote SSH: Disconnected');
+  }
+
+  private debugPatchAdapter(): void {
+    if (this.state !== SyncState.CONNECTED || !this.activeRemoteBasePath) {
+      new Notice('Remote SSH: connect first');
+      return;
+    }
+    if (this.patcher?.isPatched()) {
+      new Notice('Remote SSH: adapter already patched');
+      return;
+    }
+    const targetAdapter = this.app.vault.adapter as unknown as object;
+    this.readCache = new ReadCache();
+    this.dirCache = new DirCache();
+    this.dataAdapter = new SftpDataAdapter(
+      this.client,
+      this.activeRemoteBasePath,
+      this.readCache,
+      this.dirCache,
+      this.app.vault.getName(),
+    );
+    this.patcher = new AdapterPatcher(targetAdapter, this.dataAdapter);
+    try {
+      this.patcher.patch(PATCHED_METHODS as unknown as ReadonlyArray<keyof object & string>);
+      logger.info(`Adapter patched: [${PATCHED_METHODS.join(', ')}]`);
+      new Notice(`Remote SSH: adapter patched (${PATCHED_METHODS.join(', ')})`);
+    } catch (e) {
+      logger.error(`Adapter patch failed: ${(e as Error).message}`);
+      this.patcher = null;
+      this.dataAdapter = null;
+      this.readCache = null;
+      this.dirCache = null;
+      new Notice(`Adapter patch failed: ${(e as Error).message}`);
+    }
+  }
+
+  private debugRestoreAdapter(): void {
+    if (!this.patcher?.isPatched()) {
+      new Notice('Remote SSH: adapter is not patched');
+      return;
+    }
+    this.restoreAdapter();
+    new Notice('Remote SSH: adapter restored');
+  }
+
+  private restoreAdapter(): void {
+    if (this.patcher?.isPatched()) {
+      try {
+        this.patcher.restore();
+        logger.info('Adapter restored');
+      } catch (e) {
+        logger.error(`Adapter restore failed: ${(e as Error).message}`);
+      }
+    }
+    this.patcher = null;
+    this.dataAdapter = null;
+    this.readCache = null;
+    this.dirCache = null;
+  }
+
+  private async debugListRoot(): Promise<void> {
+    try {
+      const out = await this.app.vault.adapter.list('');
+      const via = this.patcher?.isPatched() ? 'PATCHED (SFTP)' : 'ORIGINAL (local)';
+      logger.info(`debugListRoot via ${via}: ${out.files.length} files, ${out.folders.length} folders`);
+      logger.info(`  files (first 5): ${out.files.slice(0, 5).join(', ')}`);
+      logger.info(`  folders (first 5): ${out.folders.slice(0, 5).join(', ')}`);
+      new Notice(`List via ${via}: ${out.files.length} files, ${out.folders.length} folders (see console.log)`);
+    } catch (e) {
+      logger.error(`debugListRoot failed: ${(e as Error).message}`);
+      new Notice(`debugListRoot failed: ${(e as Error).message}`);
+    }
   }
 
   private setState(s: SyncState) {

--- a/tests/AdapterPatcher.test.ts
+++ b/tests/AdapterPatcher.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { AdapterPatcher } from '../src/adapter/AdapterPatcher';
+
+describe('AdapterPatcher', () => {
+  it('replaces named methods and routes calls through the replacement', () => {
+    const target: { greet(name: string): string; shout?(name: string): string } = {
+      greet: (name) => `hello, ${name}`,
+    };
+    const replacement = {
+      greet(this: { suffix: string }, name: string) { return `hi ${name}${this.suffix}`; },
+      suffix: '!',
+    };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['greet']);
+    expect(target.greet('souta')).toBe('hi souta!');
+  });
+
+  it('binds the replacement to its own host so this resolves correctly', () => {
+    const target: { value(): number } = { value: () => 1 };
+    const replacement = {
+      multiplier: 7,
+      value(this: { multiplier: number }) { return this.multiplier; },
+    };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['value']);
+    expect(target.value()).toBe(7);
+  });
+
+  it('restore puts the original methods back', () => {
+    const target = { greet: (name: string) => `original ${name}` };
+    const replacement = { greet: (name: string) => `replaced ${name}` };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['greet']);
+    expect(target.greet('x')).toBe('replaced x');
+    patcher.restore();
+    expect(target.greet('x')).toBe('original x');
+  });
+
+  it('isPatched reflects the current state', () => {
+    const target = { greet: () => 'a' };
+    const replacement = { greet: () => 'b' };
+    const patcher = new AdapterPatcher(target, replacement);
+    expect(patcher.isPatched()).toBe(false);
+    patcher.patch(['greet']);
+    expect(patcher.isPatched()).toBe(true);
+    patcher.restore();
+    expect(patcher.isPatched()).toBe(false);
+  });
+
+  it('throws when patch is called twice without an intervening restore', () => {
+    const target = { greet: () => 'a' };
+    const replacement = { greet: () => 'b' };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['greet']);
+    expect(() => patcher.patch(['greet'])).toThrow(/already patched/);
+  });
+
+  it('rolls back partial swaps if patch encounters a non-function replacement', () => {
+    const target: Record<string, unknown> = {
+      a: () => 'orig-a',
+      b: () => 'orig-b',
+    };
+    // "b" is missing on the replacement on purpose.
+    const replacement: Record<string, unknown> = {
+      a: () => 'new-a',
+    };
+    const patcher = new AdapterPatcher(target, replacement);
+    expect(() => patcher.patch(['a', 'b'] as never)).toThrow(/is not a function/);
+    expect((target.a as () => string)()).toBe('orig-a');
+    expect((target.b as () => string)()).toBe('orig-b');
+    expect(patcher.isPatched()).toBe(false);
+  });
+
+  it('preserves the value of an originally-undefined property and restores it as undefined', () => {
+    const target: Record<string, unknown> = { a: 1 }; // no `greet` originally
+    const replacement = { greet: () => 'hi' };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['greet']);
+    expect((target.greet as () => string)()).toBe('hi');
+    patcher.restore();
+    expect(target.greet).toBeUndefined();
+  });
+
+  it('restore is a no-op when not patched', () => {
+    const target = { greet: () => 'orig' };
+    const replacement = { greet: () => 'new' };
+    const patcher = new AdapterPatcher(target, replacement);
+    expect(() => patcher.restore()).not.toThrow();
+    expect(target.greet()).toBe('orig');
+  });
+
+  it('supports patching multiple methods at once', () => {
+    const target = {
+      a: () => 'orig-a',
+      b: () => 'orig-b',
+      c: () => 'orig-c',
+    };
+    const replacement = {
+      a: () => 'new-a',
+      b: () => 'new-b',
+      c: () => 'new-c',
+    };
+    const patcher = new AdapterPatcher(target, replacement);
+    patcher.patch(['a', 'c']); // skip b
+    expect(target.a()).toBe('new-a');
+    expect(target.b()).toBe('orig-b');
+    expect(target.c()).toBe('new-c');
+    patcher.restore();
+    expect(target.a()).toBe('orig-a');
+    expect(target.c()).toBe('orig-c');
+  });
+});


### PR DESCRIPTION
## Summary
\`AdapterPatcher\` swaps named methods on a target object with bound versions from a replacement object. It snapshots the original value before swapping (including \`undefined\` when a method did not exist) so \`restore()\` puts back exactly what was there. A swap that throws partway through is rolled back atomically so the target is never half-patched.

\`main.ts\` wires the read-side \`SftpDataAdapter\` behind three debug commands rather than auto-patching on \`connect\`:

- **Debug: patch app.vault.adapter onto SFTP (read-side only)**
- **Debug: restore app.vault.adapter to its original**
- **Debug: list vault root via current adapter** — labels its output as \`PATCHED (SFTP)\` or \`ORIGINAL (local)\` so the result is unambiguous

## Why opt-in?
Obsidian still reads local paths it owns (\`.obsidian/workspace.json\`, plugin data, etc.) that do not have a counterpart on the remote until \`PathMapper\` (Phase 4-J0) can redirect them to a per-client subtree. Auto-patching on connect would break Obsidian for any vault that has any \`.obsidian/\` state worth keeping. The debug commands let the operator opt in once the rest of the pipeline is in place.

## Safety
- \`disconnect\`, \`onunload\`, and the unexpected-close handler all call \`restoreAdapter()\` defensively. The original \`FileSystemAdapter\` is always put back even when other teardown steps fail.
- \`AdapterPatcher.patch\` rolls back partial swaps if any replacement is not a function; the target is left untouched in that case.
- Bundle size moved from 361 KB to 367 KB now that the cache + adapter modules are reachable.

## Test plan
- [x] \`npm test\` — 60 tests pass (9 new across binding, restore, idempotence, partial-swap rollback, undefined-original preservation)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build:install\` succeeds
- [ ] Reload plugin in dev vault. Connect. Run \`Debug: list vault root via current adapter\` and confirm it logs \`ORIGINAL (local)\`. Run \`Debug: patch adapter\` and rerun the list; it should now log \`PATCHED (SFTP)\` with the remote count. Run \`Debug: restore adapter\` and confirm subsequent listings go back to \`ORIGINAL (local)\`. Disconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)