### PR TITLE
feat: implement SftpDataAdapter write side and fs ops

### DIFF
--- a/src/adapter/SftpDataAdapter.ts
+++ b/src/adapter/SftpDataAdapter.ts
@@ -1,15 +1,19 @@
-import type { ListedFiles, Stat } from 'obsidian';
+import type { DataWriteOptions, ListedFiles, Stat } from 'obsidian';
 import type { SftpClient } from '../ssh/SftpClient';
 import type { ReadCache } from '../cache/ReadCache';
 import type { DirCache } from '../cache/DirCache';
 import { logger } from '../util/logger';
 
 /**
- * Read-side implementation of Obsidian's `DataAdapter` over SFTP.
+ * Implementation of Obsidian's `DataAdapter` over SFTP.
  *
- * Write methods (write/writeBinary/mkdir/remove/...) will be added in
- * Phase 4-G; this class is constructed in Phase 4-E and patched onto
- * `app.vault.adapter` in Phase 4-F.
+ * The class is constructed in Phase 4-E, patched onto `app.vault.adapter`
+ * in Phase 4-F, and grew its write surface (write/writeBinary/append/
+ * process/mkdir/remove/rmdir/rename/copy/trashSystem/trashLocal) in
+ * Phase 4-G.
+ *
+ * `getResourcePath` is intentionally not implemented yet; Phase 4-I will
+ * add a localhost HTTP bridge for binary serving.
  *
  * Path translation is currently a straight join of `remoteBasePath` and
  * the vault-relative `normalizedPath`. The per-client user-cache rewrite
@@ -83,6 +87,110 @@ export class SftpDataAdapter {
     return ab;
   }
 
+  // ─── DataAdapter (write-side) ────────────────────────────────────────────
+
+  async write(normalizedPath: string, data: string, _options?: DataWriteOptions): Promise<void> {
+    await this.writeBuffer(normalizedPath, Buffer.from(data, 'utf8'));
+  }
+
+  async writeBinary(normalizedPath: string, data: ArrayBuffer, _options?: DataWriteOptions): Promise<void> {
+    await this.writeBuffer(normalizedPath, Buffer.from(data));
+  }
+
+  async append(normalizedPath: string, data: string, options?: DataWriteOptions): Promise<void> {
+    let existing = '';
+    try { existing = await this.read(normalizedPath); }
+    catch { /* file did not exist; start empty so append acts like create */ }
+    await this.write(normalizedPath, existing + data, options);
+  }
+
+  async appendBinary(normalizedPath: string, data: ArrayBuffer, options?: DataWriteOptions): Promise<void> {
+    let existing: Buffer;
+    try { existing = await this.readBuffer(normalizedPath); }
+    catch { existing = Buffer.alloc(0); }
+    const merged = Buffer.concat([existing, Buffer.from(data)]);
+    await this.writeBuffer(normalizedPath, merged);
+    void options;
+  }
+
+  /**
+   * Read, transform, and write back a plaintext file. Not atomic across
+   * concurrent writers — same caveat as the underlying SFTP write (which
+   * goes through a tmp+rename inside SftpClient).
+   */
+  async process(
+    normalizedPath: string,
+    fn: (data: string) => string,
+    options?: DataWriteOptions,
+  ): Promise<string> {
+    const current = await this.read(normalizedPath);
+    const next = fn(current);
+    await this.write(normalizedPath, next, options);
+    return next;
+  }
+
+  async mkdir(normalizedPath: string): Promise<void> {
+    const remote = this.toRemote(normalizedPath);
+    await this.client.mkdirp(remote);
+    this.dirCache.invalidate(parentDirRemote(remote));
+  }
+
+  async remove(normalizedPath: string): Promise<void> {
+    const remote = this.toRemote(normalizedPath);
+    await this.client.remove(remote);
+    this.readCache.invalidate(remote);
+    this.dirCache.invalidate(parentDirRemote(remote));
+  }
+
+  async rmdir(normalizedPath: string, recursive: boolean): Promise<void> {
+    const remote = this.toRemote(normalizedPath);
+    await this.client.rmdir(remote, recursive);
+    this.readCache.invalidatePrefix(remote);
+    this.dirCache.invalidatePrefix(remote);
+    this.dirCache.invalidate(parentDirRemote(remote));
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    const oldRemote = this.toRemote(oldPath);
+    const newRemote = this.toRemote(newPath);
+    await this.client.mkdirp(parentDirRemote(newRemote));
+    await this.client.rename(oldRemote, newRemote);
+    this.readCache.invalidatePrefix(oldRemote);
+    this.readCache.invalidate(newRemote);
+    this.dirCache.invalidatePrefix(oldRemote);
+    this.dirCache.invalidate(parentDirRemote(oldRemote));
+    this.dirCache.invalidate(parentDirRemote(newRemote));
+  }
+
+  async copy(oldPath: string, newPath: string): Promise<void> {
+    const oldRemote = this.toRemote(oldPath);
+    const newRemote = this.toRemote(newPath);
+    await this.client.mkdirp(parentDirRemote(newRemote));
+    await this.client.copy(oldRemote, newRemote);
+    this.readCache.invalidate(newRemote);
+    this.dirCache.invalidate(parentDirRemote(newRemote));
+  }
+
+  /**
+   * SFTP has no concept of a system trash. Return false so Obsidian falls
+   * through to its local-trash flow (`trashLocal`); we don't perform any
+   * destructive action here.
+   */
+  async trashSystem(_normalizedPath: string): Promise<boolean> {
+    return false;
+  }
+
+  /**
+   * Move the path under `<vault>/.trash/`, mirroring Obsidian's local-trash
+   * behaviour but on the remote. Existing files at the target are
+   * overwritten; existing directories cause the rename to fail (that
+   * matches the desktop behaviour).
+   */
+  async trashLocal(normalizedPath: string): Promise<void> {
+    const trashedPath = '.trash/' + normalizedPath;
+    await this.rename(normalizedPath, trashedPath);
+  }
+
   // ─── internals ───────────────────────────────────────────────────────────
 
   /**
@@ -105,12 +213,10 @@ export class SftpDataAdapter {
           this.readCache.get(remote); // bump LRU on hit
           return cached.data;
         }
-        // Stale: refetch. We already have a fresh stat to record.
         const data = await this.client.readBinary(remote);
         this.readCache.put(remote, data, s.mtime);
         return data;
       } catch (e) {
-        // Stat or refetch failed; surface the error.
         throw e;
       }
     }
@@ -127,10 +233,47 @@ export class SftpDataAdapter {
     return data;
   }
 
+  /**
+   * Atomic-on-the-server write through SftpClient (tmp+rename). Ensures
+   * the parent directory exists, then refreshes the read cache with the
+   * just-written content using the freshly-read mtime.
+   */
+  private async writeBuffer(normalizedPath: string, data: Buffer): Promise<void> {
+    const remote = this.toRemote(normalizedPath);
+    const parent = parentDirRemote(remote);
+    if (parent && parent !== remote) {
+      await this.client.mkdirp(parent);
+    }
+    await this.client.writeBinary(remote, data);
+
+    let mtime = 0;
+    try {
+      const s = await this.client.stat(remote);
+      mtime = s.mtime;
+    } catch (e) {
+      logger.warn(`stat-after-write failed for "${remote}": ${(e as Error).message}`);
+    }
+    this.readCache.put(remote, data, mtime);
+    this.dirCache.invalidate(parent);
+  }
+
   toRemote(normalizedPath: string): string {
     if (!normalizedPath || normalizedPath === '/') return this.remoteBasePath;
     if (this.remoteBasePath === '') return normalizedPath;
     if (this.remoteBasePath === '/') return '/' + normalizedPath;
     return `${this.remoteBasePath}/${normalizedPath}`;
   }
+}
+
+/**
+ * Parent directory of a remote path. Handles absolute (`/foo/bar` → `/foo`),
+ * relative (`foo/bar` → `foo`), and edge cases (`/foo` → `/`, `foo` → ``,
+ * `/` → `/`, `` → ``).
+ */
+function parentDirRemote(p: string): string {
+  if (p === '' || p === '/') return p;
+  const i = p.lastIndexOf('/');
+  if (i < 0) return '';
+  if (i === 0) return '/';
+  return p.slice(0, i);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,16 @@ import { installErrorHook, uninstallErrorHook } from './util/errorHook';
 import { normalizeRemotePath } from './util/pathUtils';
 import * as path from 'path';
 
-const PATCHED_METHODS = ['exists', 'stat', 'list', 'read', 'readBinary', 'getName'] as const;
+const PATCHED_METHODS = [
+  // read-side
+  'getName', 'exists', 'stat', 'list', 'read', 'readBinary',
+  // write-side
+  'write', 'writeBinary', 'append', 'appendBinary', 'process',
+  // fs ops
+  'mkdir', 'remove', 'rmdir', 'rename', 'copy',
+  // trash
+  'trashSystem', 'trashLocal',
+] as const;
 
 export default class RemoteSshPlugin extends Plugin {
   settings: PluginSettings = DEFAULT_SETTINGS;

--- a/tests/SftpDataAdapter.test.ts
+++ b/tests/SftpDataAdapter.test.ts
@@ -4,13 +4,43 @@ import { ReadCache } from '../src/cache/ReadCache';
 import { DirCache } from '../src/cache/DirCache';
 import type { RemoteEntry, RemoteStat } from '../src/types';
 
-/** Minimal stand-in for SftpClient — only the read-side methods the adapter calls. */
+/** Minimal stand-in for SftpClient covering both read- and write-side calls. */
 function makeFakeClient(initial: {
   files?: Record<string, { data: Buffer; mtime: number }>;
   dirs?: Record<string, RemoteEntry[]>;
 } = {}) {
   const files: Record<string, { data: Buffer; mtime: number }> = { ...(initial.files ?? {}) };
   const dirs: Record<string, RemoteEntry[]> = { ...(initial.dirs ?? {}) };
+  let clock = 1000;
+  const tick = () => ++clock;
+
+  const dirEntry = (name: string, isDirectory: boolean): RemoteEntry => ({
+    name, isDirectory,
+    isFile: !isDirectory,
+    isSymbolicLink: false,
+    mtime: 0, size: 0,
+  });
+
+  /** Walk parent dirs and add `name` to each parent's dir listing. */
+  const linkIntoParent = (fullPath: string, isDirectory: boolean): void => {
+    const i = fullPath.lastIndexOf('/');
+    if (i <= 0) return;
+    const parent = fullPath.slice(0, i) || '/';
+    const name = fullPath.slice(i + 1);
+    if (!(parent in dirs)) dirs[parent] = [];
+    const existingIdx = dirs[parent].findIndex(e => e.name === name);
+    if (existingIdx >= 0) dirs[parent][existingIdx] = dirEntry(name, isDirectory);
+    else dirs[parent].push(dirEntry(name, isDirectory));
+  };
+
+  const unlinkFromParent = (fullPath: string): void => {
+    const i = fullPath.lastIndexOf('/');
+    if (i <= 0) return;
+    const parent = fullPath.slice(0, i) || '/';
+    const name = fullPath.slice(i + 1);
+    if (!(parent in dirs)) return;
+    dirs[parent] = dirs[parent].filter(e => e.name !== name);
+  };
 
   const stat = vi.fn(async (p: string): Promise<RemoteStat> => {
     if (files[p]) {
@@ -43,10 +73,77 @@ function makeFakeClient(initial: {
     return files[p].data;
   });
 
+  const writeBinary = vi.fn(async (p: string, data: Buffer): Promise<void> => {
+    files[p] = { data: Buffer.from(data), mtime: tick() };
+    linkIntoParent(p, false);
+  });
+
+  const mkdirp = vi.fn(async (p: string): Promise<void> => {
+    if (!p) return;
+    const parts = p.split('/').filter(Boolean);
+    const isAbs = p.startsWith('/');
+    let current = '';
+    for (const part of parts) {
+      current = isAbs ? current + '/' + part : (current ? current + '/' + part : part);
+      if (!(current in dirs)) {
+        dirs[current] = [];
+        linkIntoParent(current, true);
+      }
+    }
+  });
+
+  const rename = vi.fn(async (oldPath: string, newPath: string): Promise<void> => {
+    if (oldPath in files) {
+      files[newPath] = files[oldPath];
+      delete files[oldPath];
+      unlinkFromParent(oldPath);
+      linkIntoParent(newPath, false);
+    } else if (oldPath in dirs) {
+      dirs[newPath] = dirs[oldPath];
+      delete dirs[oldPath];
+      unlinkFromParent(oldPath);
+      linkIntoParent(newPath, true);
+    } else {
+      throw new Error(`rename: no such path "${oldPath}"`);
+    }
+  });
+
+  const copy = vi.fn(async (src: string, dst: string): Promise<void> => {
+    if (!(src in files)) throw new Error(`copy: no such file "${src}"`);
+    files[dst] = { data: Buffer.from(files[src].data), mtime: tick() };
+    linkIntoParent(dst, false);
+  });
+
+  const remove = vi.fn(async (p: string): Promise<void> => {
+    if (!(p in files)) throw new Error(`remove: no such file "${p}"`);
+    delete files[p];
+    unlinkFromParent(p);
+  });
+
+  const rmdir = vi.fn(async (p: string, recursive = false): Promise<void> => {
+    if (!(p in dirs)) throw new Error(`rmdir: no such dir "${p}"`);
+    if (recursive) {
+      const prefix = p.endsWith('/') ? p : p + '/';
+      for (const f of Object.keys(files)) {
+        if (f === p || f.startsWith(prefix)) { delete files[f]; }
+      }
+      for (const d of Object.keys(dirs)) {
+        if (d !== p && (d === p || d.startsWith(prefix))) { delete dirs[d]; }
+      }
+    } else if (dirs[p].length > 0) {
+      throw new Error('rmdir: not empty');
+    }
+    delete dirs[p];
+    unlinkFromParent(p);
+  });
+
   return {
     files, dirs,
-    client: { stat, exists, list, readBinary } as unknown as import('../src/ssh/SftpClient').SftpClient,
-    spies: { stat, exists, list, readBinary },
+    client: {
+      stat, exists, list, readBinary,
+      writeBinary, mkdirp, rename, copy, remove, rmdir,
+    } as unknown as import('../src/ssh/SftpClient').SftpClient,
+    spies: { stat, exists, list, readBinary, writeBinary, mkdirp, rename, copy, remove, rmdir },
   };
 }
 
@@ -214,10 +311,186 @@ describe('SftpDataAdapter (read-side)', () => {
       expect(ab).toBeInstanceOf(ArrayBuffer);
       const view = new Uint8Array(ab);
       expect([...view]).toEqual([1, 2, 3, 4]);
-      // Mutating the returned view must not affect the cached entry.
       view[0] = 99;
       const cached = readCache.peek('/v/img.png');
       expect(cached?.data[0]).toBe(1);
+    });
+  });
+
+  describe('write', () => {
+    it('persists text content and refreshes ReadCache with the new mtime', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.write('note.md', 'hello');
+      expect(fake.files['/v/note.md'].data.toString('utf8')).toBe('hello');
+      const cached = readCache.peek('/v/note.md');
+      expect(cached?.data.toString('utf8')).toBe('hello');
+      expect(cached?.mtime).toBe(fake.files['/v/note.md'].mtime);
+    });
+
+    it('writeBinary round-trips an ArrayBuffer faithfully', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      const ab = new ArrayBuffer(4);
+      new Uint8Array(ab).set([10, 20, 30, 40]);
+      await adapter.writeBinary('blob.bin', ab);
+      expect([...fake.files['/v/blob.bin'].data]).toEqual([10, 20, 30, 40]);
+    });
+
+    it('creates parent directories on the way to the file', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.write('docs/sub/a.md', 'x');
+      expect(fake.dirs['/v/docs']).toBeDefined();
+      expect(fake.dirs['/v/docs/sub']).toBeDefined();
+      expect(fake.files['/v/docs/sub/a.md'].data.toString('utf8')).toBe('x');
+    });
+
+    it('invalidates the parent dir entry in DirCache after a write', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      // Prime DirCache with an empty listing so we can observe invalidation.
+      await adapter.list('');
+      expect(dirCache.get('/v')).not.toBeNull();
+      await adapter.write('note.md', 'hi');
+      expect(dirCache.get('/v')).toBeNull();
+    });
+  });
+
+  describe('append', () => {
+    it('appends text to an existing file', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/log.md': { data: Buffer.from('first\n'), mtime: 1 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.append('log.md', 'second\n');
+      expect(fake.files['/v/log.md'].data.toString('utf8')).toBe('first\nsecond\n');
+    });
+
+    it('creates the file when it does not exist yet', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.append('new.md', 'hello');
+      expect(fake.files['/v/new.md'].data.toString('utf8')).toBe('hello');
+    });
+
+    it('appendBinary concatenates bytes', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/blob.bin': { data: Buffer.from([1, 2]), mtime: 1 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      const more = new ArrayBuffer(2);
+      new Uint8Array(more).set([3, 4]);
+      await adapter.appendBinary('blob.bin', more);
+      expect([...fake.files['/v/blob.bin'].data]).toEqual([1, 2, 3, 4]);
+    });
+  });
+
+  describe('process', () => {
+    it('reads, transforms, writes back, and returns the new content', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/note.md': { data: Buffer.from('hello'), mtime: 1 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      const result = await adapter.process('note.md', s => s.toUpperCase());
+      expect(result).toBe('HELLO');
+      expect(fake.files['/v/note.md'].data.toString('utf8')).toBe('HELLO');
+    });
+  });
+
+  describe('mkdir / remove / rmdir', () => {
+    it('mkdir creates the directory chain', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.mkdir('a/b/c');
+      expect(fake.dirs['/v/a/b/c']).toBeDefined();
+    });
+
+    it('remove deletes the file and invalidates the entry in ReadCache', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/note.md': { data: Buffer.from('hi'), mtime: 1 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.read('note.md'); // populate the cache
+      expect(readCache.peek('/v/note.md')).not.toBeNull();
+      await adapter.remove('note.md');
+      expect('/v/note.md' in fake.files).toBe(false);
+      expect(readCache.peek('/v/note.md')).toBeNull();
+    });
+
+    it('rmdir(recursive) removes the dir and invalidates the prefix in both caches', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/dir/a.md': { data: Buffer.from('a'), mtime: 1 } },
+        dirs:  { '/v': [], '/v/dir': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.read('dir/a.md'); // populate ReadCache
+      await adapter.list('dir');      // populate DirCache
+      await adapter.rmdir('dir', true);
+      expect('/v/dir' in fake.dirs).toBe(false);
+      expect(readCache.peek('/v/dir/a.md')).toBeNull();
+      expect(dirCache.get('/v/dir')).toBeNull();
+    });
+  });
+
+  describe('rename / copy', () => {
+    it('rename moves a file and invalidates the old prefix in caches', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/old.md': { data: Buffer.from('content'), mtime: 1 } },
+        dirs: { '/v': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.read('old.md'); // cache it
+      await adapter.rename('old.md', 'new.md');
+      expect(fake.files['/v/new.md'].data.toString('utf8')).toBe('content');
+      expect('/v/old.md' in fake.files).toBe(false);
+      expect(readCache.peek('/v/old.md')).toBeNull();
+    });
+
+    it('rename creates the destination parent dirs', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/a.md': { data: Buffer.from('x'), mtime: 1 } },
+        dirs: { '/v': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.rename('a.md', 'archived/2026/a.md');
+      expect(fake.dirs['/v/archived/2026']).toBeDefined();
+      expect(fake.files['/v/archived/2026/a.md'].data.toString('utf8')).toBe('x');
+    });
+
+    it('copy duplicates the file and invalidates the new path in ReadCache', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/src.md': { data: Buffer.from('src'), mtime: 1 } },
+        dirs: { '/v': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.copy('src.md', 'dst.md');
+      expect(fake.files['/v/dst.md'].data.toString('utf8')).toBe('src');
+      expect(fake.files['/v/src.md'].data.toString('utf8')).toBe('src'); // src untouched
+    });
+  });
+
+  describe('trash', () => {
+    it('trashSystem returns false unconditionally so Obsidian falls back to local trash', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/a.md': { data: Buffer.from('x'), mtime: 1 } },
+        dirs: { '/v': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await expect(adapter.trashSystem('a.md')).resolves.toBe(false);
+      // Must not be moved or deleted.
+      expect(fake.files['/v/a.md'].data.toString('utf8')).toBe('x');
+    });
+
+    it('trashLocal moves the path under <vault>/.trash/', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/note.md': { data: Buffer.from('bye'), mtime: 1 } },
+        dirs: { '/v': [] },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.trashLocal('note.md');
+      expect('/v/note.md' in fake.files).toBe(false);
+      expect(fake.files['/v/.trash/note.md'].data.toString('utf8')).toBe('bye');
     });
   });
 });


### PR DESCRIPTION
## Summary
Completes the \`DataAdapter\` surface that \`SftpDataAdapter\` exposes to Obsidian, so the next \`Debug: patch adapter\` swap covers reads **and** writes.

### New methods on \`SftpDataAdapter\`
- \`write\` / \`writeBinary\` — atomic-on-server via \`SftpClient\` (tmp+rename internally)
- \`append\` / \`appendBinary\` — read-then-write with empty fallback when the file is missing
- \`process\` — read, transform, write back, return the new content
- \`mkdir\` (uses \`mkdirp\`)
- \`remove\`, \`rmdir(recursive)\`
- \`rename\` (creates the destination's parent dirs first)
- \`copy\`
- \`trashSystem\` returns \`false\` unconditionally (no system trash over SFTP) so Obsidian falls back to \`trashLocal\`
- \`trashLocal\` moves the path under \`<vault>/.trash/\`

### Cache invalidation
- Writes refresh \`ReadCache\` with the just-written buffer and freshly-read mtime, and invalidate the parent in \`DirCache\`.
- \`remove\` clears the path in \`ReadCache\` and its parent in \`DirCache\`.
- \`rmdir(recursive)\` clears the prefix in both caches.
- \`rename\` clears the old path's prefix everywhere and both parent dirs.
- \`copy\` clears the new path in \`ReadCache\` and its parent in \`DirCache\`; the source stays put.

### main.ts
\`PATCHED_METHODS\` grows to the full read+write surface. The \`Debug: patch adapter\` command now swaps everything except \`getResourcePath\`, which lands in Phase 4-I (the localhost binary bridge).

## Test plan
- [x] \`npm test\` — 76 tests pass (16 new across write / append / process / mkdir-remove-rmdir / rename-copy / trash, plus parent-dir creation and DirCache invalidation)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build:install\` succeeds; bundle 369 KB (was 367 KB)
- [ ] After plugin reload + connect, run \`Debug: patch adapter\` then create / edit / delete a note in Obsidian against an isolated remote vault (e.g. \`~/work/VaultDev/\`); confirm the file appears and changes on the remote, then \`Debug: restore adapter\`. **Avoid testing against a vault whose \`.obsidian/\` you care about until Phase 4-J0 (\`PathMapper\`) is in place.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)