### PR TITLE
feat(server): read-side fs handlers (stat/exists/list/readText/readBinary)

### DIFF
--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -112,6 +112,12 @@ func run(args []string) (int, error) {
 	disp := srv.Dispatcher()
 	disp.Handle("auth", handlers.Auth(token))
 	disp.Handle("server.info", handlers.ServerInfo(disp, Version, absRoot))
+	// fs.* handlers are gated behind session auth.
+	disp.Handle("fs.stat", handlers.RequireAuth(handlers.FsStat(absRoot)))
+	disp.Handle("fs.exists", handlers.RequireAuth(handlers.FsExists(absRoot)))
+	disp.Handle("fs.list", handlers.RequireAuth(handlers.FsList(absRoot)))
+	disp.Handle("fs.readText", handlers.RequireAuth(handlers.FsReadText(absRoot)))
+	disp.Handle("fs.readBinary", handlers.RequireAuth(handlers.FsReadBinary(absRoot)))
 
 	// Wire signal-driven shutdown: closing the listener unwinds Serve.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/server/internal/handlers/common.go
+++ b/server/internal/handlers/common.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/vaultfs"
+)
+
+// decodeParams unmarshals raw into out and returns an InvalidParams
+// rpc.Error on failure. `methodName` is used to tag the error so the
+// client can correlate it with the call that failed.
+func decodeParams(methodName string, raw json.RawMessage, out interface{}) *rpc.Error {
+	if len(raw) == 0 || string(raw) == "null" {
+		// Methods with no params accept this; methods that need params
+		// will notice the zero value downstream.
+		return nil
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return rpc.ErrInvalidParams(methodName + ": " + err.Error())
+	}
+	return nil
+}
+
+// resolveOrErr wraps vaultfs.Resolve with a PathOutsideVault response.
+func resolveOrErr(vaultRoot, relative string) (string, *rpc.Error) {
+	abs, err := vaultfs.Resolve(vaultRoot, relative)
+	if err != nil {
+		return "", rpc.ErrPathOutsideVault(relative)
+	}
+	return abs, nil
+}
+
+// mapFsError maps a filesystem error to the nearest proto error code.
+// `relativePath` is echoed in the message so the client sees a vault-
+// relative path, not the absolute path on the remote.
+func mapFsError(err error, relativePath string) *rpc.Error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return rpc.ErrFileNotFound(relativePath)
+	case errors.Is(err, fs.ErrPermission):
+		return rpc.ErrPermissionDenied(relativePath)
+	case errors.Is(err, fs.ErrExist):
+		return rpc.ErrExists(relativePath)
+	case isNotDirectoryErr(err):
+		return rpc.ErrNotADirectory(relativePath)
+	case isIsDirectoryErr(err):
+		return rpc.ErrIsADirectory(relativePath)
+	}
+	return rpc.ErrInternal(err.Error())
+}
+
+// entryTypeFrom maps an os.FileInfo / fs.DirEntry type to the proto
+// EntryType string the client speaks. Symlinks are reported as
+// symlinks (not followed); the caller decides whether to stat the
+// target separately.
+func entryTypeFrom(mode os.FileMode) proto.EntryType {
+	switch {
+	case mode&os.ModeSymlink != 0:
+		return proto.EntryTypeSymlink
+	case mode.IsDir():
+		return proto.EntryTypeFolder
+	default:
+		return proto.EntryTypeFile
+	}
+}
+
+// mtimeMillis renders a file mtime as unix milliseconds, matching the
+// wire format used by proto.Stat.Mtime and proto.Entry.Mtime.
+func mtimeMillis(info os.FileInfo) int64 {
+	return info.ModTime().UnixMilli()
+}
+
+// isNotDirectoryErr / isIsDirectoryErr detect the POSIX-style
+// directory-related errors (ENOTDIR, EISDIR) across platforms. Go's
+// standard library doesn't expose these as sentinel errors, so we
+// unwrap to the syscall.Errno layer manually. On Windows these errors
+// are reported with different codes; the best-effort fallthrough is
+// harmless (mapFsError returns InternalError in that case).
+
+func isNotDirectoryErr(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ENOTDIR
+	}
+	return false
+}
+
+func isIsDirectoryErr(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.EISDIR
+	}
+	return false
+}

--- a/server/internal/handlers/fs_exists.go
+++ b/server/internal/handlers/fs_exists.go
@@ -1,0 +1,37 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsExists returns the handler for `fs.exists`. It's a thin wrapper
+// around os.Stat: a missing file yields exists=false, any other
+// stat-level failure is mapped through mapFsError so PermissionDenied
+// (etc.) still surface correctly instead of being masked as
+// exists=false.
+func FsExists(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.exists", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		if _, err := os.Stat(abs); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return proto.ExistsResult{Exists: false}, nil
+			}
+			return nil, mapFsError(err, p.Path)
+		}
+		return proto.ExistsResult{Exists: true}, nil
+	}
+}

--- a/server/internal/handlers/fs_list.go
+++ b/server/internal/handlers/fs_list.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsList returns the handler for `fs.list`.
+//
+// Implementation notes:
+//   - Non-directory targets resolve to NotADirectory so callers can
+//     distinguish "this is a file, use fs.stat" from "does not exist".
+//   - Symlinks in the listing are reported as EntryTypeSymlink; we
+//     don't follow them, matching the Node adapter's behaviour.
+//   - Per-entry Info() failures are logged into the InternalError
+//     channel but skipped from the listing so one flaky entry does
+//     not kill the whole call.
+func FsList(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.list", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+
+		// Disambiguate "target is a file" from "target does not
+		// exist" up front — os.ReadDir collapses both into a
+		// PathError that the client can't tell apart otherwise.
+		info, err := os.Stat(abs)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, rpc.ErrFileNotFound(p.Path)
+			}
+			return nil, mapFsError(err, p.Path)
+		}
+		if !info.IsDir() {
+			return nil, rpc.ErrNotADirectory(p.Path)
+		}
+
+		entries, err := os.ReadDir(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+
+		out := make([]proto.Entry, 0, len(entries))
+		for _, e := range entries {
+			einfo, err := e.Info()
+			if err != nil {
+				// Skip entries we can't stat (concurrent delete, etc.)
+				continue
+			}
+			out = append(out, proto.Entry{
+				Name:  e.Name(),
+				Type:  entryTypeFrom(e.Type()),
+				Mtime: mtimeMillis(einfo),
+				Size:  einfo.Size(),
+			})
+		}
+		return proto.ListResult{Entries: out}, nil
+	}
+}

--- a/server/internal/handlers/fs_read_binary.go
+++ b/server/internal/handlers/fs_read_binary.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsReadBinary returns the handler for `fs.readBinary`.
+//
+// Payload is standard base64 (not URL-safe) — matching what
+// encoding/base64 in Node also produces by default. Callers should
+// use fs.readText for UTF-8 plain text to avoid the +33% wire overhead.
+func FsReadBinary(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.readBinary", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		if info.IsDir() {
+			return nil, rpc.ErrIsADirectory(p.Path)
+		}
+
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		return proto.ReadBinaryResult{
+			ContentBase64: base64.StdEncoding.EncodeToString(data),
+			Mtime:         mtimeMillis(info),
+			Size:          int64(len(data)),
+		}, nil
+	}
+}

--- a/server/internal/handlers/fs_read_test.go
+++ b/server/internal/handlers/fs_read_test.go
@@ -1,0 +1,339 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+// vaultFixture returns a temp dir seeded with a small file tree and
+// the absolute paths to a couple of anchor files for assertions.
+type vaultFixture struct {
+	Root     string
+	NoteAbs  string // <root>/note.md
+	ImgAbs   string // <root>/img/logo.png
+	SubDirs  []string
+}
+
+func newVault(t *testing.T) *vaultFixture {
+	t.Helper()
+	root := t.TempDir()
+	mustMkdir := func(rel string) {
+		if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite := func(rel string, data []byte) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustMkdir("docs/sub")
+	mustMkdir("img")
+	mustMkdir("empty")
+	mustWrite("note.md", []byte("# Hello\nbody"))
+	mustWrite("docs/a.md", []byte("one"))
+	mustWrite("docs/sub/b.md", []byte("two"))
+	mustWrite("img/logo.png", []byte{0x89, 0x50, 0x4e, 0x47, 0x01, 0x02})
+	return &vaultFixture{
+		Root:    root,
+		NoteAbs: filepath.Join(root, "note.md"),
+		ImgAbs:  filepath.Join(root, "img", "logo.png"),
+		SubDirs: []string{"docs", "img", "empty"},
+	}
+}
+
+// ─── fs.stat ─────────────────────────────────────────────────────────────
+
+func TestFsStat_File(t *testing.T) {
+	v := newVault(t)
+	h := FsStat(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "note.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	got, ok := result.(proto.Stat)
+	if !ok {
+		t.Fatalf("result type = %T, want proto.Stat", result)
+	}
+	if got.Type != proto.EntryTypeFile {
+		t.Errorf("Type = %q, want file", got.Type)
+	}
+	if got.Size != int64(len("# Hello\nbody")) {
+		t.Errorf("Size = %d, want %d", got.Size, len("# Hello\nbody"))
+	}
+	if got.Mtime <= 0 {
+		t.Errorf("Mtime = %d, want positive unix ms", got.Mtime)
+	}
+	if time.UnixMilli(got.Mtime).After(time.Now().Add(time.Minute)) {
+		t.Errorf("Mtime %d is unreasonably in the future", got.Mtime)
+	}
+}
+
+func TestFsStat_Folder(t *testing.T) {
+	v := newVault(t)
+	h := FsStat(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "docs"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	got, ok := result.(proto.Stat)
+	if !ok {
+		t.Fatalf("result type = %T", result)
+	}
+	if got.Type != proto.EntryTypeFolder {
+		t.Errorf("Type = %q, want folder", got.Type)
+	}
+}
+
+func TestFsStat_MissingReturnsNull(t *testing.T) {
+	v := newVault(t)
+	h := FsStat(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "missing.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if result != nil {
+		t.Errorf("missing path should return nil result, got %+v", result)
+	}
+}
+
+func TestFsStat_PathOutsideVault(t *testing.T) {
+	v := newVault(t)
+	h := FsStat(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "../etc/passwd"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorPathOutsideVault {
+		t.Fatalf("want PathOutsideVault, got %+v", rerr)
+	}
+}
+
+// ─── fs.exists ───────────────────────────────────────────────────────────
+
+func TestFsExists_TrueForFile(t *testing.T) {
+	v := newVault(t)
+	h := FsExists(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "note.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if !result.(proto.ExistsResult).Exists {
+		t.Error("want exists=true for note.md")
+	}
+}
+
+func TestFsExists_FalseForMissing(t *testing.T) {
+	v := newVault(t)
+	h := FsExists(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "nope.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	if result.(proto.ExistsResult).Exists {
+		t.Error("want exists=false for nope.md")
+	}
+}
+
+func TestFsExists_PathOutsideVault(t *testing.T) {
+	v := newVault(t)
+	h := FsExists(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "/etc/passwd"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorPathOutsideVault {
+		t.Fatalf("want PathOutsideVault, got %+v", rerr)
+	}
+}
+
+// ─── fs.list ─────────────────────────────────────────────────────────────
+
+func TestFsList_Root(t *testing.T) {
+	v := newVault(t)
+	h := FsList(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: ""})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	list := result.(proto.ListResult)
+	names := make([]string, 0, len(list.Entries))
+	types := map[string]proto.EntryType{}
+	for _, e := range list.Entries {
+		names = append(names, e.Name)
+		types[e.Name] = e.Type
+	}
+	sort.Strings(names)
+	wantNames := []string{"docs", "empty", "img", "note.md"}
+	if len(names) != len(wantNames) {
+		t.Fatalf("names = %v, want %v", names, wantNames)
+	}
+	for i := range wantNames {
+		if names[i] != wantNames[i] {
+			t.Errorf("names[%d] = %q, want %q", i, names[i], wantNames[i])
+		}
+	}
+	if types["note.md"] != proto.EntryTypeFile {
+		t.Errorf("note.md type = %q, want file", types["note.md"])
+	}
+	if types["docs"] != proto.EntryTypeFolder {
+		t.Errorf("docs type = %q, want folder", types["docs"])
+	}
+}
+
+func TestFsList_Subdirectory(t *testing.T) {
+	v := newVault(t)
+	h := FsList(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "docs"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	list := result.(proto.ListResult)
+	got := map[string]bool{}
+	for _, e := range list.Entries {
+		got[e.Name] = true
+	}
+	if !got["a.md"] {
+		t.Error("docs should contain a.md")
+	}
+	if !got["sub"] {
+		t.Error("docs should contain sub/")
+	}
+}
+
+func TestFsList_MissingReturnsFileNotFound(t *testing.T) {
+	v := newVault(t)
+	h := FsList(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "nope"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound, got %+v", rerr)
+	}
+}
+
+func TestFsList_OnFileReturnsNotADirectory(t *testing.T) {
+	v := newVault(t)
+	h := FsList(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "note.md"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorNotADirectory {
+		t.Fatalf("want NotADirectory, got %+v", rerr)
+	}
+}
+
+// ─── fs.readText ─────────────────────────────────────────────────────────
+
+func TestFsReadText_Happy(t *testing.T) {
+	v := newVault(t)
+	h := FsReadText(v.Root)
+	raw, _ := json.Marshal(proto.ReadTextParams{Path: "note.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	got := result.(proto.ReadTextResult)
+	if got.Content != "# Hello\nbody" {
+		t.Errorf("Content = %q, want %q", got.Content, "# Hello\nbody")
+	}
+	if got.Encoding != "utf8" {
+		t.Errorf("Encoding = %q, want utf8", got.Encoding)
+	}
+	if got.Size != int64(len(got.Content)) {
+		t.Errorf("Size = %d, want %d", got.Size, len(got.Content))
+	}
+}
+
+func TestFsReadText_RejectsInvalidUTF8(t *testing.T) {
+	v := newVault(t)
+	h := FsReadText(v.Root)
+	// The seeded PNG header is not valid UTF-8.
+	raw, _ := json.Marshal(proto.ReadTextParams{Path: "img/logo.png"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams for non-UTF-8, got %+v", rerr)
+	}
+}
+
+func TestFsReadText_RejectsDirectory(t *testing.T) {
+	v := newVault(t)
+	h := FsReadText(v.Root)
+	raw, _ := json.Marshal(proto.ReadTextParams{Path: "docs"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorIsADirectory {
+		t.Fatalf("want IsADirectory, got %+v", rerr)
+	}
+}
+
+func TestFsReadText_MissingReturnsFileNotFound(t *testing.T) {
+	v := newVault(t)
+	h := FsReadText(v.Root)
+	raw, _ := json.Marshal(proto.ReadTextParams{Path: "nope.md"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound, got %+v", rerr)
+	}
+}
+
+func TestFsReadText_RejectsUnknownEncoding(t *testing.T) {
+	v := newVault(t)
+	h := FsReadText(v.Root)
+	raw, _ := json.Marshal(proto.ReadTextParams{Path: "note.md", Encoding: "shift-jis"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams for unknown encoding, got %+v", rerr)
+	}
+}
+
+// ─── fs.readBinary ───────────────────────────────────────────────────────
+
+func TestFsReadBinary_Happy(t *testing.T) {
+	v := newVault(t)
+	h := FsReadBinary(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "img/logo.png"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	got := result.(proto.ReadBinaryResult)
+	decoded, err := base64.StdEncoding.DecodeString(got.ContentBase64)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	wantBytes := []byte{0x89, 0x50, 0x4e, 0x47, 0x01, 0x02}
+	if len(decoded) != len(wantBytes) {
+		t.Fatalf("decoded len = %d, want %d", len(decoded), len(wantBytes))
+	}
+	for i := range wantBytes {
+		if decoded[i] != wantBytes[i] {
+			t.Errorf("decoded[%d] = %#x, want %#x", i, decoded[i], wantBytes[i])
+		}
+	}
+	if got.Size != int64(len(wantBytes)) {
+		t.Errorf("Size = %d, want %d", got.Size, len(wantBytes))
+	}
+}
+
+func TestFsReadBinary_RejectsDirectory(t *testing.T) {
+	v := newVault(t)
+	h := FsReadBinary(v.Root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "docs"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorIsADirectory {
+		t.Fatalf("want IsADirectory, got %+v", rerr)
+	}
+}

--- a/server/internal/handlers/fs_read_text.go
+++ b/server/internal/handlers/fs_read_text.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"unicode/utf8"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsReadText returns the handler for `fs.readText`.
+//
+// The handler reads the whole file into memory and returns it as a
+// JSON string. Invalid UTF-8 is rejected as InvalidParams so
+// attachment-like payloads don't silently turn into replacement
+// characters; clients wanting raw bytes should use fs.readBinary.
+//
+// On a directory target the handler returns IsADirectory — otherwise
+// os.ReadFile would surface a platform-specific error that the
+// client can't interpret.
+func FsReadText(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.ReadTextParams
+		if e := decodeParams("fs.readText", params, &p); e != nil {
+			return nil, e
+		}
+		if p.Encoding != "" && p.Encoding != "utf8" {
+			return nil, rpc.ErrInvalidParams("fs.readText: only utf8 encoding is supported")
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		if info.IsDir() {
+			return nil, rpc.ErrIsADirectory(p.Path)
+		}
+
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		if !utf8.Valid(data) {
+			return nil, rpc.ErrInvalidParams("fs.readText: file is not valid UTF-8; use fs.readBinary")
+		}
+
+		return proto.ReadTextResult{
+			Content:  string(data),
+			Mtime:    mtimeMillis(info),
+			Size:     int64(len(data)),
+			Encoding: "utf8",
+		}, nil
+	}
+}

--- a/server/internal/handlers/fs_stat.go
+++ b/server/internal/handlers/fs_stat.go
@@ -1,0 +1,42 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsStat returns the handler for `fs.stat`. For a missing path the
+// handler resolves to `null` (per the spec — this is the only fs.*
+// method that returns null instead of FileNotFound). Every other
+// filesystem failure is mapped to the appropriate proto error code.
+func FsStat(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.stat", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil, nil
+			}
+			return nil, mapFsError(err, p.Path)
+		}
+		return proto.Stat{
+			Type:  entryTypeFrom(info.Mode()),
+			Mtime: mtimeMillis(info),
+			Size:  info.Size(),
+			Mode:  uint32(info.Mode()),
+		}, nil
+	}
+}

--- a/server/internal/rpc/errors.go
+++ b/server/internal/rpc/errors.go
@@ -43,6 +43,38 @@ func ErrFileNotFound(p string) *Error {
 	return Err(proto.ErrorFileNotFound, "no such file: "+p, nil)
 }
 
+// ErrNotADirectory signals that the target of a dir-only op (list,
+// rmdir, …) points to a regular file.
+func ErrNotADirectory(p string) *Error {
+	return Err(proto.ErrorNotADirectory, "not a directory: "+p, nil)
+}
+
+// ErrIsADirectory signals that the target of a file-only op (read,
+// remove) points to a directory.
+func ErrIsADirectory(p string) *Error {
+	return Err(proto.ErrorIsADirectory, "is a directory: "+p, nil)
+}
+
+// ErrExists signals that a create-like op found the path already present.
+func ErrExists(p string) *Error {
+	return Err(proto.ErrorExists, "already exists: "+p, nil)
+}
+
+// ErrPermissionDenied signals that the OS refused the operation.
+func ErrPermissionDenied(p string) *Error {
+	return Err(proto.ErrorPermissionDenied, "permission denied: "+p, nil)
+}
+
+// ErrPathOutsideVault signals that the resolved path escapes the vault.
+func ErrPathOutsideVault(p string) *Error {
+	return Err(proto.ErrorPathOutsideVault, "path outside vault: "+p, nil)
+}
+
+// ErrPreconditionFailed signals that an expectedMtime did not match.
+func ErrPreconditionFailed(msg string) *Error {
+	return Err(proto.ErrorPreconditionFailed, msg, nil)
+}
+
 // encodeResult marshals a result value for WriteSuccess. Centralised
 // here so the dispatcher and tests agree on JSON shape (omit null,
 // preserve zero values, etc).

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"net"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -19,11 +21,12 @@ import (
 )
 
 // testServer spins up a listening Server on 127.0.0.1:<random>, wires
-// the auth + server.info handlers, and tears everything down on
-// Cleanup. It returns a helper that dials fresh framed connections.
+// the full handler set (matching main.go), and tears everything down
+// on Cleanup. It returns a helper that dials fresh framed connections.
 type testServer struct {
-	addr  string
-	token auth.Token
+	addr      string
+	token     auth.Token
+	vaultRoot string
 }
 
 func startTestServer(t *testing.T) *testServer {
@@ -39,14 +42,20 @@ func startTestServer(t *testing.T) *testServer {
 		t.Fatalf("generate: %v", err)
 	}
 
+	vaultRoot := t.TempDir()
 	srv := server.New(server.Options{
 		Token:     tk,
-		VaultRoot: t.TempDir(),
+		VaultRoot: vaultRoot,
 		Version:   "test",
 	})
 	disp := srv.Dispatcher()
 	disp.Handle("auth", handlers.Auth(tk))
-	disp.Handle("server.info", handlers.ServerInfo(disp, "test", srv.Options().VaultRoot))
+	disp.Handle("server.info", handlers.ServerInfo(disp, "test", vaultRoot))
+	disp.Handle("fs.stat", handlers.RequireAuth(handlers.FsStat(vaultRoot)))
+	disp.Handle("fs.exists", handlers.RequireAuth(handlers.FsExists(vaultRoot)))
+	disp.Handle("fs.list", handlers.RequireAuth(handlers.FsList(vaultRoot)))
+	disp.Handle("fs.readText", handlers.RequireAuth(handlers.FsReadText(vaultRoot)))
+	disp.Handle("fs.readBinary", handlers.RequireAuth(handlers.FsReadBinary(vaultRoot)))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -61,7 +70,7 @@ func startTestServer(t *testing.T) *testServer {
 		wg.Wait()
 	})
 
-	return &testServer{addr: listener.Addr().String(), token: tk}
+	return &testServer{addr: listener.Addr().String(), token: tk, vaultRoot: vaultRoot}
 }
 
 // client represents one JSON-RPC session over a TCP loopback.
@@ -140,6 +149,105 @@ func TestServer_MethodNotFound(t *testing.T) {
 	}
 }
 
+func TestServer_FsOpsRequireAuth(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+
+	// Pre-auth: fs.list should be rejected with AuthRequired, not
+	// silently return the vault contents.
+	_, errObj := c.call(t, "fs.list", map[string]string{"path": ""})
+	if errObj == nil || errObj.Code != proto.ErrorAuthRequired {
+		t.Fatalf("want AuthRequired before auth, got %+v", errObj)
+	}
+}
+
+func TestServer_ReadPipeline(t *testing.T) {
+	ts := startTestServer(t)
+
+	// Seed a small vault so fs.list / fs.readText have something
+	// concrete to observe.
+	mustWrite(t, filepath.Join(ts.vaultRoot, "note.md"), []byte("# hello"))
+	mustWrite(t, filepath.Join(ts.vaultRoot, "docs", "a.md"), []byte("alpha"))
+
+	c := ts.dial(t)
+
+	// Step 1: auth.
+	if _, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)}); errObj != nil {
+		t.Fatalf("auth: %+v", errObj)
+	}
+
+	// Step 2: fs.stat root.
+	result, errObj := c.call(t, "fs.stat", map[string]string{"path": ""})
+	if errObj != nil {
+		t.Fatalf("fs.stat(root): %+v", errObj)
+	}
+	var stat proto.Stat
+	if err := json.Unmarshal(result, &stat); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+	if stat.Type != proto.EntryTypeFolder {
+		t.Errorf("root stat type = %q, want folder", stat.Type)
+	}
+
+	// Step 3: fs.list root — expect our seeded file + dir.
+	result, errObj = c.call(t, "fs.list", map[string]string{"path": ""})
+	if errObj != nil {
+		t.Fatalf("fs.list: %+v", errObj)
+	}
+	var list proto.ListResult
+	if err := json.Unmarshal(result, &list); err != nil {
+		t.Fatalf("unmarshal list: %v", err)
+	}
+	names := map[string]proto.EntryType{}
+	for _, e := range list.Entries {
+		names[e.Name] = e.Type
+	}
+	if names["note.md"] != proto.EntryTypeFile {
+		t.Errorf("note.md missing or wrong type; got map = %v", names)
+	}
+	if names["docs"] != proto.EntryTypeFolder {
+		t.Errorf("docs missing or wrong type; got map = %v", names)
+	}
+
+	// Step 4: fs.readText.
+	result, errObj = c.call(t, "fs.readText", map[string]string{"path": "note.md"})
+	if errObj != nil {
+		t.Fatalf("fs.readText: %+v", errObj)
+	}
+	var readText proto.ReadTextResult
+	if err := json.Unmarshal(result, &readText); err != nil {
+		t.Fatalf("unmarshal readText: %v", err)
+	}
+	if readText.Content != "# hello" {
+		t.Errorf("content = %q, want %q", readText.Content, "# hello")
+	}
+	if readText.Encoding != "utf8" {
+		t.Errorf("encoding = %q, want utf8", readText.Encoding)
+	}
+
+	// Step 5: fs.readText on a missing file should fail cleanly.
+	_, errObj = c.call(t, "fs.readText", map[string]string{"path": "missing.md"})
+	if errObj == nil || errObj.Code != proto.ErrorFileNotFound {
+		t.Fatalf("missing read: want FileNotFound, got %+v", errObj)
+	}
+
+	// Step 6: path escape is refused with PathOutsideVault.
+	_, errObj = c.call(t, "fs.stat", map[string]string{"path": "../../etc/passwd"})
+	if errObj == nil || errObj.Code != proto.ErrorPathOutsideVault {
+		t.Fatalf("escape: want PathOutsideVault, got %+v", errObj)
+	}
+}
+
+func mustWrite(t *testing.T, abs string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(abs, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestServer_AuthThenServerInfo(t *testing.T) {
 	ts := startTestServer(t)
 	c := ts.dial(t)
@@ -172,7 +280,10 @@ func TestServer_AuthThenServerInfo(t *testing.T) {
 	if info.ProtocolVersion != proto.ProtocolVersion {
 		t.Errorf("ProtocolVersion = %d, want %d", info.ProtocolVersion, proto.ProtocolVersion)
 	}
-	wantCaps := []string{"auth", "server.info"}
+	wantCaps := []string{
+		"auth", "fs.exists", "fs.list", "fs.readBinary",
+		"fs.readText", "fs.stat", "server.info",
+	}
 	got := append([]string(nil), info.Capabilities...)
 	sort.Strings(got)
 	if strings.Join(got, ",") != strings.Join(wantCaps, ",") {

--- a/server/internal/vaultfs/path.go
+++ b/server/internal/vaultfs/path.go
@@ -1,0 +1,46 @@
+// Package vaultfs is the thin filesystem layer the daemon uses to
+// enforce "every remote operation stays inside the configured vault
+// root". Handlers call Resolve to turn a client-supplied
+// vault-relative path into an absolute OS path (or an error) and then
+// use os.* / io.* as usual.
+package vaultfs
+
+import (
+	"errors"
+	"path/filepath"
+)
+
+// ErrOutsideVault is returned by Resolve when the input escapes the
+// vault root through an absolute path, `..` component, or Windows
+// reserved device name.
+var ErrOutsideVault = errors.New("vaultfs: path escapes vault root")
+
+// Resolve returns the absolute OS path for a vault-relative input.
+//
+// Accepted shapes:
+//
+//	""     → the vault root itself
+//	"/"    → the vault root itself (convenience for clients that always prepend "/")
+//	"a.md" → <root>/a.md
+//	"docs/sub/a.md" → <root>/docs/sub/a.md (slashes may also be OS-native)
+//
+// Rejected shapes (all return ErrOutsideVault):
+//
+//	"/etc/passwd"      — absolute path
+//	"../outside"       — parent escape
+//	"docs/../../etc"   — parent escape after cleaning
+//	"NUL" on Windows   — reserved device name
+//
+// Path safety relies on Go's filepath.IsLocal (Go 1.20+), which does
+// lexical analysis only. Symlink escapes on disk are *not* caught
+// here; they're the caller's problem (currently out of scope — the
+// vault root is assumed to be a single-owner directory tree).
+func Resolve(vaultRoot, relative string) (string, error) {
+	if relative == "" || relative == "/" {
+		return vaultRoot, nil
+	}
+	if !filepath.IsLocal(filepath.FromSlash(relative)) {
+		return "", ErrOutsideVault
+	}
+	return filepath.Join(vaultRoot, filepath.FromSlash(relative)), nil
+}

--- a/server/internal/vaultfs/path_test.go
+++ b/server/internal/vaultfs/path_test.go
@@ -1,0 +1,110 @@
+package vaultfs
+
+import (
+	"errors"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestResolve_Happy(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "srv", "vault")
+
+	cases := map[string]string{
+		"":                    root,
+		"/":                   root,
+		"a.md":                filepath.Join(root, "a.md"),
+		"docs/sub/a.md":       filepath.Join(root, "docs", "sub", "a.md"),
+		// "." is valid — filepath.IsLocal accepts it.
+		".":                   root,
+		// A trailing slash is fine after Join cleans it.
+		"docs/":               filepath.Join(root, "docs"),
+	}
+	for in, want := range cases {
+		got, err := Resolve(root, in)
+		if err != nil {
+			t.Errorf("Resolve(%q): unexpected error %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("Resolve(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolve_RejectsAbsolute(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "srv", "vault")
+	inputs := []string{
+		"/etc/passwd",
+		"/tmp/evil",
+	}
+	for _, in := range inputs {
+		_, err := Resolve(root, in)
+		if !errors.Is(err, ErrOutsideVault) {
+			t.Errorf("Resolve(%q): want ErrOutsideVault, got %v", in, err)
+		}
+	}
+}
+
+func TestResolve_RejectsParentEscape(t *testing.T) {
+	root := filepath.Join(string(filepath.Separator), "srv", "vault")
+	inputs := []string{
+		"../outside",
+		"..",
+		"docs/../../etc",
+		"a/b/../../../c",
+	}
+	for _, in := range inputs {
+		_, err := Resolve(root, in)
+		if !errors.Is(err, ErrOutsideVault) {
+			t.Errorf("Resolve(%q): want ErrOutsideVault, got %v", in, err)
+		}
+	}
+}
+
+func TestResolve_AcceptsInnerDotDot(t *testing.T) {
+	// An internal ".." that doesn't escape the root should resolve to
+	// a path that's still under root. filepath.IsLocal accepts this.
+	root := filepath.Join(string(filepath.Separator), "srv", "vault")
+	got, err := Resolve(root, "docs/sub/../other.md")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(root, "docs", "other.md")
+	if got != want {
+		t.Errorf("Resolve cleaned to %q, want %q", got, want)
+	}
+}
+
+func TestResolve_RejectsWindowsReservedNames(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("reserved device names are a Windows-only concern")
+	}
+	// Only the bare reserved names are guaranteed to be rejected by
+	// filepath.IsLocal across Go versions. Windows itself also treats
+	// e.g. "aux.txt" as the AUX device, but the standard library does
+	// not consistently flag the suffixed form, so we don't assert on it.
+	root := "C:\\vault"
+	for _, in := range []string{"NUL", "CON", "PRN", "AUX", "COM1", "LPT1"} {
+		_, err := Resolve(root, in)
+		if !errors.Is(err, ErrOutsideVault) {
+			t.Errorf("Resolve(%q): want ErrOutsideVault on Windows, got %v", in, err)
+		}
+	}
+}
+
+func TestResolve_ForwardSlashesOnWindows(t *testing.T) {
+	// Protocol uses forward slashes; on Windows, Resolve must convert
+	// them to backslashes when joining.
+	if runtime.GOOS != "windows" {
+		t.Skip("path separator behaviour is Windows-specific")
+	}
+	got, err := Resolve("C:\\vault", "docs/sub/a.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "C:\\vault\\docs\\sub\\a.md"
+	if got != want {
+		t.Errorf("Resolve returned %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Five new JSON-RPC methods backed by the OS filesystem, all gated behind session auth by the \`main.go\` wiring. Every method goes through a shared vault-root-safe path resolver so \`..\`, absolute paths, and (on Windows) reserved device names are rejected before we ever touch \`os.*\`.

## New packages / files

### \`internal/vaultfs\`
\`Resolve(vaultRoot, relative) → absolute-path | ErrOutsideVault\` backed by \`filepath.IsLocal\` (Go 1.20+). Rejects absolute paths, any \`..\` component that escapes the root, and — on Windows — the reserved device names (NUL / CON / PRN / AUX / COM1 / LPT1). Forward-slash paths from the wire are converted with \`filepath.FromSlash\`, so \`docs/sub/a.md\` resolves to \`<root>\docs\sub\a.md\` on Windows. Symlink escapes on disk are explicitly out of scope for now (vault tree assumed single-owner).

### \`internal/handlers/common.go\`
- \`decodeParams\` — \`InvalidParams\` on JSON errors, tolerant of empty / null params bodies.
- \`resolveOrErr\` — \`Resolve\` + \`PathOutsideVault\`.
- \`mapFsError\` — unifies \`errors.Is\` against \`fs.ErrNotExist\` / \`fs.ErrPermission\` / \`fs.ErrExist\` and \`syscall.Errno\` \`ENOTDIR\` / \`EISDIR\` into the right proto code; falls back to \`InternalError\` with the original message.
- \`entryTypeFrom\` / \`mtimeMillis\` — small formatters shared by stat and list.

### \`internal/rpc/errors.go\` — extended
\`ErrNotADirectory\`, \`ErrIsADirectory\`, \`ErrExists\`, \`ErrPermissionDenied\`, \`ErrPathOutsideVault\`, \`ErrPreconditionFailed\`. (The last is unused by read-side but avoids a follow-up deps-only PR for the write phase.)

### Handlers
| Method          | Failure modes it raises distinctly                                         |
|-----------------|----------------------------------------------------------------------------|
| \`fs.stat\`       | \`null\` on missing (per spec), otherwise \`PathOutsideVault\` / mapped       |
| \`fs.exists\`     | \`PermissionDenied\` surfaces; missing → \`exists=false\` (no error)          |
| \`fs.list\`       | \`FileNotFound\`, \`NotADirectory\`, \`PathOutsideVault\`                      |
| \`fs.readText\`   | \`IsADirectory\`, \`InvalidParams\` on non-UTF-8 / unknown encoding           |
| \`fs.readBinary\` | \`IsADirectory\`; payload is std base64                                     |

Symlinks appear as \`EntryTypeSymlink\` in \`fs.list\` results without being followed. Per-entry \`Info()\` failures during a listing are skipped rather than killing the call.

### Wiring (\`cmd/obsidian-remote-server/main.go\`)
All five methods are registered through \`handlers.RequireAuth\` so an unauthenticated session gets \`AuthRequired\` instead of file contents.

### Tests
- \`vaultfs/path_test.go\` — happy paths, absolute rejection, parent-escape rejection (including the "cancelling" case \`docs/../../etc\`), the \`.\` shorthand, Windows-only reserved-name pass, Windows-only forward-slash normalisation.
- \`handlers/fs_read_test.go\` — 18 cases across the five methods, seeded from a small temp-vault fixture.
- \`server/server_test.go\` — extended fixture wires the full handler set; two new tests:
  - \`TestServer_FsOpsRequireAuth\` — pre-auth \`fs.list\` returns \`AuthRequired\`.
  - \`TestServer_ReadPipeline\` — \`auth → fs.stat(root) → fs.list(root) → fs.readText(note.md) → fs.readText(missing)→FileNotFound → fs.stat(../../etc/passwd)→PathOutsideVault\` on a real TCP loopback.

## Verification
Local Go 1.22.10 (portable):
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 6 packages pass (adds \`vaultfs\` on top of the five from Phase 5-C.1)
- [x] \`go build -o bin/obsidian-remote-server.exe ./cmd/obsidian-remote-server\` — 3.94 MB static binary
- [x] Plugin side untouched; \`cd plugin && npm test\` still 79/79 pass

## Follow-ups
- **Phase 5-C.3**: write-side \`fs.*\` handlers (\`write\`, \`writeBinary\`, \`append*\`, \`mkdir\`, \`remove\`, \`rmdir\`, \`rename\`, \`copy\`, \`trashLocal\`) with atomic tmp+rename and the \`expectedMtime\` precondition.
- **Phase 5-D**: plugin transport — \`SshTunnel\` + \`RpcClient\` that dials the SSH-forwarded local port and backs a new \`RemoteFsClient\` interface, behind which \`SftpDataAdapter\` gets swapped in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)