### PR TITLE
feat(server): skeleton with framing, dispatcher, auth, server.info

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -5,13 +5,23 @@ Shared JSON-RPC protocol between the obsidian-remote-ssh plugin
 
 ## Transport
 
-- JSON-RPC 2.0 messages over a single WebSocket frame per message.
-- The WebSocket rides an SSH-forwarded local TCP port → remote unix
-  socket. The plugin opens the SSH session using its existing
-  credentials; nothing here is exposed to the network.
-- Text frames only. Binary payloads (file bytes) are base64-encoded
-  inside the JSON body. MVP trade-off: +33% wire overhead for a much
-  simpler client.
+- **Length-prefixed JSON messages** (LSP-style framing) over a unix
+  socket. One message per frame; no WebSocket or HTTP on this channel.
+    ```
+    Content-Length: <bytes>\r\n
+    \r\n
+    <JSON body>
+    ```
+- The plugin opens a local TCP connection that SSH forwards to the
+  daemon's unix socket (`ssh -L <port>:<sockpath> …`). Nothing is
+  exposed to the network.
+- The framing handles multi-MB payloads cleanly and lets both sides
+  reject oversized messages up front (future limit, configurable).
+- Binary payloads (file bytes) are base64-encoded inside the JSON
+  body. MVP trade-off: +33% wire overhead for a much simpler client.
+  Attachment serving for `getResourcePath` lives on a separate HTTP
+  channel on a second forwarded port (Phase 5-F); this channel is
+  always framed JSON.
 
 ## Handshake
 

--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -1,30 +1,142 @@
-// Command obsidian-remote-server is the remote-side daemon spoken to by the
-// obsidian-remote-ssh plugin. The plugin auto-deploys this binary over SSH,
-// starts it, and forwards a local port to the unix socket it listens on.
-//
-// This file is a placeholder during the monorepo restructure (Phase 5-A).
-// The real implementation — JSON-RPC over WebSocket, fsnotify watcher,
-// HTTP attachment serving — lands in the subsequent phases.
+// Command obsidian-remote-server is the remote-side daemon spoken to
+// by the obsidian-remote-ssh plugin. The plugin auto-deploys the
+// binary over SSH and forwards a local TCP port to the unix socket
+// this process listens on.
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
+	"log/slog"
+	"net"
 	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/handlers"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
 )
 
 // Version is replaced at link time via -ldflags "-X main.Version=...".
 var Version = "0.0.0-dev"
 
 func main() {
-	versionFlag := flag.Bool("version", false, "print version and exit")
-	flag.Parse()
+	code, err := run(os.Args[1:])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+	}
+	os.Exit(code)
+}
 
+// run is the unit-testable entry point: argv without the program name
+// in, exit code + optional error out.
+func run(args []string) (int, error) {
+	fs := flag.NewFlagSet("obsidian-remote-server", flag.ContinueOnError)
+	var (
+		vaultRoot   = fs.String("vault-root", "", "absolute path of the vault on this host (required)")
+		socketPath  = fs.String("socket", "", "unix socket to listen on (default ~/.obsidian-remote/server.sock)")
+		tokenPath   = fs.String("token-file", "", "file to write the session token to (default ~/.obsidian-remote/token)")
+		versionFlag = fs.Bool("version", false, "print version and exit")
+		verbose     = fs.Bool("verbose", false, "log connection and dispatch events to stderr")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2, err
+	}
 	if *versionFlag {
 		fmt.Println(Version)
-		return
+		return 0, nil
 	}
 
-	fmt.Fprintf(os.Stderr, "obsidian-remote-server %s — not implemented yet (Phase 5-B onward)\n", Version)
-	os.Exit(1)
+	if *vaultRoot == "" {
+		return 2, errors.New("--vault-root is required")
+	}
+	absRoot, err := filepath.Abs(*vaultRoot)
+	if err != nil {
+		return 2, fmt.Errorf("resolve --vault-root: %w", err)
+	}
+	if info, err := os.Stat(absRoot); err != nil || !info.IsDir() {
+		return 2, fmt.Errorf("--vault-root %q is not a directory", absRoot)
+	}
+
+	defaultDir, err := defaultStateDir()
+	if err != nil {
+		return 1, err
+	}
+	if *socketPath == "" {
+		*socketPath = filepath.Join(defaultDir, "server.sock")
+	}
+	if *tokenPath == "" {
+		*tokenPath = filepath.Join(defaultDir, "token")
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if *verbose {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	}
+
+	token, err := auth.Generate()
+	if err != nil {
+		return 1, err
+	}
+	if err := auth.WriteFile(*tokenPath, token); err != nil {
+		return 1, err
+	}
+	defer func() { _ = os.Remove(*tokenPath) }()
+
+	// Clean up any dangling socket from a prior crashed run.
+	_ = os.Remove(*socketPath)
+	if err := os.MkdirAll(filepath.Dir(*socketPath), 0o700); err != nil {
+		return 1, fmt.Errorf("mkdir socket dir: %w", err)
+	}
+	listener, err := net.Listen("unix", *socketPath)
+	if err != nil {
+		return 1, fmt.Errorf("listen %q: %w", *socketPath, err)
+	}
+	defer func() { _ = os.Remove(*socketPath) }()
+	// Restrict socket to the current user.
+	if err := os.Chmod(*socketPath, 0o600); err != nil {
+		logger.Warn("chmod socket", "err", err.Error())
+	}
+
+	srv := server.New(server.Options{
+		Token:     token,
+		VaultRoot: absRoot,
+		Version:   Version,
+		Logger:    logger,
+	})
+	disp := srv.Dispatcher()
+	disp.Handle("auth", handlers.Auth(token))
+	disp.Handle("server.info", handlers.ServerInfo(disp, Version, absRoot))
+
+	// Wire signal-driven shutdown: closing the listener unwinds Serve.
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+	go func() {
+		<-ctx.Done()
+		logger.Info("shutdown signal received")
+		_ = listener.Close()
+	}()
+
+	fmt.Fprintf(os.Stderr, "obsidian-remote-server %s\n", Version)
+	fmt.Fprintf(os.Stderr, "  vault:  %s\n", absRoot)
+	fmt.Fprintf(os.Stderr, "  socket: %s\n", *socketPath)
+	fmt.Fprintf(os.Stderr, "  token:  %s\n", *tokenPath)
+
+	if err := srv.Serve(ctx, listener); err != nil && !errors.Is(err, net.ErrClosed) {
+		return 1, err
+	}
+	return 0, nil
+}
+
+func defaultStateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("home dir: %w", err)
+	}
+	return filepath.Join(home, ".obsidian-remote"), nil
 }

--- a/server/internal/auth/token.go
+++ b/server/internal/auth/token.go
@@ -1,0 +1,85 @@
+// Package auth owns the session token that proves a connecting client
+// is the same user that started the daemon. The token is generated
+// once at startup, written to a file the user owns (POSIX mode 0600),
+// and read by the plugin over the same SSH session that started the
+// daemon. Tokens are not rotated during a session.
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Token is a hex-encoded random string backing a single server run.
+type Token string
+
+// Generate returns a 32-byte cryptographically random token as hex.
+func Generate() (Token, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("auth: generate token: %w", err)
+	}
+	return Token(hex.EncodeToString(b[:])), nil
+}
+
+// Equals performs a constant-time comparison against another string.
+// Both arguments may be of different lengths; a mismatch never falls
+// back to early-exit comparison.
+func (t Token) Equals(other string) bool {
+	return subtle.ConstantTimeCompare([]byte(t), []byte(other)) == 1
+}
+
+// WriteFile persists the token to path with mode 0600. Any parent
+// directory is created with mode 0700 if missing; the file itself is
+// truncated + rewritten atomically via a sibling temp file + rename.
+// Existing tokens are replaced silently.
+func WriteFile(path string, t Token) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("auth: mkdir %q: %w", dir, err)
+	}
+	// Create a sibling tmp with the same mode so the eventual rename
+	// never exposes a file with looser perms.
+	tmp, err := os.CreateTemp(dir, ".token-*")
+	if err != nil {
+		return fmt.Errorf("auth: tempfile: %w", err)
+	}
+	// On any error below, do our best to remove the tmp.
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("auth: chmod %q: %w", tmpPath, err)
+	}
+	if _, err := tmp.WriteString(string(t)); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("auth: write %q: %w", tmpPath, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("auth: close %q: %w", tmpPath, err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("auth: rename %q → %q: %w", tmpPath, path, err)
+	}
+	// os.Rename doesn't preserve mode on all platforms; reassert.
+	if err := os.Chmod(path, 0o600); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("auth: chmod %q: %w", path, err)
+	}
+	return nil
+}
+
+// ReadFile loads a token previously written by WriteFile.
+func ReadFile(path string) (Token, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("auth: read %q: %w", path, err)
+	}
+	return Token(b), nil
+}

--- a/server/internal/auth/token_test.go
+++ b/server/internal/auth/token_test.go
@@ -1,0 +1,111 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGenerate_Uniqueness(t *testing.T) {
+	a, err := Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Generate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a == b {
+		t.Fatalf("two successive Generate() calls returned the same token: %q", a)
+	}
+	// 32 bytes hex-encoded = 64 chars.
+	if len(a) != 64 {
+		t.Errorf("want 64-char hex token, got %d chars", len(a))
+	}
+	if strings.TrimFunc(string(a), isHex) != "" {
+		t.Errorf("token contains non-hex chars: %q", a)
+	}
+}
+
+func isHex(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+}
+
+func TestToken_Equals(t *testing.T) {
+	tk := Token("aaaa")
+	if !tk.Equals("aaaa") {
+		t.Error("Equals should accept exact match")
+	}
+	if tk.Equals("aaab") {
+		t.Error("Equals should reject different value of same length")
+	}
+	if tk.Equals("") {
+		t.Error("Equals should reject empty string")
+	}
+	if tk.Equals("aaaaa") {
+		t.Error("Equals should reject different length")
+	}
+}
+
+func TestWriteAndReadFile_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "token")
+
+	tk := Token("0123456789abcdef")
+	if err := WriteFile(path, tk); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	// POSIX perm bits are advisory on Windows; assert only on POSIX.
+	if runtime.GOOS != "windows" {
+		got := info.Mode().Perm()
+		if got != 0o600 {
+			t.Errorf("token file perm = %04o, want 0600", got)
+		}
+	}
+
+	got, err := ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if got != tk {
+		t.Errorf("round-trip mismatch: got %q, want %q", got, tk)
+	}
+}
+
+func TestWriteFile_Overwrites(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "token")
+
+	if err := WriteFile(path, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteFile(path, "second"); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "second" {
+		t.Errorf("after overwrite, got %q, want %q", got, "second")
+	}
+
+	// Ensure the temp file didn't leak in the same directory.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".token-") {
+			t.Errorf("leftover temp file after WriteFile: %q", e.Name())
+		}
+	}
+}

--- a/server/internal/handlers/auth.go
+++ b/server/internal/handlers/auth.go
@@ -1,0 +1,42 @@
+// Package handlers implements the method handlers registered with the
+// JSON-RPC dispatcher. One file per method keeps the blast radius of
+// changes small.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+)
+
+// Auth returns the handler for the `auth` method. The caller passes
+// in the expected token (read from disk at startup); this keeps the
+// handler stateless and trivially testable.
+func Auth(expected auth.Token) rpc.Handler {
+	return func(ctx context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.AuthParams
+		if err := json.Unmarshal(params, &p); err != nil {
+			return nil, rpc.ErrInvalidParams("auth: " + err.Error())
+		}
+		if !expected.Equals(p.Token) {
+			return nil, rpc.ErrAuthInvalid()
+		}
+		server.SessionFromContext(ctx).MarkAuthenticated()
+		return proto.AuthResult{OK: true}, nil
+	}
+}
+
+// RequireAuth wraps h so that a non-auth method fails with AuthRequired
+// until the session has accepted a valid auth call.
+func RequireAuth(h rpc.Handler) rpc.Handler {
+	return func(ctx context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		if !server.SessionFromContext(ctx).IsAuthenticated() {
+			return nil, rpc.ErrAuthRequired()
+		}
+		return h(ctx, params)
+	}
+}

--- a/server/internal/handlers/auth_test.go
+++ b/server/internal/handlers/auth_test.go
@@ -1,0 +1,89 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+)
+
+const token = "correct-horse-battery-staple"
+
+func TestAuth_AcceptsMatchingToken(t *testing.T) {
+	h := Auth(auth.Token(token))
+	sess := server.NewSession()
+	ctx := server.WithSession(context.Background(), sess)
+
+	result, rpcErr := h(ctx, json.RawMessage(`{"token":"correct-horse-battery-staple"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected error: %+v", rpcErr)
+	}
+	if !sess.IsAuthenticated() {
+		t.Error("session should be marked authenticated after a successful auth call")
+	}
+	got, ok := result.(proto.AuthResult)
+	if !ok {
+		t.Fatalf("result type = %T, want proto.AuthResult", result)
+	}
+	if !got.OK {
+		t.Error("AuthResult.OK should be true")
+	}
+}
+
+func TestAuth_RejectsMismatchedToken(t *testing.T) {
+	h := Auth(auth.Token(token))
+	sess := server.NewSession()
+	ctx := server.WithSession(context.Background(), sess)
+
+	_, rpcErr := h(ctx, json.RawMessage(`{"token":"wrong"}`))
+	if rpcErr == nil || rpcErr.Code != proto.ErrorAuthInvalid {
+		t.Fatalf("want AuthInvalid, got %+v", rpcErr)
+	}
+	if sess.IsAuthenticated() {
+		t.Error("session must not be authenticated after a failed auth")
+	}
+}
+
+func TestAuth_InvalidParams(t *testing.T) {
+	h := Auth(auth.Token(token))
+	ctx := server.WithSession(context.Background(), server.NewSession())
+
+	_, rpcErr := h(ctx, json.RawMessage(`{"not json`))
+	if rpcErr == nil || rpcErr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams for garbage params, got %+v", rpcErr)
+	}
+}
+
+func TestRequireAuth_BlocksUntilAuthenticated(t *testing.T) {
+	innerCalled := false
+	inner := func(_ context.Context, _ json.RawMessage) (interface{}, *rpc.Error) {
+		innerCalled = true
+		return "ok", nil
+	}
+	gated := RequireAuth(inner)
+
+	sess := server.NewSession()
+	ctx := server.WithSession(context.Background(), sess)
+
+	// Before auth: should reject with AuthRequired and never call inner.
+	_, rpcErr := gated(ctx, nil)
+	if rpcErr == nil || rpcErr.Code != proto.ErrorAuthRequired {
+		t.Fatalf("want AuthRequired before auth, got %+v", rpcErr)
+	}
+	if innerCalled {
+		t.Error("inner handler must not be invoked before auth")
+	}
+
+	// After marking the session authenticated, the gate opens.
+	sess.MarkAuthenticated()
+	if _, err := gated(ctx, nil); err != nil {
+		t.Errorf("gated call after auth failed: %+v", err)
+	}
+	if !innerCalled {
+		t.Error("inner handler should be invoked once authenticated")
+	}
+}

--- a/server/internal/handlers/server_info.go
+++ b/server/internal/handlers/server_info.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// InfoSource is the subset of the dispatcher the server.info handler
+// needs in order to advertise capabilities. Injecting an interface
+// keeps the handler decoupled from `*rpc.Dispatcher` and makes it
+// testable with a fake.
+type InfoSource interface {
+	// Methods returns the registered method names in any order.
+	Methods() []string
+}
+
+// ServerInfo returns the handler for the `server.info` method.
+// `version` is the daemon's implementation version string; `vaultRoot`
+// is echoed to the client as documentation. Capabilities are the
+// current dispatcher's registered method names, sorted for stability.
+func ServerInfo(src InfoSource, version, vaultRoot string) rpc.Handler {
+	return func(_ context.Context, _ json.RawMessage) (interface{}, *rpc.Error) {
+		capabilities := src.Methods()
+		sort.Strings(capabilities)
+		return proto.ServerInfo{
+			Version:         version,
+			ProtocolVersion: proto.ProtocolVersion,
+			Capabilities:    capabilities,
+			VaultRoot:       vaultRoot,
+		}, nil
+	}
+}

--- a/server/internal/handlers/server_info_test.go
+++ b/server/internal/handlers/server_info_test.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+type fakeInfoSource struct{ methods []string }
+
+func (f fakeInfoSource) Methods() []string { return f.methods }
+
+func TestServerInfo_EchosVersionAndRoot(t *testing.T) {
+	src := fakeInfoSource{methods: []string{"fs.stat", "auth", "fs.list"}}
+	h := ServerInfo(src, "0.1.2", "/home/me/vault")
+
+	raw, rpcErr := h(context.Background(), nil)
+	if rpcErr != nil {
+		t.Fatalf("unexpected error: %+v", rpcErr)
+	}
+	info, ok := raw.(proto.ServerInfo)
+	if !ok {
+		t.Fatalf("result type = %T, want proto.ServerInfo", raw)
+	}
+
+	if info.Version != "0.1.2" {
+		t.Errorf("Version = %q, want 0.1.2", info.Version)
+	}
+	if info.ProtocolVersion != proto.ProtocolVersion {
+		t.Errorf("ProtocolVersion = %d, want %d", info.ProtocolVersion, proto.ProtocolVersion)
+	}
+	if info.VaultRoot != "/home/me/vault" {
+		t.Errorf("VaultRoot = %q, want /home/me/vault", info.VaultRoot)
+	}
+
+	// Capabilities must be sorted so callers can diff across runs.
+	want := []string{"auth", "fs.list", "fs.stat"}
+	if len(info.Capabilities) != len(want) {
+		t.Fatalf("Capabilities length = %d, want %d", len(info.Capabilities), len(want))
+	}
+	for i := range want {
+		if info.Capabilities[i] != want[i] {
+			t.Errorf("Capabilities[%d] = %q, want %q", i, info.Capabilities[i], want[i])
+		}
+	}
+}

--- a/server/internal/rpc/dispatcher.go
+++ b/server/internal/rpc/dispatcher.go
@@ -1,0 +1,140 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+// Handler runs one method call. `params` is the raw JSON value of the
+// request's params (may be null or absent — handlers decide whether
+// that is acceptable). Return a value to wrap in a success envelope,
+// or a non-nil *Error to wrap in an error envelope. Returning both
+// nil is treated as a `null` result.
+type Handler func(ctx context.Context, params json.RawMessage) (interface{}, *Error)
+
+// Dispatcher routes JSON-RPC requests by method name.
+//
+// Dispatcher is safe for concurrent use: handlers are only looked up,
+// never mutated, after construction.
+type Dispatcher struct {
+	handlers map[string]Handler
+}
+
+// NewDispatcher returns an empty dispatcher. Register handlers via Handle.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{handlers: map[string]Handler{}}
+}
+
+// Handle installs h under the given method name. Overwriting an
+// existing handler is allowed (tests rely on it).
+func (d *Dispatcher) Handle(method string, h Handler) {
+	d.handlers[method] = h
+}
+
+// Methods returns the registered method names in arbitrary order.
+// Intended for server.info.
+func (d *Dispatcher) Methods() []string {
+	out := make([]string, 0, len(d.handlers))
+	for k := range d.handlers {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Process parses one framed request body and returns the bytes of the
+// response envelope to write back, or nil if the message was a
+// notification (no reply expected).
+//
+// Process never returns a Go error; all problems are reported as
+// JSON-RPC error envelopes so the caller can just feed the bytes to
+// WriteFrame.
+func (d *Dispatcher) Process(ctx context.Context, body []byte) []byte {
+	var req proto.Request
+	if err := json.Unmarshal(body, &req); err != nil {
+		return encodeError(nil, ErrParse(fmt.Sprintf("parse: %s", err)))
+	}
+	// A missing/empty id field means "notification" in JSON-RPC 2.0.
+	isNotification := len(req.ID) == 0 || string(req.ID) == "null"
+
+	if req.JSONRPC != proto.JSONRPCVersion {
+		if isNotification {
+			return nil
+		}
+		return encodeError(req.ID, ErrInvalidReq("jsonrpc must be \"2.0\""))
+	}
+	if req.Method == "" {
+		if isNotification {
+			return nil
+		}
+		return encodeError(req.ID, ErrInvalidReq("method is required"))
+	}
+
+	h, ok := d.handlers[req.Method]
+	if !ok {
+		if isNotification {
+			return nil
+		}
+		return encodeError(req.ID, ErrMethodMissing(req.Method))
+	}
+
+	result, rpcErr := safeCall(ctx, h, req.Params)
+	if isNotification {
+		// Client asked for no reply; drop whatever the handler returned.
+		return nil
+	}
+	if rpcErr != nil {
+		return encodeError(req.ID, rpcErr)
+	}
+	return encodeSuccess(req.ID, result)
+}
+
+// safeCall runs a handler with a panic-to-InternalError recovery so
+// one buggy handler can't take the whole session down.
+func safeCall(ctx context.Context, h Handler, params json.RawMessage) (result interface{}, rpcErr *Error) {
+	defer func() {
+		if r := recover(); r != nil {
+			rpcErr = ErrInternal(fmt.Sprintf("handler panicked: %v", r))
+		}
+	}()
+	return h(ctx, params)
+}
+
+func encodeSuccess(id json.RawMessage, result interface{}) []byte {
+	r, err := encodeResult(result)
+	if err != nil {
+		// Serialisation of a handler's result should not realistically
+		// fail for our types, but handle it gracefully anyway.
+		return encodeError(id, ErrInternal(fmt.Sprintf("encode result: %s", err)))
+	}
+	env := proto.Success{
+		JSONRPC: proto.JSONRPCVersion,
+		ID:      id,
+		Result:  r,
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return encodeError(id, ErrInternal(fmt.Sprintf("encode envelope: %s", err)))
+	}
+	return b
+}
+
+func encodeError(id json.RawMessage, e *Error) []byte {
+	if id == nil {
+		id = json.RawMessage("null")
+	}
+	env := proto.ErrorEnvelope{
+		JSONRPC: proto.JSONRPCVersion,
+		ID:      id,
+		Error:   *e,
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		// Last-resort static error envelope so the connection doesn't
+		// silently drop messages when something weird happens.
+		return []byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"envelope encode failure"}}`)
+	}
+	return b
+}

--- a/server/internal/rpc/dispatcher_test.go
+++ b/server/internal/rpc/dispatcher_test.go
@@ -1,0 +1,126 @@
+package rpc
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+func TestDispatcher_RoutesByMethod(t *testing.T) {
+	d := NewDispatcher()
+	d.Handle("echo", func(_ context.Context, params json.RawMessage) (interface{}, *Error) {
+		return map[string]json.RawMessage{"echoed": params}, nil
+	})
+
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"echo","params":{"hello":"world"}}`))
+	var env proto.Success
+	if err := json.Unmarshal(reply, &env); err != nil {
+		t.Fatalf("unmarshal success: %v\n%s", err, reply)
+	}
+	if string(env.ID) != "1" {
+		t.Errorf("id = %s, want 1", env.ID)
+	}
+}
+
+func TestDispatcher_MethodNotFound(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","id":7,"method":"missing"}`))
+	if code := errorCode(t, reply); code != proto.ErrorMethodNotFound {
+		t.Errorf("error code = %d, want %d", code, proto.ErrorMethodNotFound)
+	}
+}
+
+func TestDispatcher_HandlerErrorsArePropagated(t *testing.T) {
+	d := NewDispatcher()
+	d.Handle("forbid", func(_ context.Context, _ json.RawMessage) (interface{}, *Error) {
+		return nil, ErrAuthRequired()
+	})
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","id":2,"method":"forbid"}`))
+	if code := errorCode(t, reply); code != proto.ErrorAuthRequired {
+		t.Errorf("error code = %d, want %d", code, proto.ErrorAuthRequired)
+	}
+}
+
+func TestDispatcher_PanicBecomesInternalError(t *testing.T) {
+	d := NewDispatcher()
+	d.Handle("boom", func(_ context.Context, _ json.RawMessage) (interface{}, *Error) {
+		panic("explosion in handler")
+	})
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","id":3,"method":"boom"}`))
+	if code := errorCode(t, reply); code != proto.ErrorInternalError {
+		t.Errorf("error code = %d, want %d", code, proto.ErrorInternalError)
+	}
+	if !strings.Contains(string(reply), "explosion") {
+		t.Errorf("error message should mention panic text:\n%s", reply)
+	}
+}
+
+func TestDispatcher_MalformedJSON(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Process(context.Background(), []byte(`not a json doc`))
+	if code := errorCode(t, reply); code != proto.ErrorParseError {
+		t.Errorf("error code = %d, want %d", code, proto.ErrorParseError)
+	}
+}
+
+func TestDispatcher_WrongJSONRPCVersion(t *testing.T) {
+	d := NewDispatcher()
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"1.0","id":1,"method":"anything"}`))
+	if code := errorCode(t, reply); code != proto.ErrorInvalidRequest {
+		t.Errorf("error code = %d, want %d", code, proto.ErrorInvalidRequest)
+	}
+}
+
+func TestDispatcher_NotificationReturnsNoBytes(t *testing.T) {
+	d := NewDispatcher()
+	called := false
+	d.Handle("ping", func(_ context.Context, _ json.RawMessage) (interface{}, *Error) {
+		called = true
+		return nil, nil
+	})
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","method":"ping"}`))
+	if reply != nil {
+		t.Errorf("notification produced a reply: %s", reply)
+	}
+	if !called {
+		t.Error("handler should still be invoked for notifications")
+	}
+}
+
+func TestDispatcher_NullResultIsEncodedAsNull(t *testing.T) {
+	d := NewDispatcher()
+	d.Handle("nothing", func(_ context.Context, _ json.RawMessage) (interface{}, *Error) {
+		return nil, nil
+	})
+	reply := d.Process(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"nothing"}`))
+	var env proto.Success
+	if err := json.Unmarshal(reply, &env); err != nil {
+		t.Fatal(err)
+	}
+	if string(env.Result) != "null" {
+		t.Errorf("result = %s, want null", env.Result)
+	}
+}
+
+func TestDispatcher_Methods(t *testing.T) {
+	d := NewDispatcher()
+	d.Handle("a", func(context.Context, json.RawMessage) (interface{}, *Error) { return nil, nil })
+	d.Handle("b", func(context.Context, json.RawMessage) (interface{}, *Error) { return nil, nil })
+	got := d.Methods()
+	if len(got) != 2 {
+		t.Fatalf("want 2 methods, got %d: %v", len(got), got)
+	}
+}
+
+// errorCode unmarshals reply as an ErrorEnvelope and returns the code.
+func errorCode(t *testing.T, reply []byte) int {
+	t.Helper()
+	var env proto.ErrorEnvelope
+	if err := json.Unmarshal(reply, &env); err != nil {
+		t.Fatalf("not an error envelope: %v\n%s", err, reply)
+	}
+	return env.Error.Code
+}

--- a/server/internal/rpc/errors.go
+++ b/server/internal/rpc/errors.go
@@ -1,0 +1,54 @@
+package rpc
+
+import (
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+// Error is a convenience wrapper around proto.ErrorObject used in
+// dispatch paths so handlers can `return nil, rpc.Err(...)` without
+// rebuilding the struct literal each time.
+type Error = proto.ErrorObject
+
+// Err builds an Error with the given code and message. `data` is
+// optional; pass nil when there's nothing structured to include.
+func Err(code int, message string, data interface{}) *Error {
+	return &Error{Code: code, Message: message, Data: data}
+}
+
+// ErrParse       returns a -32700 ParseError.
+func ErrParse(msg string) *Error { return Err(proto.ErrorParseError, msg, nil) }
+
+// ErrInvalidReq  returns a -32600 InvalidRequest.
+func ErrInvalidReq(msg string) *Error { return Err(proto.ErrorInvalidRequest, msg, nil) }
+
+// ErrMethodMissing returns a -32601 MethodNotFound.
+func ErrMethodMissing(method string) *Error {
+	return Err(proto.ErrorMethodNotFound, "method not found: "+method, nil)
+}
+
+// ErrInvalidParams returns a -32602 InvalidParams.
+func ErrInvalidParams(msg string) *Error { return Err(proto.ErrorInvalidParams, msg, nil) }
+
+// ErrInternal    returns a -32603 InternalError.
+func ErrInternal(msg string) *Error { return Err(proto.ErrorInternalError, msg, nil) }
+
+// ErrAuthRequired and friends are convenience builders for the custom
+// error codes defined in proto/types.go.
+
+func ErrAuthRequired() *Error    { return Err(proto.ErrorAuthRequired, "auth required", nil) }
+func ErrAuthInvalid() *Error     { return Err(proto.ErrorAuthInvalid, "invalid token", nil) }
+func ErrFileNotFound(p string) *Error {
+	return Err(proto.ErrorFileNotFound, "no such file: "+p, nil)
+}
+
+// encodeResult marshals a result value for WriteSuccess. Centralised
+// here so the dispatcher and tests agree on JSON shape (omit null,
+// preserve zero values, etc).
+func encodeResult(v interface{}) (json.RawMessage, error) {
+	if v == nil {
+		return json.RawMessage("null"), nil
+	}
+	return json.Marshal(v)
+}

--- a/server/internal/rpc/frame.go
+++ b/server/internal/rpc/frame.go
@@ -1,0 +1,104 @@
+// Package rpc implements the wire-framing and dispatch of JSON-RPC 2.0
+// messages between the plugin and the daemon.
+//
+// The framing convention matches the Language Server Protocol:
+//
+//	Content-Length: <N>\r\n
+//	\r\n
+//	<N bytes of UTF-8 JSON body>
+//
+// No other headers are recognised; a missing or malformed
+// Content-Length closes the connection.
+package rpc
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// DefaultMaxMessageBytes caps a single inbound message. Messages
+// larger than this close the connection with a framing error rather
+// than risk unbounded memory use.
+const DefaultMaxMessageBytes = 16 * 1024 * 1024 // 16 MiB
+
+// ErrMessageTooLarge is returned by ReadFrame when Content-Length
+// exceeds the configured limit.
+var ErrMessageTooLarge = errors.New("rpc: message exceeds maximum size")
+
+// ReadFrame reads one framed message off r and returns the JSON body
+// (without the headers). `max` bounds the declared Content-Length; a
+// value of 0 means "use DefaultMaxMessageBytes".
+//
+// An io.EOF at a clean frame boundary is returned as-is so callers can
+// treat it as "peer closed cleanly" rather than as an error.
+func ReadFrame(r *bufio.Reader, max int) ([]byte, error) {
+	if max <= 0 {
+		max = DefaultMaxMessageBytes
+	}
+
+	contentLength := -1
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			// An EOF before we've seen any header is a clean close.
+			if errors.Is(err, io.EOF) && line == "" && contentLength < 0 {
+				return nil, io.EOF
+			}
+			return nil, fmt.Errorf("rpc: read header: %w", err)
+		}
+		// LSP requires \r\n; tolerate bare \n from lenient clients.
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			// Blank line terminates the header block.
+			break
+		}
+		name, value, ok := strings.Cut(line, ":")
+		if !ok {
+			return nil, fmt.Errorf("rpc: malformed header %q", line)
+		}
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+		if strings.EqualFold(name, "Content-Length") {
+			n, err := strconv.Atoi(value)
+			if err != nil || n < 0 {
+				return nil, fmt.Errorf("rpc: invalid Content-Length %q", value)
+			}
+			contentLength = n
+		}
+		// Any other header is ignored for forward-compat.
+	}
+
+	if contentLength < 0 {
+		return nil, errors.New("rpc: missing Content-Length header")
+	}
+	if contentLength > max {
+		return nil, fmt.Errorf("%w: %d > %d", ErrMessageTooLarge, contentLength, max)
+	}
+
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("rpc: read body: %w", err)
+	}
+	return body, nil
+}
+
+// WriteFrame writes body as one framed message to w.
+func WriteFrame(w io.Writer, body []byte) error {
+	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
+	if _, err := io.WriteString(w, header); err != nil {
+		return fmt.Errorf("rpc: write header: %w", err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("rpc: write body: %w", err)
+	}
+	if flusher, ok := w.(interface{ Flush() error }); ok {
+		if err := flusher.Flush(); err != nil {
+			return fmt.Errorf("rpc: flush: %w", err)
+		}
+	}
+	return nil
+}

--- a/server/internal/rpc/frame_test.go
+++ b/server/internal/rpc/frame_test.go
@@ -1,0 +1,119 @@
+package rpc
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadFrame_Roundtrip(t *testing.T) {
+	var buf bytes.Buffer
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"auth","params":{"token":"abc"}}`)
+	if err := WriteFrame(&buf, body); err != nil {
+		t.Fatal(err)
+	}
+	r := bufio.NewReader(&buf)
+	got, err := ReadFrame(r, 0)
+	if err != nil {
+		t.Fatalf("ReadFrame: %v", err)
+	}
+	if !bytes.Equal(got, body) {
+		t.Errorf("body mismatch:\n  got  %q\n  want %q", got, body)
+	}
+}
+
+func TestReadFrame_MultipleInSequence(t *testing.T) {
+	var buf bytes.Buffer
+	bodies := [][]byte{
+		[]byte(`{"a":1}`),
+		[]byte(`{"b":2}`),
+		[]byte(`{"c":"payload with\nembedded\r\nwhitespace"}`),
+	}
+	for _, b := range bodies {
+		if err := WriteFrame(&buf, b); err != nil {
+			t.Fatal(err)
+		}
+	}
+	r := bufio.NewReader(&buf)
+	for i, want := range bodies {
+		got, err := ReadFrame(r, 0)
+		if err != nil {
+			t.Fatalf("ReadFrame[%d]: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Errorf("frame[%d] mismatch:\n  got  %q\n  want %q", i, got, want)
+		}
+	}
+}
+
+func TestReadFrame_CleanEOF(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader(""))
+	_, err := ReadFrame(r, 0)
+	if !errors.Is(err, io.EOF) {
+		t.Errorf("want io.EOF for empty stream, got %v", err)
+	}
+}
+
+func TestReadFrame_MissingContentLength(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("X-Foo: bar\r\n\r\n"))
+	_, err := ReadFrame(r, 0)
+	if err == nil {
+		t.Fatal("expected error for missing Content-Length, got nil")
+	}
+	if !strings.Contains(err.Error(), "Content-Length") {
+		t.Errorf("error should mention Content-Length, got %v", err)
+	}
+}
+
+func TestReadFrame_InvalidContentLength(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("Content-Length: not-a-number\r\n\r\n"))
+	_, err := ReadFrame(r, 0)
+	if err == nil || !strings.Contains(err.Error(), "invalid Content-Length") {
+		t.Errorf("want invalid Content-Length error, got %v", err)
+	}
+}
+
+func TestReadFrame_IgnoresUnknownHeader(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("X-Forwarded-For: 1.2.3.4\r\nContent-Length: 2\r\n\r\nok"))
+	got, err := ReadFrame(r, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ok" {
+		t.Errorf("body = %q, want %q", got, "ok")
+	}
+}
+
+func TestReadFrame_MessageTooLarge(t *testing.T) {
+	r := bufio.NewReader(strings.NewReader("Content-Length: 5000\r\n\r\nhello"))
+	_, err := ReadFrame(r, 100)
+	if !errors.Is(err, ErrMessageTooLarge) {
+		t.Errorf("want ErrMessageTooLarge, got %v", err)
+	}
+}
+
+func TestReadFrame_ToleratesBareLF(t *testing.T) {
+	// Some lenient clients emit \n instead of \r\n.
+	r := bufio.NewReader(strings.NewReader("Content-Length: 2\n\nok"))
+	got, err := ReadFrame(r, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "ok" {
+		t.Errorf("body = %q, want %q", got, "ok")
+	}
+}
+
+func TestWriteFrame_Bytes(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteFrame(&buf, []byte(`{"x":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	want := "Content-Length: 7\r\n\r\n{\"x\":1}"
+	if buf.String() != want {
+		t.Errorf("output = %q, want %q", buf.String(), want)
+	}
+}

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -1,0 +1,181 @@
+// Package server wires the dispatcher, framing, and per-session state
+// to a net.Listener. It is the only place in the tree that touches
+// network I/O directly, so tests that want to exercise the whole stack
+// can pass a pipe or a TCP loopback listener instead of a unix socket.
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// Options configure a Server.
+type Options struct {
+	// Token is the shared secret a client must present before any
+	// non-auth method succeeds. Must not be empty.
+	Token auth.Token
+
+	// VaultRoot is the absolute path of the vault on disk. Method
+	// handlers that touch the filesystem use this to resolve
+	// vault-relative paths. server.info echoes it to the client.
+	VaultRoot string
+
+	// Version is the daemon's implementation version string used by
+	// server.info. Defaults to "0.0.0-dev" when empty.
+	Version string
+
+	// Logger is used for connection-level events. Defaults to a no-op
+	// logger when nil.
+	Logger *slog.Logger
+}
+
+// Server accepts one connection at a time on an external listener and
+// runs the dispatch loop against each. Multiple concurrent
+// connections are allowed; each gets its own Session.
+type Server struct {
+	opts       Options
+	dispatcher *rpc.Dispatcher
+	log        *slog.Logger
+
+	// Per-connection bookkeeping.
+	connCount atomic.Int64
+}
+
+// New returns a Server with the given options and a pre-populated
+// dispatcher. The caller may mutate the dispatcher via Dispatcher()
+// before the first Serve() call.
+func New(opts Options) *Server {
+	if opts.Version == "" {
+		opts.Version = "0.0.0-dev"
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Server{
+		opts:       opts,
+		dispatcher: rpc.NewDispatcher(),
+		log:        opts.Logger,
+	}
+}
+
+// Dispatcher exposes the inner dispatcher so command handlers can be
+// registered before serving.
+func (s *Server) Dispatcher() *rpc.Dispatcher { return s.dispatcher }
+
+// Options returns a copy of the server's options (for handlers that
+// need the vault root, version string, etc.)
+func (s *Server) Options() Options { return s.opts }
+
+// Serve accepts connections until l returns an error. Each accepted
+// conn runs its own read/dispatch/write loop in a goroutine. Serve
+// blocks until the listener closes; it does NOT close individual
+// connections on return — the listener's Close is the signal.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return fmt.Errorf("server: accept: %w", err)
+		}
+		wg.Add(1)
+		go func(c net.Conn) {
+			defer wg.Done()
+			s.handleConn(ctx, c)
+		}(conn)
+	}
+}
+
+func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
+	connID := s.connCount.Add(1)
+	log := s.log.With("conn", connID, "peer", conn.RemoteAddr().String())
+	log.Info("connection opened")
+	defer func() {
+		_ = conn.Close()
+		log.Info("connection closed")
+	}()
+
+	session := NewSession()
+	reader := bufio.NewReader(conn)
+	// Protect concurrent writes to the connection (currently only the
+	// reply path writes, but fs.watch push events will write from
+	// other goroutines in a later phase).
+	var writeMu sync.Mutex
+
+	for {
+		body, err := rpc.ReadFrame(reader, 0)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return
+			}
+			log.Warn("framing error", "err", err.Error())
+			return
+		}
+
+		callCtx := WithSession(ctx, session)
+		reply := s.dispatcher.Process(callCtx, body)
+		if reply == nil {
+			continue
+		}
+
+		writeMu.Lock()
+		err = rpc.WriteFrame(conn, reply)
+		writeMu.Unlock()
+		if err != nil {
+			log.Warn("write error", "err", err.Error())
+			return
+		}
+	}
+}
+
+// --- context plumbing for handler access ---------------------------------
+
+type sessionCtxKey struct{}
+
+// WithSession returns a context that carries the given session so
+// handlers can fetch it via SessionFromContext. Exported so handler
+// tests can plant a Session of their own without routing through the
+// full network stack.
+func WithSession(parent context.Context, s *Session) context.Context {
+	return context.WithValue(parent, sessionCtxKey{}, s)
+}
+
+// SessionFromContext recovers the per-connection Session from a
+// handler's context. Handlers that receive a context without a
+// session get a fresh unauthenticated one; this keeps unit tests of
+// individual handlers simple (no need to thread a Session through
+// every rpc.Process call).
+func SessionFromContext(ctx context.Context) *Session {
+	if s, ok := ctx.Value(sessionCtxKey{}).(*Session); ok && s != nil {
+		return s
+	}
+	return NewSession()
+}
+
+// --- tiny helper so handlers don't have to import "encoding/json" just
+//     to shape their return values. -----------------------------------
+
+// RawJSON converts any JSON-marshalable value to json.RawMessage,
+// panicking on failure (reserved for test fixtures / static data).
+func RawJSON(v interface{}) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(fmt.Errorf("server: marshal fixture: %w", err))
+	}
+	return b
+}

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -1,0 +1,198 @@
+package server_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/handlers"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+)
+
+// testServer spins up a listening Server on 127.0.0.1:<random>, wires
+// the auth + server.info handlers, and tears everything down on
+// Cleanup. It returns a helper that dials fresh framed connections.
+type testServer struct {
+	addr  string
+	token auth.Token
+}
+
+func startTestServer(t *testing.T) *testServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	tk, err := auth.Generate()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	srv := server.New(server.Options{
+		Token:     tk,
+		VaultRoot: t.TempDir(),
+		Version:   "test",
+	})
+	disp := srv.Dispatcher()
+	disp.Handle("auth", handlers.Auth(tk))
+	disp.Handle("server.info", handlers.ServerInfo(disp, "test", srv.Options().VaultRoot))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = srv.Serve(ctx, listener)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_ = listener.Close()
+		wg.Wait()
+	})
+
+	return &testServer{addr: listener.Addr().String(), token: tk}
+}
+
+// client represents one JSON-RPC session over a TCP loopback.
+type client struct {
+	conn   net.Conn
+	reader *bufio.Reader
+	nextID int
+}
+
+func (ts *testServer) dial(t *testing.T) *client {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", ts.addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return &client{conn: conn, reader: bufio.NewReader(conn)}
+}
+
+func (c *client) call(t *testing.T, method string, params interface{}) (json.RawMessage, *proto.ErrorObject) {
+	t.Helper()
+	c.nextID++
+	id := c.nextID
+	paramsBytes, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	if params == nil {
+		paramsBytes = json.RawMessage("null")
+	}
+	reqBytes, err := json.Marshal(map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"method":  method,
+		"params":  json.RawMessage(paramsBytes),
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if err := rpc.WriteFrame(c.conn, reqBytes); err != nil {
+		t.Fatalf("write frame: %v", err)
+	}
+	reply, err := rpc.ReadFrame(c.reader, 0)
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	// Decode into a shape that accepts either success or error.
+	var env struct {
+		ID     json.RawMessage     `json:"id"`
+		Result json.RawMessage     `json:"result,omitempty"`
+		Error  *proto.ErrorObject  `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(reply, &env); err != nil {
+		t.Fatalf("unmarshal reply: %v\n%s", err, reply)
+	}
+	return env.Result, env.Error
+}
+
+func TestServer_AuthInvalidToken(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+
+	_, errObj := c.call(t, "auth", map[string]string{"token": "nope"})
+	if errObj == nil || errObj.Code != proto.ErrorAuthInvalid {
+		t.Fatalf("want AuthInvalid, got %+v", errObj)
+	}
+}
+
+func TestServer_MethodNotFound(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+
+	_, errObj := c.call(t, "fs.nope", nil)
+	if errObj == nil || errObj.Code != proto.ErrorMethodNotFound {
+		t.Fatalf("want MethodNotFound, got %+v", errObj)
+	}
+}
+
+func TestServer_AuthThenServerInfo(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+
+	// Step 1: auth with the correct token.
+	result, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)})
+	if errObj != nil {
+		t.Fatalf("auth: %+v", errObj)
+	}
+	var authOK proto.AuthResult
+	if err := json.Unmarshal(result, &authOK); err != nil {
+		t.Fatalf("unmarshal auth result: %v", err)
+	}
+	if !authOK.OK {
+		t.Error("auth should have returned ok=true")
+	}
+
+	// Step 2: server.info responds on the same session.
+	result, errObj = c.call(t, "server.info", map[string]any{})
+	if errObj != nil {
+		t.Fatalf("server.info: %+v", errObj)
+	}
+	var info proto.ServerInfo
+	if err := json.Unmarshal(result, &info); err != nil {
+		t.Fatalf("unmarshal info: %v", err)
+	}
+	if info.Version != "test" {
+		t.Errorf("Version = %q, want test", info.Version)
+	}
+	if info.ProtocolVersion != proto.ProtocolVersion {
+		t.Errorf("ProtocolVersion = %d, want %d", info.ProtocolVersion, proto.ProtocolVersion)
+	}
+	wantCaps := []string{"auth", "server.info"}
+	got := append([]string(nil), info.Capabilities...)
+	sort.Strings(got)
+	if strings.Join(got, ",") != strings.Join(wantCaps, ",") {
+		t.Errorf("capabilities = %v, want %v", got, wantCaps)
+	}
+}
+
+func TestServer_GracefulEOF(t *testing.T) {
+	ts := startTestServer(t)
+	conn, err := net.Dial("tcp", ts.addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Closing immediately should not crash the server; subsequent
+	// dials must still succeed.
+	_ = conn.Close()
+
+	c := ts.dial(t)
+	_, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)})
+	if errObj != nil {
+		t.Fatalf("auth after prior close: %+v", errObj)
+	}
+}

--- a/server/internal/server/session.go
+++ b/server/internal/server/session.go
@@ -1,0 +1,63 @@
+package server
+
+import "sync"
+
+// Session is the per-connection state used by method handlers.
+// Every accepted connection gets its own Session, so mutation of
+// `authenticated` / `subscriptions` does not need to be locked across
+// sessions. A single session can, however, race its own read loop
+// against timers / push notifications, so the exported accessors
+// take the session-local lock.
+type Session struct {
+	mu              sync.Mutex
+	authenticated   bool
+	subscriptionIDs map[string]struct{}
+}
+
+// NewSession returns a fresh, unauthenticated session.
+func NewSession() *Session {
+	return &Session{subscriptionIDs: map[string]struct{}{}}
+}
+
+// IsAuthenticated reports whether auth has been accepted on this session.
+func (s *Session) IsAuthenticated() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.authenticated
+}
+
+// MarkAuthenticated transitions the session to the authenticated state.
+// Subsequent calls are no-ops.
+func (s *Session) MarkAuthenticated() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.authenticated = true
+}
+
+// AddSubscription records that the session is watching a path.
+func (s *Session) AddSubscription(id string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.subscriptionIDs[id] = struct{}{}
+}
+
+// RemoveSubscription drops a subscription and returns whether it was
+// present (useful for `fs.unwatch` when the id is unknown).
+func (s *Session) RemoveSubscription(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.subscriptionIDs[id]
+	delete(s.subscriptionIDs, id)
+	return ok
+}
+
+// SubscriptionIDs returns a snapshot of the session's current subscriptions.
+func (s *Session) SubscriptionIDs() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, 0, len(s.subscriptionIDs))
+	for id := range s.subscriptionIDs {
+		out = append(out, id)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
First working obsidian-remote-server. Accepts connections on a \`net.Listener\`, reads length-prefixed JSON frames (LSP style), routes them through a JSON-RPC 2.0 dispatcher, and exposes two methods so a client can handshake end-to-end.

Read- and write-side \`fs.*\` handlers land in the next two PRs; this one is the plumbing.

## Transport change vs. the earlier plan
\`proto/README.md\` now documents **length-prefixed JSON over a unix socket** (SSH-forwarded TCP port) instead of the WebSocket-over-SSH plan originally sketched in Phase 5-B. The JSON-RPC envelope shape did not change, so the TS mirror didn't need to move.

Why: stdlib-only on the Go side (no third-party WebSocket dep, no go.sum entries for external packages in CI), trivially debuggable with a raw socket viewer, LSP's framing already handles multi-MB payloads cleanly. Attachment serving for \`getResourcePath\` will live on a separate forwarded HTTP port in Phase 5-F rather than multiplexing on this channel.

## Layout
\`\`\`
server/
├── cmd/obsidian-remote-server/main.go     — entry point: flags, listener, signal handling
├── internal/
│   ├── auth/
│   │   ├── token.go                       — 32-byte hex, atomic 0600 write, constant-time compare
│   │   └── token_test.go
│   ├── rpc/
│   │   ├── frame.go                       — LSP-style framing (ReadFrame / WriteFrame)
│   │   ├── dispatcher.go                  — parse + route + reply, panic recovery, notifications
│   │   ├── errors.go                      — typed ErrorObject builders
│   │   ├── frame_test.go
│   │   └── dispatcher_test.go
│   ├── server/
│   │   ├── server.go                      — accept loop, per-conn goroutine, write-mutex, context plumbing
│   │   ├── session.go                     — per-connection Session (authenticated, subscription set)
│   │   └── server_test.go                 — TCP loopback integration test
│   └── handlers/
│       ├── auth.go                        — auth handler + RequireAuth middleware
│       ├── server_info.go                 — advertises version, protocol version, sorted capabilities
│       └── *_test.go
└── Makefile / go.mod                      — unchanged from 5-A
\`\`\`

## Verification
All local, using a portable Go 1.22.10 extracted into \`~/tools/go-portable\`:
- [x] \`go vet ./...\` clean
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all 5 packages pass
    - \`internal/auth\` — token generation, constant-time compare, write/read roundtrip (0600 asserted on POSIX), overwrite, no \`.token-*\` leaks
    - \`internal/rpc\` — framing roundtrip + multi-frame + missing/invalid Content-Length + unknown headers + too-large rejection + bare-LF tolerance; dispatcher happy-path + MethodNotFound + propagated errors + panic recovery + malformed JSON + wrong version + notification + null-result + Methods enumeration
    - \`internal/handlers\` — auth match / mismatch / invalid params; \`RequireAuth\` gate; \`server.info\` echos version + sorted capabilities
    - \`internal/server\` — TCP loopback: \`auth\` with correct token → \`server.info\` returns expected shape; \`auth\` with wrong token returns \`AuthInvalid\`; \`MethodNotFound\` for unknown methods; graceful EOF
- [x] \`./bin/obsidian-remote-server.exe --version\` → \`0.0.0-dev\`
- [x] Plugin side unchanged; \`cd plugin && npm test\` still 79/79 pass

## Follow-ups
- **Phase 5-C.2**: read-side \`fs.*\` handlers (\`stat\`, \`exists\`, \`list\`, \`readText\`, \`readBinary\`) with a path-safety helper that refuses \`..\` and absolute escapes (\`PathOutsideVault\`).
- **Phase 5-C.3**: write-side \`fs.*\` handlers (\`write\`, \`writeBinary\`, \`append*\`, \`mkdir\`, \`remove\`, \`rmdir\`, \`rename\`, \`copy\`, \`trashLocal\`) with atomic tmp+rename and \`expectedMtime\` preconditions.
- **Phase 5-D**: plugin transport — \`SshTunnel\` + \`RpcClient\` that dials the SSH-forwarded local port and speaks framed JSON-RPC, backing a new \`RemoteFsClient\` interface that \`SftpDataAdapter\` will switch to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)