### PR TITLE
feat: define JSON-RPC protocol (proto/, plugin TS, server Go)

### DIFF
--- a/plugin/src/proto/types.ts
+++ b/plugin/src/proto/types.ts
@@ -1,0 +1,207 @@
+/**
+ * Shared JSON-RPC protocol types between the obsidian-remote-ssh plugin and
+ * the obsidian-remote-server daemon.
+ *
+ * **This file is a hand-maintained mirror of `server/internal/proto/types.go`.**
+ * When the spec changes, both sides move in the same PR. See `proto/README.md`
+ * for the normative protocol description.
+ */
+
+export const PROTOCOL_VERSION = 1;
+
+// ─── core shapes ─────────────────────────────────────────────────────────────
+
+export interface ServerInfo {
+  /** Implementation version of the running daemon, e.g. "0.1.0". */
+  version: string;
+  /** Protocol version the daemon speaks. Must be compared against PROTOCOL_VERSION. */
+  protocolVersion: number;
+  /** Method names the daemon implements, e.g. ["fs.stat", "fs.list", ...]. */
+  capabilities: string[];
+  /** Absolute vault root on the remote host (informational; paths are vault-relative). */
+  vaultRoot: string;
+}
+
+export interface Stat {
+  type: 'file' | 'folder';
+  /** Modification time in unix milliseconds. */
+  mtime: number;
+  /** Size in bytes. 0 for directories. */
+  size: number;
+  /** POSIX mode bits (informational). */
+  mode: number;
+}
+
+export interface Entry {
+  /** Basename only, no slashes. */
+  name: string;
+  type: 'file' | 'folder' | 'symlink';
+  mtime: number;
+  size: number;
+}
+
+// ─── method tables ───────────────────────────────────────────────────────────
+
+export type MethodName =
+  | 'auth'
+  | 'server.info'
+  | 'fs.stat'
+  | 'fs.exists'
+  | 'fs.list'
+  | 'fs.readText'
+  | 'fs.readBinary'
+  | 'fs.write'
+  | 'fs.writeBinary'
+  | 'fs.append'
+  | 'fs.appendBinary'
+  | 'fs.mkdir'
+  | 'fs.remove'
+  | 'fs.rmdir'
+  | 'fs.rename'
+  | 'fs.copy'
+  | 'fs.trashLocal'
+  | 'fs.watch'
+  | 'fs.unwatch';
+
+export interface MethodMap {
+  'auth':            { params: AuthParams;            result: AuthResult };
+  'server.info':     { params: Record<string, never>; result: ServerInfo };
+
+  'fs.stat':         { params: PathOnlyParams;        result: Stat | null };
+  'fs.exists':       { params: PathOnlyParams;        result: ExistsResult };
+  'fs.list':         { params: PathOnlyParams;        result: ListResult };
+
+  'fs.readText':     { params: ReadTextParams;        result: ReadTextResult };
+  'fs.readBinary':   { params: PathOnlyParams;        result: ReadBinaryResult };
+
+  'fs.write':        { params: WriteTextParams;       result: MtimeResult };
+  'fs.writeBinary':  { params: WriteBinaryParams;     result: MtimeResult };
+  'fs.append':       { params: AppendTextParams;      result: MtimeResult };
+  'fs.appendBinary': { params: AppendBinaryParams;    result: MtimeResult };
+
+  'fs.mkdir':        { params: MkdirParams;           result: Record<string, never> };
+  'fs.remove':       { params: PathOnlyParams;        result: Record<string, never> };
+  'fs.rmdir':        { params: RmdirParams;           result: Record<string, never> };
+  'fs.rename':       { params: RenameParams;          result: MtimeResult };
+  'fs.copy':         { params: CopyParams;            result: MtimeResult };
+  'fs.trashLocal':   { params: PathOnlyParams;        result: Record<string, never> };
+
+  'fs.watch':        { params: WatchParams;           result: WatchResult };
+  'fs.unwatch':      { params: UnwatchParams;         result: Record<string, never> };
+}
+
+export type Params<M extends MethodName> = MethodMap[M]['params'];
+export type Result<M extends MethodName> = MethodMap[M]['result'];
+
+// ─── method param / result shapes ────────────────────────────────────────────
+
+export interface AuthParams { token: string }
+export interface AuthResult { ok: true }
+
+export interface PathOnlyParams { path: string }
+export interface ExistsResult { exists: boolean }
+export interface ListResult { entries: Entry[] }
+
+export interface ReadTextParams { path: string; encoding?: 'utf8' }
+export interface ReadTextResult { content: string; mtime: number; size: number; encoding: 'utf8' }
+export interface ReadBinaryResult { contentBase64: string; mtime: number; size: number }
+
+export interface WriteTextParams {
+  path: string;
+  content: string;
+  /** If set, the write is rejected with PreconditionFailed when the remote mtime differs. */
+  expectedMtime?: number;
+}
+export interface WriteBinaryParams {
+  path: string;
+  contentBase64: string;
+  expectedMtime?: number;
+}
+export interface AppendTextParams { path: string; content: string }
+export interface AppendBinaryParams { path: string; contentBase64: string }
+export interface MtimeResult { mtime: number }
+
+export interface MkdirParams { path: string; recursive?: boolean }
+export interface RmdirParams { path: string; recursive?: boolean }
+export interface RenameParams { oldPath: string; newPath: string }
+export interface CopyParams { srcPath: string; destPath: string }
+
+export interface WatchParams { path: string; recursive?: boolean }
+export interface WatchResult { subscriptionId: string }
+export interface UnwatchParams { subscriptionId: string }
+
+// ─── server-push notifications ───────────────────────────────────────────────
+
+export type FsChangeEvent = 'created' | 'modified' | 'deleted' | 'renamed';
+
+export interface FsChangedParams {
+  subscriptionId: string;
+  path: string;
+  event: FsChangeEvent;
+  mtime?: number;
+  /** Set iff event === 'renamed'. */
+  newPath?: string;
+}
+
+export interface ServerNotificationMap {
+  'fs.changed': FsChangedParams;
+}
+
+export type ServerNotificationName = keyof ServerNotificationMap;
+
+// ─── JSON-RPC envelopes ──────────────────────────────────────────────────────
+
+export interface JsonRpcRequest<M extends MethodName = MethodName> {
+  jsonrpc: '2.0';
+  id: number | string;
+  method: M;
+  params: Params<M>;
+}
+
+export interface JsonRpcSuccess<M extends MethodName = MethodName> {
+  jsonrpc: '2.0';
+  id: number | string;
+  result: Result<M>;
+}
+
+export interface JsonRpcError {
+  jsonrpc: '2.0';
+  id: number | string | null;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export interface JsonRpcNotification<N extends ServerNotificationName = ServerNotificationName> {
+  jsonrpc: '2.0';
+  method: N;
+  params: ServerNotificationMap[N];
+}
+
+export type JsonRpcMessage =
+  | JsonRpcRequest
+  | JsonRpcSuccess
+  | JsonRpcError
+  | JsonRpcNotification;
+
+// ─── error codes ─────────────────────────────────────────────────────────────
+
+export const ErrorCode = {
+  // JSON-RPC 2.0 reserved range.
+  ParseError:            -32700,
+  InvalidRequest:        -32600,
+  MethodNotFound:        -32601,
+  InvalidParams:         -32602,
+  InternalError:         -32603,
+  // obsidian-remote-server custom range (-32000 .. -32099).
+  AuthRequired:          -32000,
+  AuthInvalid:           -32001,
+  FileNotFound:          -32010,
+  NotADirectory:         -32011,
+  IsADirectory:          -32012,
+  Exists:                -32013,
+  PermissionDenied:      -32014,
+  PathOutsideVault:      -32015,
+  PreconditionFailed:    -32020,
+  ProtocolVersionTooOld: -32021,
+} as const;
+
+export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/plugin/tests/proto-types.test.ts
+++ b/plugin/tests/proto-types.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PROTOCOL_VERSION,
+  ErrorCode,
+  type JsonRpcRequest,
+  type JsonRpcSuccess,
+  type JsonRpcError,
+  type JsonRpcNotification,
+  type Params,
+  type Result,
+} from '../src/proto/types';
+
+/**
+ * These tests don't validate behavior — they exist to make the proto
+ * types actually reachable through the test runner, and to pin a few
+ * invariants we expect to keep in lockstep with the Go mirror
+ * (`server/internal/proto/types.go`). If any of them fails, update
+ * both sides in the same PR.
+ */
+describe('proto types', () => {
+  it('PROTOCOL_VERSION is 1', () => {
+    expect(PROTOCOL_VERSION).toBe(1);
+  });
+
+  it('exposes the expected error code constants', () => {
+    expect(ErrorCode.ParseError).toBe(-32700);
+    expect(ErrorCode.InvalidRequest).toBe(-32600);
+    expect(ErrorCode.MethodNotFound).toBe(-32601);
+    expect(ErrorCode.InvalidParams).toBe(-32602);
+    expect(ErrorCode.InternalError).toBe(-32603);
+    expect(ErrorCode.AuthRequired).toBe(-32000);
+    expect(ErrorCode.AuthInvalid).toBe(-32001);
+    expect(ErrorCode.FileNotFound).toBe(-32010);
+    expect(ErrorCode.NotADirectory).toBe(-32011);
+    expect(ErrorCode.IsADirectory).toBe(-32012);
+    expect(ErrorCode.Exists).toBe(-32013);
+    expect(ErrorCode.PermissionDenied).toBe(-32014);
+    expect(ErrorCode.PathOutsideVault).toBe(-32015);
+    expect(ErrorCode.PreconditionFailed).toBe(-32020);
+    expect(ErrorCode.ProtocolVersionTooOld).toBe(-32021);
+  });
+
+  it('typechecks a well-formed request/response/error/notification (compile-time assertion)', () => {
+    const statParams: Params<'fs.stat'> = { path: 'note.md' };
+    const statOk: Result<'fs.stat'> = {
+      type: 'file', mtime: 1_700_000_000_000, size: 42, mode: 0o100644,
+    };
+    const statMissing: Result<'fs.stat'> = null;
+
+    const req: JsonRpcRequest<'fs.stat'> = {
+      jsonrpc: '2.0', id: 1, method: 'fs.stat', params: statParams,
+    };
+    const ok: JsonRpcSuccess<'fs.stat'> = {
+      jsonrpc: '2.0', id: 1, result: statOk,
+    };
+    const err: JsonRpcError = {
+      jsonrpc: '2.0', id: 1, error: { code: ErrorCode.FileNotFound, message: 'no such file' },
+    };
+    const note: JsonRpcNotification<'fs.changed'> = {
+      jsonrpc: '2.0',
+      method: 'fs.changed',
+      params: { subscriptionId: 's1', path: 'note.md', event: 'modified', mtime: 123 },
+    };
+
+    // Runtime assertions are superficial; the real win is that TypeScript
+    // refused to compile this block if any type drifted.
+    expect(req.method).toBe('fs.stat');
+    expect(ok.result).toEqual(statOk);
+    expect(statMissing).toBeNull();
+    expect(err.error.code).toBe(ErrorCode.FileNotFound);
+    expect(note.params.event).toBe('modified');
+  });
+});

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,6 +1,168 @@
 # proto
 
-Shared protocol definitions for the JSON-RPC traffic between the
-obsidian-remote-ssh plugin (TypeScript) and the obsidian-remote-server
-daemon (Go). The actual schema lands in the next phase; this directory
-exists so both sides agree on the location going forward.
+Shared JSON-RPC protocol between the obsidian-remote-ssh plugin
+(TypeScript) and the obsidian-remote-server daemon (Go).
+
+## Transport
+
+- JSON-RPC 2.0 messages over a single WebSocket frame per message.
+- The WebSocket rides an SSH-forwarded local TCP port → remote unix
+  socket. The plugin opens the SSH session using its existing
+  credentials; nothing here is exposed to the network.
+- Text frames only. Binary payloads (file bytes) are base64-encoded
+  inside the JSON body. MVP trade-off: +33% wire overhead for a much
+  simpler client.
+
+## Handshake
+
+Before any `fs.*` method succeeds, the client must authenticate:
+
+```
+→ { "jsonrpc": "2.0", "id": 1, "method": "auth", "params": { "token": "…" } }
+← { "jsonrpc": "2.0", "id": 1, "result": { "ok": true } }
+```
+
+- The server writes `~/.obsidian-remote/token` (mode `0600`) at startup
+  with a fresh 32-byte random token.
+- The plugin reads that file over SSH (since SSH already authenticates
+  the right user, and POSIX perms forbid other local users from
+  reading it) and presents it here.
+- A session is pinned to one authenticated client. Rejecting `auth`
+  closes the connection.
+
+After `auth` succeeds, the plugin should call `server.info` once to
+check protocol compatibility.
+
+## Versioning
+
+The protocol version is an integer. The client is responsible for
+refusing to proceed when the server advertises a version it does not
+understand. Breaking changes bump the integer; additive changes do
+not.
+
+Current protocol version: **1**.
+
+## Path conventions
+
+All paths are **vault-relative** and use **forward slashes**.
+
+- `"note.md"`, `"docs/sub/a.md"` — valid
+- `""` or `"/"` — the vault root itself
+- `"../"` or any `..` component — rejected with `PathOutsideVault`
+- A leading `/` (absolute path) — rejected with `PathOutsideVault`
+
+The vault root is fixed at server start via `--vault-root=<abs>`. The
+server refuses to open any path that, once resolved, does not live
+under that root.
+
+## Methods
+
+| Method              | Params                                        | Result                              |
+|---------------------|-----------------------------------------------|-------------------------------------|
+| `auth`              | `{ token }`                                    | `{ ok: true }`                      |
+| `server.info`       | `{}`                                           | `ServerInfo`                        |
+| `fs.stat`           | `{ path }`                                     | `Stat \| null`                      |
+| `fs.exists`         | `{ path }`                                     | `{ exists: boolean }`               |
+| `fs.list`           | `{ path }`                                     | `{ entries: Entry[] }`              |
+| `fs.readText`       | `{ path, encoding? }`                          | `ReadTextResult`                    |
+| `fs.readBinary`     | `{ path }`                                     | `ReadBinaryResult`                  |
+| `fs.write`          | `{ path, content, expectedMtime? }`            | `{ mtime }`                         |
+| `fs.writeBinary`    | `{ path, contentBase64, expectedMtime? }`      | `{ mtime }`                         |
+| `fs.append`         | `{ path, content }`                            | `{ mtime }`                         |
+| `fs.appendBinary`   | `{ path, contentBase64 }`                      | `{ mtime }`                         |
+| `fs.mkdir`          | `{ path, recursive? }`                         | `{}`                                |
+| `fs.remove`         | `{ path }`                                     | `{}`                                |
+| `fs.rmdir`          | `{ path, recursive? }`                         | `{}`                                |
+| `fs.rename`         | `{ oldPath, newPath }`                         | `{ mtime }`                         |
+| `fs.copy`           | `{ srcPath, destPath }`                        | `{ mtime }`                         |
+| `fs.trashLocal`     | `{ path }`                                     | `{}`                                |
+| `fs.watch`          | `{ path, recursive? }`                         | `{ subscriptionId }`                |
+| `fs.unwatch`        | `{ subscriptionId }`                           | `{}`                                |
+
+Shapes:
+
+```ts
+interface ServerInfo {
+  version: string;         // implementation version, e.g. "0.1.0"
+  protocolVersion: number; // currently 1
+  capabilities: string[];  // e.g. ["fs.stat", "fs.watch", …]
+  vaultRoot: string;       // absolute path on the remote host (informational)
+}
+
+interface Stat {
+  type: 'file' | 'folder';
+  mtime: number;  // unix milliseconds
+  size: number;   // bytes (0 for folders)
+  mode: number;   // POSIX mode bits (informational)
+}
+
+interface Entry {
+  name: string;   // basename only, no slashes
+  type: 'file' | 'folder' | 'symlink';
+  mtime: number;
+  size: number;
+}
+
+interface ReadTextResult  { content: string;        mtime: number; size: number; encoding: 'utf8'; }
+interface ReadBinaryResult { contentBase64: string; mtime: number; size: number; }
+```
+
+Atomicity notes:
+- `fs.write` and `fs.writeBinary` are atomic on the remote (tmp file
+  + rename). If `expectedMtime` is set and the current file's mtime
+  does not match, the server rejects with `PreconditionFailed`.
+- `fs.rename` creates the destination's parent directory if needed.
+- `fs.copy` goes through the file contents (no server-side reflink).
+- `fs.trashLocal` moves the path under `<vaultRoot>/.trash/…`,
+  creating intermediate dirs as needed.
+
+## Notifications (server → client)
+
+The server pushes notifications on subscribed paths:
+
+```
+{
+  "jsonrpc": "2.0",
+  "method": "fs.changed",
+  "params": {
+    "subscriptionId": "…",
+    "path": "note.md",
+    "event": "created" | "modified" | "deleted" | "renamed",
+    "mtime"?: number,
+    "newPath"?: string   // set when event === "renamed"
+  }
+}
+```
+
+- Events are debounced on the server (coalesced if the same path is
+  touched within a few hundred ms) so a single editor save doesn't
+  flood the wire.
+- An `fs.watch` subscription with `recursive: true` emits events for
+  every descendant.
+
+## Error codes
+
+| Code     | Name                   | When                                                        |
+|----------|------------------------|-------------------------------------------------------------|
+| `-32700` | ParseError             | Not JSON.                                                   |
+| `-32600` | InvalidRequest         | JSON-RPC envelope is malformed.                             |
+| `-32601` | MethodNotFound         | Unknown method.                                             |
+| `-32602` | InvalidParams          | Params don't match the method's shape.                      |
+| `-32603` | InternalError          | Unexpected server error.                                    |
+| `-32000` | AuthRequired           | A non-`auth` method was called before auth succeeded.       |
+| `-32001` | AuthInvalid            | `auth` called with a wrong token.                           |
+| `-32010` | FileNotFound           | Path doesn't exist on the remote.                           |
+| `-32011` | NotADirectory          | `fs.list` / `fs.rmdir` target is a file.                    |
+| `-32012` | IsADirectory           | A file-only op targeted a directory.                        |
+| `-32013` | Exists                 | Create-like op found the path already present.              |
+| `-32014` | PermissionDenied       | OS rejected the operation (mode bits, quota, …).            |
+| `-32015` | PathOutsideVault       | Resolved path escapes the vault root.                       |
+| `-32020` | PreconditionFailed     | `expectedMtime` did not match the file's current mtime.     |
+| `-32021` | ProtocolVersionTooOld  | `server.info` returned a version the client can't speak.    |
+
+## Source of truth
+
+- This document is normative for wire shape.
+- `plugin/src/proto/types.ts` and `server/internal/proto/types.go`
+  are hand-maintained mirrors. When the spec changes, both sides
+  move in the same PR.

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -1,0 +1,232 @@
+// Package proto defines the JSON-RPC protocol shared with the
+// obsidian-remote-ssh plugin.
+//
+// This file is a hand-maintained mirror of
+// plugin/src/proto/types.ts. When the spec changes, both sides move
+// in the same PR. See proto/README.md for the normative description.
+package proto
+
+import "encoding/json"
+
+// ProtocolVersion is the integer version negotiated at handshake.
+// Bump it for any breaking change on the wire.
+const ProtocolVersion = 1
+
+// ─── core shapes ────────────────────────────────────────────────────────────
+
+// ServerInfo is returned by the server.info method.
+type ServerInfo struct {
+	// Version is the daemon's implementation version, e.g. "0.1.0".
+	Version string `json:"version"`
+	// ProtocolVersion is the wire version; compare against ProtocolVersion.
+	ProtocolVersion int `json:"protocolVersion"`
+	// Capabilities lists the methods this daemon implements,
+	// e.g. ["fs.stat", "fs.list", ...].
+	Capabilities []string `json:"capabilities"`
+	// VaultRoot is the absolute path of the vault on the remote host
+	// (informational; every `path` in other methods is vault-relative).
+	VaultRoot string `json:"vaultRoot"`
+}
+
+// EntryType distinguishes files from directories.
+type EntryType string
+
+const (
+	EntryTypeFile    EntryType = "file"
+	EntryTypeFolder  EntryType = "folder"
+	EntryTypeSymlink EntryType = "symlink"
+)
+
+// Stat describes a single filesystem entry.
+type Stat struct {
+	Type EntryType `json:"type"`
+	// Mtime is the modification time in unix milliseconds.
+	Mtime int64 `json:"mtime"`
+	// Size in bytes; 0 for directories.
+	Size int64 `json:"size"`
+	// Mode is POSIX mode bits (informational).
+	Mode uint32 `json:"mode"`
+}
+
+// Entry is a directory listing row.
+type Entry struct {
+	// Name is the basename only (no slashes).
+	Name  string    `json:"name"`
+	Type  EntryType `json:"type"`
+	Mtime int64     `json:"mtime"`
+	Size  int64     `json:"size"`
+}
+
+// ─── method param / result shapes ───────────────────────────────────────────
+
+type AuthParams struct {
+	Token string `json:"token"`
+}
+type AuthResult struct {
+	OK bool `json:"ok"`
+}
+
+type PathOnlyParams struct {
+	Path string `json:"path"`
+}
+type ExistsResult struct {
+	Exists bool `json:"exists"`
+}
+type ListResult struct {
+	Entries []Entry `json:"entries"`
+}
+
+type ReadTextParams struct {
+	Path     string `json:"path"`
+	Encoding string `json:"encoding,omitempty"` // "utf8" when set
+}
+type ReadTextResult struct {
+	Content  string `json:"content"`
+	Mtime    int64  `json:"mtime"`
+	Size     int64  `json:"size"`
+	Encoding string `json:"encoding"` // always "utf8" for now
+}
+type ReadBinaryResult struct {
+	ContentBase64 string `json:"contentBase64"`
+	Mtime         int64  `json:"mtime"`
+	Size          int64  `json:"size"`
+}
+
+type WriteTextParams struct {
+	Path          string `json:"path"`
+	Content       string `json:"content"`
+	// ExpectedMtime, when non-zero, causes the write to fail with
+	// PreconditionFailed if the remote file's mtime differs.
+	ExpectedMtime int64 `json:"expectedMtime,omitempty"`
+}
+type WriteBinaryParams struct {
+	Path          string `json:"path"`
+	ContentBase64 string `json:"contentBase64"`
+	ExpectedMtime int64  `json:"expectedMtime,omitempty"`
+}
+type AppendTextParams struct {
+	Path    string `json:"path"`
+	Content string `json:"content"`
+}
+type AppendBinaryParams struct {
+	Path          string `json:"path"`
+	ContentBase64 string `json:"contentBase64"`
+}
+type MtimeResult struct {
+	Mtime int64 `json:"mtime"`
+}
+
+type MkdirParams struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+type RmdirParams struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+type RenameParams struct {
+	OldPath string `json:"oldPath"`
+	NewPath string `json:"newPath"`
+}
+type CopyParams struct {
+	SrcPath  string `json:"srcPath"`
+	DestPath string `json:"destPath"`
+}
+
+type WatchParams struct {
+	Path      string `json:"path"`
+	Recursive bool   `json:"recursive,omitempty"`
+}
+type WatchResult struct {
+	SubscriptionID string `json:"subscriptionId"`
+}
+type UnwatchParams struct {
+	SubscriptionID string `json:"subscriptionId"`
+}
+
+// ─── server-push notifications ──────────────────────────────────────────────
+
+// FsChangeEvent is the kind of change the server observed on a watched path.
+type FsChangeEvent string
+
+const (
+	FsChangeEventCreated  FsChangeEvent = "created"
+	FsChangeEventModified FsChangeEvent = "modified"
+	FsChangeEventDeleted  FsChangeEvent = "deleted"
+	FsChangeEventRenamed  FsChangeEvent = "renamed"
+)
+
+type FsChangedParams struct {
+	SubscriptionID string        `json:"subscriptionId"`
+	Path           string        `json:"path"`
+	Event          FsChangeEvent `json:"event"`
+	// Mtime is set for created/modified/renamed.
+	Mtime int64 `json:"mtime,omitempty"`
+	// NewPath is set iff Event == FsChangeEventRenamed.
+	NewPath string `json:"newPath,omitempty"`
+}
+
+// ─── JSON-RPC envelopes ─────────────────────────────────────────────────────
+
+// JSONRPCVersion is the fixed protocol label on every envelope.
+const JSONRPCVersion = "2.0"
+
+// Request is a client-to-server call.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"` // always JSONRPCVersion
+	ID      json.RawMessage `json:"id"`      // number or string (raw so we echo it faithfully)
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// Success is a server-to-client successful response.
+type Success struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result"`
+}
+
+// ErrorEnvelope is a server-to-client error response. `ID` is null when
+// the server couldn't parse the request's id.
+type ErrorEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   ErrorObject     `json:"error"`
+}
+
+// ErrorObject is the payload of ErrorEnvelope.Error.
+type ErrorObject struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Notification is a server-to-client message with no id (no reply expected).
+type Notification struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// ─── error codes ────────────────────────────────────────────────────────────
+
+// Error codes shared with the client. The JSON-RPC 2.0 reserved range is
+// -32768..-32000; our custom codes live in the -32000..-32099 block.
+const (
+	ErrorParseError     = -32700
+	ErrorInvalidRequest = -32600
+	ErrorMethodNotFound = -32601
+	ErrorInvalidParams  = -32602
+	ErrorInternalError  = -32603
+
+	ErrorAuthRequired          = -32000
+	ErrorAuthInvalid           = -32001
+	ErrorFileNotFound          = -32010
+	ErrorNotADirectory         = -32011
+	ErrorIsADirectory          = -32012
+	ErrorExists                = -32013
+	ErrorPermissionDenied      = -32014
+	ErrorPathOutsideVault      = -32015
+	ErrorPreconditionFailed    = -32020
+	ErrorProtocolVersionTooOld = -32021
+)


### PR DESCRIPTION
## Summary
Spec + hand-maintained TS/Go type mirrors for the daemon the plugin will speak to. No wire code yet — transport and method handlers land in the next phases. Without the proto settled, those PRs would be bikeshedding shapes.

### \`proto/README.md\` — normative wire description
- **Transport**: JSON-RPC 2.0 over WebSocket, tunnelled through SSH to a unix socket on the remote. Nothing exposed to the network.
- **Handshake**: \`auth { token }\` reads \`~/.obsidian-remote/token\` (mode \`0600\`, written by the server at startup). Client then calls \`server.info\` for version negotiation.
- **Protocol version 1.**
- **Path rules**: vault-relative, forward slashes. \`..\` components and leading \`/\` are rejected with \`PathOutsideVault\`.
- **18 methods** covering stat/exists/list, readText/readBinary, write/writeBinary/append/appendBinary, mkdir/remove/rmdir, rename/copy, trashLocal, watch/unwatch — plus \`auth\` and \`server.info\`.
- **Push notification** \`fs.changed\` with \`created\` / \`modified\` / \`deleted\` / \`renamed\` events, debounced server-side so a single save doesn't flood the wire.
- **Error codes**: JSON-RPC reserved range plus a \`-32000..-32021\` custom block (\`AuthRequired\`, \`FileNotFound\`, \`IsADirectory\`, \`PreconditionFailed\`, \`PathOutsideVault\`, \`ProtocolVersionTooOld\`, …).

### \`plugin/src/proto/types.ts\`
- \`MethodMap\` keyed by method name with \`Params<M>\` / \`Result<M>\` helpers, so the upcoming \`RpcClient.call<M>(method, params)\` can be fully typed.
- \`ServerNotificationMap\` for the push side.
- Typed envelopes: \`JsonRpcRequest\` / \`JsonRpcSuccess\` / \`JsonRpcError\` / \`JsonRpcNotification\`.
- \`ErrorCode\` declared \`as const\` so switches stay exhaustive.
- \`PROTOCOL_VERSION = 1\`.

### \`server/internal/proto/types.go\`
- Same shapes translated to Go structs with \`json:\` tags matching the TS field names exactly.
- JSON-RPC envelopes use \`json.RawMessage\` for \`id\` / \`params\` / \`result\` so the dispatcher can decode once, route, and hand off raw bytes to the method handler without double-parsing.
- Error code constants with matching numeric values.
- \`ProtocolVersion = 1\`.

## Lockstep invariant
The spec is the source of truth; TS and Go are hand-maintained mirrors. Drift in either direction is expected to be caught by:
- TypeScript: a TS-mirror change that contradicts a method table entry is a compile error.
- Go: the field tags are explicit JSON names, so a rename on either side produces a structured \`InvalidParams\` on the wire and a fast-fail at the dispatcher boundary.
- \`plugin/tests/proto-types.test.ts\` pins every error-code number; drift becomes a unit test failure.

When the spec changes, **both mirrors move in the same PR**.

## Test plan
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` → 79 / 79 pass (3 new)
- [x] \`cd plugin && npm run build\` → 369 KB (proto/ is not reachable from runtime code yet; esbuild tree-shakes it until Phase 5-D wires the transport in)
- [ ] Go side: CI's server job compiles \`server/\` (no Go toolchain on the dev host; relying on CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)