### PR TITLE
fix: stale activeProfileId on reload, and mkdir over existing dir

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,9 @@ export default class RemoteSshPlugin extends Plugin {
   async loadSettings() {
     const saved = await this.loadData();
     this.settings = Object.assign({}, DEFAULT_SETTINGS, saved ?? {});
+    // We never come back online already connected; activeProfileId from disk
+    // is stale on startup and only confuses the settings UI.
+    this.settings.activeProfileId = null;
     if (saved?.hostKeyStore) {
       this.hostKeyStore.load(saved.hostKeyStore);
     }
@@ -184,19 +187,31 @@ export default class RemoteSshPlugin extends Plugin {
     new Notice(`Remote SSH: Connected to ${profile.name} (adapter NOT patched — use "Debug: patch adapter" to opt in)`);
   }
 
+  /**
+   * Idempotent: it always restores the adapter, drops the active SSH
+   * client, clears `activeProfileId`, and parks the state machine on
+   * IDLE. Calling it from a stale UI button (where state was already
+   * IDLE because the plugin had just reloaded) is a supported flow.
+   */
   async disconnect() {
-    if (this.state === SyncState.IDLE) return;
+    const wasActive = this.state !== SyncState.IDLE
+      || this.client?.isAlive()
+      || this.settings.activeProfileId !== null;
     this.restoreAdapter();
     this.activeRemoteBasePath = null;
-    try {
-      await this.client.disconnect();
-    } catch (e) {
-      logger.warn(`disconnect: ${(e as Error).message}`);
+    if (this.client?.isAlive()) {
+      try {
+        await this.client.disconnect();
+      } catch (e) {
+        logger.warn(`disconnect: ${(e as Error).message}`);
+      }
     }
     this.setState(SyncState.IDLE);
-    this.settings.activeProfileId = null;
-    await this.saveSettings();
-    new Notice('Remote SSH: Disconnected');
+    if (this.settings.activeProfileId !== null) {
+      this.settings.activeProfileId = null;
+      await this.saveSettings();
+    }
+    if (wasActive) new Notice('Remote SSH: Disconnected');
   }
 
   private debugPatchAdapter(): void {
@@ -269,6 +284,10 @@ export default class RemoteSshPlugin extends Plugin {
       logger.error(`debugListRoot failed: ${(e as Error).message}`);
       new Notice(`debugListRoot failed: ${(e as Error).message}`);
     }
+  }
+
+  isConnected(): boolean {
+    return this.state === SyncState.CONNECTED;
   }
 
   private setState(s: SyncState) {

--- a/src/settings/SettingsTab.ts
+++ b/src/settings/SettingsTab.ts
@@ -44,7 +44,8 @@ export class SettingsTab extends PluginSettingTab {
   }
 
   private renderProfileRow(containerEl: HTMLElement, profile: SshProfile) {
-    const isActive = this.plugin.settings.activeProfileId === profile.id;
+    const isActive = this.plugin.isConnected()
+      && this.plugin.settings.activeProfileId === profile.id;
 
     new Setting(containerEl)
       .setName(`${profile.name}`)

--- a/src/ssh/SftpClient.ts
+++ b/src/ssh/SftpClient.ts
@@ -265,8 +265,26 @@ export class SftpClient {
     });
   }
 
+  /**
+   * Create the directory, treating "already exists" as success.
+   *
+   * OpenSSH's SFTP server reports an existing directory as
+   * SSH_FX_FAILURE with the opaque message "Failure", so a substring
+   * match on "exist" misses it. Stat-then-mkdir avoids the ambiguity:
+   * if a directory is already there we are done; if a non-directory
+   * is in the way we surface the conflict; otherwise we mkdir and let
+   * a real SFTP error bubble up.
+   */
   async mkdir(remotePath: string): Promise<void> {
     const sftp = this.requireSftp();
+    try {
+      const s = await this.stat(remotePath);
+      if (s.isDirectory) return;
+      throw new Error(`mkdir: "${remotePath}" exists and is not a directory`);
+    } catch (e) {
+      // Treat any stat failure as "path is not there yet" and try to create it.
+      if ((e as Error).message?.startsWith('mkdir: ')) throw e;
+    }
     return new Promise((resolve, reject) => {
       sftp.mkdir(remotePath, err => {
         if (err && !err.message.toLowerCase().includes('exist')) reject(err);


### PR DESCRIPTION
## Bug 1: stale activeProfileId on reload
After closing Obsidian while connected, reopening showed "Disconnect" on the profile row but pressing it did nothing. Toggle plugin off/on was the only way to clear the state.

Root causes:
- \`loadSettings\` restored \`activeProfileId\` from disk while the plugin came back up disconnected.
- \`disconnect()\` returned early when state was already \`IDLE\`, so it never cleared the stale \`activeProfileId\`.
- The settings UI labelled the row by comparing against \`activeProfileId\` only, ignoring the actual connection state.

Fixes:
- \`loadSettings\` clears \`activeProfileId\` at startup (we never come back online already connected).
- \`disconnect\` is now idempotent: it always restores the adapter, drops the SSH client when alive, parks the state machine on \`IDLE\`, and clears \`activeProfileId\` on disk.
- \`SettingsTab\` derives the row label from \`plugin.isConnected()\` (\`state === CONNECTED\`) **and** the matching id, so an orphan id doesn't masquerade as a live connection.

## Bug 2: crash creating a note
With the Phase 4-G adapter patched, creating a note (Templater path) crashed inside ssh2's parser with a generic \`Failure\`. The trace from \`console.log\`:

\`\`\`
[error] [external] Templater Error: Couldn't create md file. Failure
[error] unhandledrejection: Failure
    at 101 (plugin:remote-ssh:14:36794)
    at ko.push (plugin:remote-ssh:14:4679)
    at CHANNEL_DATA (plugin:remote-ssh:14:67656)
    ...
    at Qs.decrypt (plugin:remote-ssh:3:44705)
\`\`\`

Templater calls \`mkdirp\` through the patched adapter, which calls \`SftpClient.mkdir\` on every ancestor — including ones that already exist. OpenSSH's SFTP server reports an existing directory as \`SSH_FX_FAILURE\` with the opaque message \`"Failure"\`, which the previous substring match on \`"exist"\` did not catch.

Fix: \`SftpClient.mkdir\` now stat-and-skips when the path is already a directory, surfaces a clear conflict when it exists as a non-directory, and only attempts \`mkdir\` when \`stat\` says nothing is there. The \`"exist"\` substring fallback is kept for servers that do return that wording.

## Test plan
- [x] \`npm test\` — 76 tests still pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build:install\` succeeds
- [ ] After plugin reload + connect, run \`Debug: patch adapter\`. Create a note in Obsidian. Confirm the file appears on the remote (\`ls ~/work/VaultDev/\`) without an unhandledrejection in \`console.log\`. \`Debug: restore adapter\` and disconnect. Close Obsidian; reopen and confirm the profile row reads "Connect", not "Disconnect".

🤖 Generated with [Claude Code](https://claude.com/claude-code)