### PR TITLE
feat(server): write-side fs handlers (write / append / mkdir / rename / copy / trash)

### DIFF
--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -113,11 +113,23 @@ func run(args []string) (int, error) {
 	disp.Handle("auth", handlers.Auth(token))
 	disp.Handle("server.info", handlers.ServerInfo(disp, Version, absRoot))
 	// fs.* handlers are gated behind session auth.
+	// Read side.
 	disp.Handle("fs.stat", handlers.RequireAuth(handlers.FsStat(absRoot)))
 	disp.Handle("fs.exists", handlers.RequireAuth(handlers.FsExists(absRoot)))
 	disp.Handle("fs.list", handlers.RequireAuth(handlers.FsList(absRoot)))
 	disp.Handle("fs.readText", handlers.RequireAuth(handlers.FsReadText(absRoot)))
 	disp.Handle("fs.readBinary", handlers.RequireAuth(handlers.FsReadBinary(absRoot)))
+	// Write side.
+	disp.Handle("fs.write", handlers.RequireAuth(handlers.FsWrite(absRoot)))
+	disp.Handle("fs.writeBinary", handlers.RequireAuth(handlers.FsWriteBinary(absRoot)))
+	disp.Handle("fs.append", handlers.RequireAuth(handlers.FsAppend(absRoot)))
+	disp.Handle("fs.appendBinary", handlers.RequireAuth(handlers.FsAppendBinary(absRoot)))
+	disp.Handle("fs.mkdir", handlers.RequireAuth(handlers.FsMkdir(absRoot)))
+	disp.Handle("fs.remove", handlers.RequireAuth(handlers.FsRemove(absRoot)))
+	disp.Handle("fs.rmdir", handlers.RequireAuth(handlers.FsRmdir(absRoot)))
+	disp.Handle("fs.rename", handlers.RequireAuth(handlers.FsRename(absRoot)))
+	disp.Handle("fs.copy", handlers.RequireAuth(handlers.FsCopy(absRoot)))
+	disp.Handle("fs.trashLocal", handlers.RequireAuth(handlers.FsTrashLocal(absRoot)))
 
 	// Wire signal-driven shutdown: closing the listener unwinds Serve.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/server/internal/handlers/common.go
+++ b/server/internal/handlers/common.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
@@ -100,4 +102,75 @@ func isIsDirectoryErr(err error) bool {
 		return errno == syscall.EISDIR
 	}
 	return false
+}
+
+// writeFilePerm is the mode used for newly-written files. Matches the
+// default Obsidian produces on desktop (umask-applied 0644).
+const writeFilePerm = 0o644
+
+// atomicWriteFile writes data to abs via a sibling tmp file + rename,
+// so a crashed or partial write never leaves the destination in a
+// half-written state. Parent directories are created as needed.
+//
+// If expectedMtime is non-zero, the existing file (when present) must
+// have exactly that mtime in unix milliseconds, otherwise the function
+// returns PreconditionFailed without touching disk. A target that
+// does not exist at all is accepted unconditionally, even when
+// expectedMtime is set — this matches the Obsidian semantics of
+// "write the file, asserting it didn't change out from under me".
+//
+// The returned int64 is the post-write mtime in unix milliseconds.
+// relativePath is used solely to tag error messages with a path the
+// client recognises.
+func atomicWriteFile(abs, relativePath string, data []byte, expectedMtime int64) (int64, *rpc.Error) {
+	if expectedMtime != 0 {
+		if info, err := os.Stat(abs); err == nil {
+			got := info.ModTime().UnixMilli()
+			if got != expectedMtime {
+				return 0, rpc.ErrPreconditionFailed(
+					fmt.Sprintf("%s: expected mtime %d, found %d", relativePath, expectedMtime, got),
+				)
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return 0, mapFsError(err, relativePath)
+		}
+	}
+
+	parent := filepath.Dir(abs)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return 0, mapFsError(err, relativePath)
+	}
+
+	tmp, err := os.CreateTemp(parent, ".rsh-write-*.tmp")
+	if err != nil {
+		return 0, mapFsError(err, relativePath)
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup in every non-success path below.
+	cleanup := func() { _ = os.Remove(tmpPath) }
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return 0, mapFsError(err, relativePath)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return 0, mapFsError(err, relativePath)
+	}
+	if err := os.Chmod(tmpPath, writeFilePerm); err != nil {
+		// Non-fatal on platforms that don't fully support chmod (e.g.
+		// some Windows filesystems): keep going.
+		_ = err
+	}
+	if err := os.Rename(tmpPath, abs); err != nil {
+		cleanup()
+		return 0, mapFsError(err, relativePath)
+	}
+
+	info, err := os.Stat(abs)
+	if err != nil {
+		return 0, mapFsError(err, relativePath)
+	}
+	return info.ModTime().UnixMilli(), nil
 }

--- a/server/internal/handlers/fs_append.go
+++ b/server/internal/handlers/fs_append.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsAppend returns the handler for `fs.append`. Appends go through an
+// O_APPEND open so the OS serialises concurrent small writes for us;
+// we do NOT go through the tmp+rename dance (append is defined as
+// "add bytes to the end", not "rewrite the file atomically").
+//
+// Creating the file on demand matches Obsidian's adapter.append which
+// callers treat as "create-or-append".
+func FsAppend(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.AppendTextParams
+		if e := decodeParams("fs.append", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		mtime, e := appendToFile(abs, p.Path, []byte(p.Content))
+		if e != nil {
+			return nil, e
+		}
+		return proto.MtimeResult{Mtime: mtime}, nil
+	}
+}
+
+// appendToFile is shared by fs.append and fs.appendBinary.
+func appendToFile(abs, relativePath string, data []byte) (int64, *rpc.Error) {
+	f, err := os.OpenFile(abs, os.O_WRONLY|os.O_APPEND|os.O_CREATE, writeFilePerm)
+	if err != nil {
+		// ENOENT on the parent dir surfaces here; let the caller decide
+		// whether to create it (we don't, to keep append cheap — the
+		// client can mkdir first).
+		if errors.Is(err, fs.ErrNotExist) {
+			return 0, rpc.ErrFileNotFound(relativePath)
+		}
+		return 0, mapFsError(err, relativePath)
+	}
+	defer f.Close()
+
+	if _, err := f.Write(data); err != nil {
+		return 0, mapFsError(err, relativePath)
+	}
+	if err := f.Sync(); err != nil {
+		// Sync failures are rare but informative — they mean the OS
+		// couldn't fully flush. Surface as Internal; the bytes may or
+		// may not have landed.
+		return 0, rpc.ErrInternal("fs.append: sync: " + err.Error())
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return 0, mapFsError(err, relativePath)
+	}
+	return info.ModTime().UnixMilli(), nil
+}

--- a/server/internal/handlers/fs_append_binary.go
+++ b/server/internal/handlers/fs_append_binary.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsAppendBinary returns the handler for `fs.appendBinary`.
+// Payload is std base64; decoding failures map to InvalidParams.
+func FsAppendBinary(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.AppendBinaryParams
+		if e := decodeParams("fs.appendBinary", params, &p); e != nil {
+			return nil, e
+		}
+		data, err := base64.StdEncoding.DecodeString(p.ContentBase64)
+		if err != nil {
+			return nil, rpc.ErrInvalidParams("fs.appendBinary: base64 decode: " + err.Error())
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		mtime, e := appendToFile(abs, p.Path, data)
+		if e != nil {
+			return nil, e
+		}
+		return proto.MtimeResult{Mtime: mtime}, nil
+	}
+}

--- a/server/internal/handlers/fs_copy.go
+++ b/server/internal/handlers/fs_copy.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsCopy returns the handler for `fs.copy`. Copies are file-only
+// (source must be a regular file) and go through the same atomic
+// tmp+rename at the destination that fs.write uses, so a crash
+// midway never exposes a half-copied file.
+func FsCopy(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.CopyParams
+		if e := decodeParams("fs.copy", params, &p); e != nil {
+			return nil, e
+		}
+		srcAbs, e := resolveOrErr(vaultRoot, p.SrcPath)
+		if e != nil {
+			return nil, e
+		}
+		dstAbs, e := resolveOrErr(vaultRoot, p.DestPath)
+		if e != nil {
+			return nil, e
+		}
+
+		info, err := os.Stat(srcAbs)
+		if err != nil {
+			return nil, mapFsError(err, p.SrcPath)
+		}
+		if info.IsDir() {
+			return nil, rpc.ErrIsADirectory(p.SrcPath)
+		}
+		data, err := os.ReadFile(srcAbs)
+		if err != nil {
+			return nil, mapFsError(err, p.SrcPath)
+		}
+		mtime, cerr := atomicWriteFile(dstAbs, p.DestPath, data, 0)
+		if cerr != nil {
+			return nil, cerr
+		}
+		return proto.MtimeResult{Mtime: mtime}, nil
+	}
+}

--- a/server/internal/handlers/fs_mkdir.go
+++ b/server/internal/handlers/fs_mkdir.go
@@ -1,0 +1,50 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsMkdir returns the handler for `fs.mkdir`.
+//
+// `recursive` = true (Obsidian's default) uses os.MkdirAll, which is
+// idempotent when the target already exists as a directory. With the
+// flag false we call os.Mkdir and return Exists if the path is
+// already there as a dir (non-dir collisions bubble up as
+// PermissionDenied or Internal depending on the OS).
+func FsMkdir(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.MkdirParams
+		if e := decodeParams("fs.mkdir", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		if p.Recursive {
+			if err := os.MkdirAll(abs, 0o755); err != nil {
+				return nil, mapFsError(err, p.Path)
+			}
+		} else {
+			if err := os.Mkdir(abs, 0o755); err != nil {
+				// An existing directory is fine; a regular file at the
+				// same path is a conflict (Exists).
+				if errors.Is(err, fs.ErrExist) {
+					if info, statErr := os.Stat(abs); statErr == nil && info.IsDir() {
+						return struct{}{}, nil
+					}
+					return nil, rpc.ErrExists(p.Path)
+				}
+				return nil, mapFsError(err, p.Path)
+			}
+		}
+		return struct{}{}, nil
+	}
+}

--- a/server/internal/handlers/fs_mutate_test.go
+++ b/server/internal/handlers/fs_mutate_test.go
@@ -1,0 +1,309 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+// ─── fs.mkdir ────────────────────────────────────────────────────────────
+
+func TestFsMkdir_Recursive(t *testing.T) {
+	root := t.TempDir()
+	h := FsMkdir(root)
+	raw, _ := json.Marshal(proto.MkdirParams{Path: "a/b/c", Recursive: true})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if info, err := os.Stat(filepath.Join(root, "a", "b", "c")); err != nil || !info.IsDir() {
+		t.Errorf("expected a/b/c to exist as a directory")
+	}
+}
+
+func TestFsMkdir_RecursiveIdempotent(t *testing.T) {
+	root := t.TempDir()
+	h := FsMkdir(root)
+	raw, _ := json.Marshal(proto.MkdirParams{Path: "docs", Recursive: true})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatal(rerr)
+	}
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("second call should be a no-op, got %+v", rerr)
+	}
+}
+
+func TestFsMkdir_NonRecursiveRequiresParent(t *testing.T) {
+	root := t.TempDir()
+	h := FsMkdir(root)
+	raw, _ := json.Marshal(proto.MkdirParams{Path: "missing-parent/child"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound without recursive, got %+v", rerr)
+	}
+}
+
+func TestFsMkdir_NonRecursiveExistingDirIsIdempotent(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := FsMkdir(root)
+	raw, _ := json.Marshal(proto.MkdirParams{Path: "docs"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("mkdir on existing dir should succeed, got %+v", rerr)
+	}
+}
+
+func TestFsMkdir_NonRecursiveFileCollision(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "existing"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsMkdir(root)
+	raw, _ := json.Marshal(proto.MkdirParams{Path: "existing"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorExists {
+		t.Fatalf("want Exists when a file is in the way, got %+v", rerr)
+	}
+}
+
+// ─── fs.remove ───────────────────────────────────────────────────────────
+
+func TestFsRemove_DeletesFile(t *testing.T) {
+	root := t.TempDir()
+	p := filepath.Join(root, "doomed.md")
+	if err := os.WriteFile(p, []byte("bye"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRemove(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "doomed.md"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(p); !os.IsNotExist(err) {
+		t.Errorf("file still exists after remove")
+	}
+}
+
+func TestFsRemove_RefusesDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "docs"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRemove(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "docs"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorIsADirectory {
+		t.Fatalf("want IsADirectory, got %+v", rerr)
+	}
+}
+
+func TestFsRemove_MissingReturnsFileNotFound(t *testing.T) {
+	root := t.TempDir()
+	h := FsRemove(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "ghost.md"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound, got %+v", rerr)
+	}
+}
+
+// ─── fs.rmdir ────────────────────────────────────────────────────────────
+
+func TestFsRmdir_NonRecursiveOnNonEmptyFails(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRmdir(root)
+	raw, _ := json.Marshal(proto.RmdirParams{Path: "docs"})
+	if _, rerr := h(context.Background(), raw); rerr == nil {
+		t.Fatal("expected rmdir(non-empty, recursive=false) to fail")
+	}
+}
+
+func TestFsRmdir_RecursiveWipesTree(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "sub", "a.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRmdir(root)
+	raw, _ := json.Marshal(proto.RmdirParams{Path: "docs", Recursive: true})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs")); !os.IsNotExist(err) {
+		t.Error("docs should be gone after recursive rmdir")
+	}
+}
+
+func TestFsRmdir_RefusesVaultRoot(t *testing.T) {
+	root := t.TempDir()
+	h := FsRmdir(root)
+	raw, _ := json.Marshal(proto.RmdirParams{Path: "", Recursive: true})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams for vault-root rmdir, got %+v", rerr)
+	}
+	// Vault root must still exist.
+	if _, err := os.Stat(root); err != nil {
+		t.Errorf("vault root was touched: %v", err)
+	}
+}
+
+func TestFsRmdir_RefusesFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRmdir(root)
+	raw, _ := json.Marshal(proto.RmdirParams{Path: "a.md"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorNotADirectory {
+		t.Fatalf("want NotADirectory, got %+v", rerr)
+	}
+}
+
+// ─── fs.rename ───────────────────────────────────────────────────────────
+
+func TestFsRename_MovesFile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "old.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRename(root)
+	raw, _ := json.Marshal(proto.RenameParams{OldPath: "old.md", NewPath: "new.md"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if mt, ok := result.(proto.MtimeResult); !ok || mt.Mtime <= 0 {
+		t.Errorf("result = %+v, want positive mtime", result)
+	}
+	if _, err := os.Stat(filepath.Join(root, "old.md")); !os.IsNotExist(err) {
+		t.Error("old.md should no longer exist")
+	}
+	if _, err := os.Stat(filepath.Join(root, "new.md")); err != nil {
+		t.Errorf("new.md missing: %v", err)
+	}
+}
+
+func TestFsRename_CreatesDestinationParents(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsRename(root)
+	raw, _ := json.Marshal(proto.RenameParams{OldPath: "a.md", NewPath: "archived/2026/a.md"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "archived", "2026", "a.md")); err != nil {
+		t.Errorf("archived/2026/a.md missing: %v", err)
+	}
+}
+
+func TestFsRename_MissingSource(t *testing.T) {
+	root := t.TempDir()
+	h := FsRename(root)
+	raw, _ := json.Marshal(proto.RenameParams{OldPath: "ghost.md", NewPath: "new.md"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound, got %+v", rerr)
+	}
+}
+
+// ─── fs.copy ─────────────────────────────────────────────────────────────
+
+func TestFsCopy_DuplicatesFile(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "src.md")
+	if err := os.WriteFile(src, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsCopy(root)
+	raw, _ := json.Marshal(proto.CopyParams{SrcPath: "src.md", DestPath: "dst.md"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	dstData, _ := os.ReadFile(filepath.Join(root, "dst.md"))
+	if string(dstData) != "content" {
+		t.Errorf("dst = %q, want %q", dstData, "content")
+	}
+	srcData, _ := os.ReadFile(src)
+	if string(srcData) != "content" {
+		t.Error("source was modified by copy")
+	}
+}
+
+func TestFsCopy_RefusesDirectorySource(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	h := FsCopy(root)
+	raw, _ := json.Marshal(proto.CopyParams{SrcPath: "dir", DestPath: "dir-copy"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorIsADirectory {
+		t.Fatalf("want IsADirectory for directory source, got %+v", rerr)
+	}
+}
+
+// ─── fs.trashLocal ───────────────────────────────────────────────────────
+
+func TestFsTrashLocal_MovesUnderDotTrash(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "note.md"), []byte("bye"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsTrashLocal(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "note.md"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "note.md")); !os.IsNotExist(err) {
+		t.Error("original should be gone after trashLocal")
+	}
+	data, err := os.ReadFile(filepath.Join(root, ".trash", "note.md"))
+	if err != nil {
+		t.Fatalf(".trash/note.md missing: %v", err)
+	}
+	if string(data) != "bye" {
+		t.Errorf("trashed content = %q, want %q", data, "bye")
+	}
+}
+
+func TestFsTrashLocal_CreatesNestedTrashDirs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "docs", "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "docs", "sub", "a.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsTrashLocal(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: "docs/sub/a.md"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".trash", "docs", "sub", "a.md")); err != nil {
+		t.Errorf(".trash/docs/sub/a.md missing: %v", err)
+	}
+}
+
+func TestFsTrashLocal_RefusesVaultRoot(t *testing.T) {
+	root := t.TempDir()
+	h := FsTrashLocal(root)
+	raw, _ := json.Marshal(proto.PathOnlyParams{Path: ""})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams for vault-root trash, got %+v", rerr)
+	}
+}

--- a/server/internal/handlers/fs_remove.go
+++ b/server/internal/handlers/fs_remove.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsRemove returns the handler for `fs.remove` (file-only delete).
+// Directories are rejected with IsADirectory — callers should use
+// fs.rmdir. Missing files return FileNotFound instead of "success by
+// coincidence" so clients can tell the difference from a success.
+func FsRemove(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.remove", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		if info.IsDir() {
+			return nil, rpc.ErrIsADirectory(p.Path)
+		}
+		if err := os.Remove(abs); err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		return struct{}{}, nil
+	}
+}

--- a/server/internal/handlers/fs_rename.go
+++ b/server/internal/handlers/fs_rename.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsRename returns the handler for `fs.rename`. Both paths must live
+// inside the vault root. The destination's parent directory is
+// created as needed so the client doesn't have to fs.mkdir separately
+// for a move into an archive folder.
+func FsRename(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.RenameParams
+		if e := decodeParams("fs.rename", params, &p); e != nil {
+			return nil, e
+		}
+		oldAbs, e := resolveOrErr(vaultRoot, p.OldPath)
+		if e != nil {
+			return nil, e
+		}
+		newAbs, e := resolveOrErr(vaultRoot, p.NewPath)
+		if e != nil {
+			return nil, e
+		}
+		if err := os.MkdirAll(filepath.Dir(newAbs), 0o755); err != nil {
+			return nil, mapFsError(err, p.NewPath)
+		}
+		if err := os.Rename(oldAbs, newAbs); err != nil {
+			return nil, mapFsError(err, p.OldPath)
+		}
+		info, err := os.Stat(newAbs)
+		if err != nil {
+			return nil, mapFsError(err, p.NewPath)
+		}
+		return proto.MtimeResult{Mtime: info.ModTime().UnixMilli()}, nil
+	}
+}

--- a/server/internal/handlers/fs_rmdir.go
+++ b/server/internal/handlers/fs_rmdir.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsRmdir returns the handler for `fs.rmdir`.
+//
+// Guards:
+//   - Refuses to remove a file with NotADirectory.
+//   - Refuses to remove the vault root itself with InvalidParams —
+//     otherwise a single `fs.rmdir ""` wipes the whole vault.
+//
+// `recursive=false` uses os.Remove (which fails on non-empty dirs);
+// `recursive=true` uses os.RemoveAll.
+func FsRmdir(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.RmdirParams
+		if e := decodeParams("fs.rmdir", params, &p); e != nil {
+			return nil, e
+		}
+		if p.Path == "" || p.Path == "/" {
+			return nil, rpc.ErrInvalidParams("fs.rmdir: refusing to remove the vault root")
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		if !info.IsDir() {
+			return nil, rpc.ErrNotADirectory(p.Path)
+		}
+		if p.Recursive {
+			if err := os.RemoveAll(abs); err != nil {
+				return nil, mapFsError(err, p.Path)
+			}
+		} else {
+			if err := os.Remove(abs); err != nil {
+				return nil, mapFsError(err, p.Path)
+			}
+		}
+		return struct{}{}, nil
+	}
+}

--- a/server/internal/handlers/fs_trash_local.go
+++ b/server/internal/handlers/fs_trash_local.go
@@ -1,0 +1,53 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/vaultfs"
+)
+
+// FsTrashLocal returns the handler for `fs.trashLocal`. The target
+// is moved under `<vaultRoot>/.trash/<path>`; intermediate directories
+// are created as needed. Matches Obsidian's local-trash fallback.
+//
+// Trashing the vault root is refused because it would collapse the
+// whole tree into `.trash/.trash/…`.
+func FsTrashLocal(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.PathOnlyParams
+		if e := decodeParams("fs.trashLocal", params, &p); e != nil {
+			return nil, e
+		}
+		if p.Path == "" || p.Path == "/" {
+			return nil, rpc.ErrInvalidParams("fs.trashLocal: refusing to trash the vault root")
+		}
+		srcAbs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+
+		// Destination is <vaultRoot>/.trash/<original path>.
+		// path.Join (posix) keeps slashes in the wire-style path
+		// before we hand it back to vaultfs.Resolve for safety
+		// checking + OS-separator conversion.
+		trashRel := path.Join(".trash", p.Path)
+		dstAbs, err := vaultfs.Resolve(vaultRoot, trashRel)
+		if err != nil {
+			return nil, rpc.ErrPathOutsideVault(trashRel)
+		}
+
+		if err := os.MkdirAll(filepath.Dir(dstAbs), 0o755); err != nil {
+			return nil, mapFsError(err, trashRel)
+		}
+		if err := os.Rename(srcAbs, dstAbs); err != nil {
+			return nil, mapFsError(err, p.Path)
+		}
+		return struct{}{}, nil
+	}
+}

--- a/server/internal/handlers/fs_write.go
+++ b/server/internal/handlers/fs_write.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsWrite returns the handler for `fs.write`. Writes go through a tmp
+// file + rename so a crash midway never leaves a half-written note
+// on disk. Optional `expectedMtime` rejects the call with
+// PreconditionFailed when the remote copy has drifted; clients can
+// use this to avoid clobbering concurrent edits.
+func FsWrite(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.WriteTextParams
+		if e := decodeParams("fs.write", params, &p); e != nil {
+			return nil, e
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		mtime, e := atomicWriteFile(abs, p.Path, []byte(p.Content), p.ExpectedMtime)
+		if e != nil {
+			return nil, e
+		}
+		return proto.MtimeResult{Mtime: mtime}, nil
+	}
+}

--- a/server/internal/handlers/fs_write_binary.go
+++ b/server/internal/handlers/fs_write_binary.go
@@ -1,0 +1,38 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+)
+
+// FsWriteBinary returns the handler for `fs.writeBinary`.
+//
+// Payload is std base64 (matches what fs.readBinary emits and what
+// Node's Buffer.toString("base64") produces). Decoding errors are
+// surfaced as InvalidParams so the client doesn't end up with a
+// zero-length file when the wire was garbled.
+func FsWriteBinary(vaultRoot string) rpc.Handler {
+	return func(_ context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.WriteBinaryParams
+		if e := decodeParams("fs.writeBinary", params, &p); e != nil {
+			return nil, e
+		}
+		data, err := base64.StdEncoding.DecodeString(p.ContentBase64)
+		if err != nil {
+			return nil, rpc.ErrInvalidParams("fs.writeBinary: base64 decode: " + err.Error())
+		}
+		abs, e := resolveOrErr(vaultRoot, p.Path)
+		if e != nil {
+			return nil, e
+		}
+		mtime, e := atomicWriteFile(abs, p.Path, data, p.ExpectedMtime)
+		if e != nil {
+			return nil, e
+		}
+		return proto.MtimeResult{Mtime: mtime}, nil
+	}
+}

--- a/server/internal/handlers/fs_write_test.go
+++ b/server/internal/handlers/fs_write_test.go
@@ -1,0 +1,235 @@
+package handlers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+// writeVault is a minimal fixture for write-side tests. It just
+// returns a fresh temp dir; each test seeds whatever it needs.
+func writeVault(t *testing.T) string {
+	t.Helper()
+	return t.TempDir()
+}
+
+// ─── fs.write ────────────────────────────────────────────────────────────
+
+func TestFsWrite_CreatesFile(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "note.md", Content: "# hello"})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	got, ok := result.(proto.MtimeResult)
+	if !ok {
+		t.Fatalf("result type = %T, want MtimeResult", result)
+	}
+	if got.Mtime <= 0 {
+		t.Errorf("mtime = %d, want positive", got.Mtime)
+	}
+	data, err := os.ReadFile(filepath.Join(root, "note.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "# hello" {
+		t.Errorf("disk content = %q, want %q", data, "# hello")
+	}
+}
+
+func TestFsWrite_AutoCreatesParentDirs(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "docs/sub/a.md", Content: "x"})
+	_, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if _, err := os.Stat(filepath.Join(root, "docs", "sub", "a.md")); err != nil {
+		t.Errorf("expected docs/sub/a.md to exist: %v", err)
+	}
+}
+
+func TestFsWrite_Overwrites(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw1, _ := json.Marshal(proto.WriteTextParams{Path: "a.md", Content: "one"})
+	if _, err := h(context.Background(), raw1); err != nil {
+		t.Fatal(err)
+	}
+	raw2, _ := json.Marshal(proto.WriteTextParams{Path: "a.md", Content: "two"})
+	if _, err := h(context.Background(), raw2); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "a.md"))
+	if string(data) != "two" {
+		t.Errorf("disk = %q, want %q", data, "two")
+	}
+}
+
+func TestFsWrite_ExpectedMtimeFailsWhenDrifted(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	// Seed an existing file, then attempt a write with a bogus mtime.
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("seed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "a.md", Content: "updated", ExpectedMtime: 1})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorPreconditionFailed {
+		t.Fatalf("want PreconditionFailed, got %+v", rerr)
+	}
+	// File must be untouched.
+	data, _ := os.ReadFile(filepath.Join(root, "a.md"))
+	if string(data) != "seed" {
+		t.Errorf("file changed despite failed precondition; got %q", data)
+	}
+}
+
+func TestFsWrite_ExpectedMtimeAcceptsNewFile(t *testing.T) {
+	// expectedMtime on a non-existent target is treated as "no constraint
+	// required — there's nothing to race". This matches the TS adapter's
+	// semantics where the client assumes "I think this file is new; create
+	// it atomically".
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "new.md", Content: "fresh", ExpectedMtime: 12345})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+}
+
+func TestFsWrite_PathOutsideVault(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "../sneaky.txt", Content: "x"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorPathOutsideVault {
+		t.Fatalf("want PathOutsideVault, got %+v", rerr)
+	}
+}
+
+// ─── fs.writeBinary ──────────────────────────────────────────────────────
+
+func TestFsWriteBinary_RoundTrip(t *testing.T) {
+	root := writeVault(t)
+	h := FsWriteBinary(root)
+	bytes := []byte{0x00, 0x01, 0x02, 0xff, 0xfe}
+	raw, _ := json.Marshal(proto.WriteBinaryParams{
+		Path:          "blob.bin",
+		ContentBase64: base64.StdEncoding.EncodeToString(bytes),
+	})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	got, _ := os.ReadFile(filepath.Join(root, "blob.bin"))
+	if len(got) != len(bytes) {
+		t.Fatalf("size = %d, want %d", len(got), len(bytes))
+	}
+	for i := range bytes {
+		if got[i] != bytes[i] {
+			t.Errorf("byte[%d] = %#x, want %#x", i, got[i], bytes[i])
+		}
+	}
+}
+
+func TestFsWriteBinary_RejectsInvalidBase64(t *testing.T) {
+	root := writeVault(t)
+	h := FsWriteBinary(root)
+	raw, _ := json.Marshal(proto.WriteBinaryParams{
+		Path:          "blob.bin",
+		ContentBase64: "not-valid-base64-@@@",
+	})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorInvalidParams {
+		t.Fatalf("want InvalidParams, got %+v", rerr)
+	}
+}
+
+// ─── fs.append ───────────────────────────────────────────────────────────
+
+func TestFsAppend_ToNewFile(t *testing.T) {
+	root := writeVault(t)
+	h := FsAppend(root)
+	raw, _ := json.Marshal(proto.AppendTextParams{Path: "log.md", Content: "line 1\n"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "log.md"))
+	if string(data) != "line 1\n" {
+		t.Errorf("disk = %q, want %q", data, "line 1\n")
+	}
+}
+
+func TestFsAppend_ToExistingFile(t *testing.T) {
+	root := writeVault(t)
+	if err := os.WriteFile(filepath.Join(root, "log.md"), []byte("first\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsAppend(root)
+	raw, _ := json.Marshal(proto.AppendTextParams{Path: "log.md", Content: "second\n"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "log.md"))
+	if string(data) != "first\nsecond\n" {
+		t.Errorf("disk = %q, want %q", data, "first\nsecond\n")
+	}
+}
+
+func TestFsAppend_ParentMissingReturnsFileNotFound(t *testing.T) {
+	root := writeVault(t)
+	h := FsAppend(root)
+	raw, _ := json.Marshal(proto.AppendTextParams{Path: "nonexistent-dir/log.md", Content: "x"})
+	_, rerr := h(context.Background(), raw)
+	if rerr == nil || rerr.Code != proto.ErrorFileNotFound {
+		t.Fatalf("want FileNotFound (parent missing), got %+v", rerr)
+	}
+}
+
+// ─── fs.appendBinary ─────────────────────────────────────────────────────
+
+func TestFsAppendBinary_Concatenates(t *testing.T) {
+	root := writeVault(t)
+	if err := os.WriteFile(filepath.Join(root, "blob.bin"), []byte{0x01, 0x02}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := FsAppendBinary(root)
+	raw, _ := json.Marshal(proto.AppendBinaryParams{
+		Path:          "blob.bin",
+		ContentBase64: base64.StdEncoding.EncodeToString([]byte{0x03, 0x04}),
+	})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	data, _ := os.ReadFile(filepath.Join(root, "blob.bin"))
+	if len(data) != 4 || data[0] != 0x01 || data[1] != 0x02 || data[2] != 0x03 || data[3] != 0x04 {
+		t.Errorf("disk = %v, want [1 2 3 4]", data)
+	}
+}
+
+// A sanity check on atomicWriteFile's tmp cleanup: the temp file name
+// should never leak into the parent dir after either a successful or
+// failing write.
+func TestAtomicWriteFile_NoTmpLeftovers(t *testing.T) {
+	root := writeVault(t)
+	h := FsWrite(root)
+	raw, _ := json.Marshal(proto.WriteTextParams{Path: "docs/a.md", Content: "hi"})
+	if _, rerr := h(context.Background(), raw); rerr != nil {
+		t.Fatal(rerr)
+	}
+	entries, _ := os.ReadDir(filepath.Join(root, "docs"))
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".rsh-write-") {
+			t.Errorf("leftover temp file after successful write: %s", e.Name())
+		}
+	}
+}

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -56,6 +56,16 @@ func startTestServer(t *testing.T) *testServer {
 	disp.Handle("fs.list", handlers.RequireAuth(handlers.FsList(vaultRoot)))
 	disp.Handle("fs.readText", handlers.RequireAuth(handlers.FsReadText(vaultRoot)))
 	disp.Handle("fs.readBinary", handlers.RequireAuth(handlers.FsReadBinary(vaultRoot)))
+	disp.Handle("fs.write", handlers.RequireAuth(handlers.FsWrite(vaultRoot)))
+	disp.Handle("fs.writeBinary", handlers.RequireAuth(handlers.FsWriteBinary(vaultRoot)))
+	disp.Handle("fs.append", handlers.RequireAuth(handlers.FsAppend(vaultRoot)))
+	disp.Handle("fs.appendBinary", handlers.RequireAuth(handlers.FsAppendBinary(vaultRoot)))
+	disp.Handle("fs.mkdir", handlers.RequireAuth(handlers.FsMkdir(vaultRoot)))
+	disp.Handle("fs.remove", handlers.RequireAuth(handlers.FsRemove(vaultRoot)))
+	disp.Handle("fs.rmdir", handlers.RequireAuth(handlers.FsRmdir(vaultRoot)))
+	disp.Handle("fs.rename", handlers.RequireAuth(handlers.FsRename(vaultRoot)))
+	disp.Handle("fs.copy", handlers.RequireAuth(handlers.FsCopy(vaultRoot)))
+	disp.Handle("fs.trashLocal", handlers.RequireAuth(handlers.FsTrashLocal(vaultRoot)))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -248,6 +258,140 @@ func mustWrite(t *testing.T, abs string, data []byte) {
 	}
 }
 
+func TestServer_WritePipeline(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+
+	// Authenticate.
+	if _, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)}); errObj != nil {
+		t.Fatalf("auth: %+v", errObj)
+	}
+
+	// Step 1: fs.write creates a note (parents auto-created).
+	_, errObj := c.call(t, "fs.write", map[string]string{
+		"path":    "docs/note.md",
+		"content": "first",
+	})
+	if errObj != nil {
+		t.Fatalf("fs.write: %+v", errObj)
+	}
+	if data, err := os.ReadFile(filepath.Join(ts.vaultRoot, "docs", "note.md")); err != nil || string(data) != "first" {
+		t.Fatalf("disk after write: data=%q err=%v", data, err)
+	}
+
+	// Step 2: fs.append adds more bytes.
+	_, errObj = c.call(t, "fs.append", map[string]string{
+		"path":    "docs/note.md",
+		"content": "-second",
+	})
+	if errObj != nil {
+		t.Fatalf("fs.append: %+v", errObj)
+	}
+	data, _ := os.ReadFile(filepath.Join(ts.vaultRoot, "docs", "note.md"))
+	if string(data) != "first-second" {
+		t.Errorf("after append disk = %q, want %q", data, "first-second")
+	}
+
+	// Step 3: fs.rename into a nested directory (auto-create parent).
+	_, errObj = c.call(t, "fs.rename", map[string]string{
+		"oldPath": "docs/note.md",
+		"newPath": "archive/2026/note.md",
+	})
+	if errObj != nil {
+		t.Fatalf("fs.rename: %+v", errObj)
+	}
+	if _, err := os.Stat(filepath.Join(ts.vaultRoot, "archive", "2026", "note.md")); err != nil {
+		t.Fatalf("renamed target missing: %v", err)
+	}
+
+	// Step 4: fs.copy → fs.trashLocal on the copy.
+	_, errObj = c.call(t, "fs.copy", map[string]string{
+		"srcPath":  "archive/2026/note.md",
+		"destPath": "latest.md",
+	})
+	if errObj != nil {
+		t.Fatalf("fs.copy: %+v", errObj)
+	}
+	_, errObj = c.call(t, "fs.trashLocal", map[string]string{"path": "latest.md"})
+	if errObj != nil {
+		t.Fatalf("fs.trashLocal: %+v", errObj)
+	}
+	if _, err := os.Stat(filepath.Join(ts.vaultRoot, "latest.md")); !os.IsNotExist(err) {
+		t.Error("latest.md should be gone after trashLocal")
+	}
+	if _, err := os.Stat(filepath.Join(ts.vaultRoot, ".trash", "latest.md")); err != nil {
+		t.Errorf(".trash/latest.md missing: %v", err)
+	}
+
+	// Step 5: fs.mkdir (recursive) then fs.rmdir (recursive) round trip.
+	if _, errObj := c.call(t, "fs.mkdir", map[string]any{
+		"path": "scratch/a/b", "recursive": true,
+	}); errObj != nil {
+		t.Fatalf("fs.mkdir: %+v", errObj)
+	}
+	if _, errObj := c.call(t, "fs.rmdir", map[string]any{
+		"path": "scratch", "recursive": true,
+	}); errObj != nil {
+		t.Fatalf("fs.rmdir: %+v", errObj)
+	}
+	if _, err := os.Stat(filepath.Join(ts.vaultRoot, "scratch")); !os.IsNotExist(err) {
+		t.Error("scratch should be gone")
+	}
+
+	// Step 6: fs.remove on a file, then confirm missing.
+	mustWrite(t, filepath.Join(ts.vaultRoot, "doomed.md"), []byte("bye"))
+	if _, errObj := c.call(t, "fs.remove", map[string]string{"path": "doomed.md"}); errObj != nil {
+		t.Fatalf("fs.remove: %+v", errObj)
+	}
+	if _, err := os.Stat(filepath.Join(ts.vaultRoot, "doomed.md")); !os.IsNotExist(err) {
+		t.Error("doomed.md should be gone")
+	}
+}
+
+func TestServer_WritePreconditionGuard(t *testing.T) {
+	ts := startTestServer(t)
+	c := ts.dial(t)
+	if _, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)}); errObj != nil {
+		t.Fatalf("auth: %+v", errObj)
+	}
+
+	// Seed a file and capture its mtime.
+	mustWrite(t, filepath.Join(ts.vaultRoot, "note.md"), []byte("seed"))
+	statRes, errObj := c.call(t, "fs.stat", map[string]string{"path": "note.md"})
+	if errObj != nil {
+		t.Fatalf("fs.stat: %+v", errObj)
+	}
+	var s proto.Stat
+	if err := json.Unmarshal(statRes, &s); err != nil {
+		t.Fatalf("unmarshal stat: %v", err)
+	}
+
+	// Matching expectedMtime: write succeeds.
+	if _, errObj := c.call(t, "fs.write", map[string]any{
+		"path":          "note.md",
+		"content":       "ok",
+		"expectedMtime": s.Mtime,
+	}); errObj != nil {
+		t.Fatalf("fs.write (matching precondition): %+v", errObj)
+	}
+	if data, _ := os.ReadFile(filepath.Join(ts.vaultRoot, "note.md")); string(data) != "ok" {
+		t.Errorf("disk = %q, want %q", data, "ok")
+	}
+
+	// Mismatched expectedMtime: write rejected, disk unchanged.
+	_, errObj = c.call(t, "fs.write", map[string]any{
+		"path":          "note.md",
+		"content":       "clobber",
+		"expectedMtime": 1, // deliberately stale
+	})
+	if errObj == nil || errObj.Code != proto.ErrorPreconditionFailed {
+		t.Fatalf("want PreconditionFailed, got %+v", errObj)
+	}
+	if data, _ := os.ReadFile(filepath.Join(ts.vaultRoot, "note.md")); string(data) != "ok" {
+		t.Errorf("disk was clobbered despite precondition: %q", data)
+	}
+}
+
 func TestServer_AuthThenServerInfo(t *testing.T) {
 	ts := startTestServer(t)
 	c := ts.dial(t)
@@ -281,8 +425,14 @@ func TestServer_AuthThenServerInfo(t *testing.T) {
 		t.Errorf("ProtocolVersion = %d, want %d", info.ProtocolVersion, proto.ProtocolVersion)
 	}
 	wantCaps := []string{
-		"auth", "fs.exists", "fs.list", "fs.readBinary",
-		"fs.readText", "fs.stat", "server.info",
+		"auth",
+		"fs.append", "fs.appendBinary", "fs.copy",
+		"fs.exists", "fs.list", "fs.mkdir",
+		"fs.readBinary", "fs.readText",
+		"fs.remove", "fs.rename", "fs.rmdir",
+		"fs.stat", "fs.trashLocal",
+		"fs.write", "fs.writeBinary",
+		"server.info",
 	}
 	got := append([]string(nil), info.Capabilities...)
 	sort.Strings(got)


### PR DESCRIPTION
## Summary
Ten new JSON-RPC methods — the full write-side of the \`DataAdapter\` surface over SFTP — backed by a shared atomic-write helper and the same vault-root-safe path resolver used by the read-side handlers.

## \`atomicWriteFile\` helper (in \`common.go\`)
- Sibling tmp file + rename so a crash midway never leaves a half-written note on disk.
- Parent directories are created on demand (\`fs.write\` into \`docs/sub/new.md\` does not need a prior \`fs.mkdir\`).
- Optional \`expectedMtime\`: if the target exists and its mtime doesn't match exactly, return \`PreconditionFailed\` without touching disk. A missing target is accepted even with \`expectedMtime\` set — matches the Obsidian "write this file, I think it's new" semantics.
- \`chmod 0644\` after tmp creation; the error is non-fatal on filesystems that don't support it (some Windows volumes).
- Returns the post-write mtime in unix milliseconds.

## Handlers
| Method             | Notable semantics |
|--------------------|-------------------|
| \`fs.write\`         | Atomic text write via \`atomicWriteFile\`. |
| \`fs.writeBinary\`   | Atomic binary write (std base64 payload; decode failure → \`InvalidParams\`). |
| \`fs.append\`        | \`O_APPEND\`-based; creates on demand; missing parent is \`FileNotFound\`. |
| \`fs.appendBinary\`  | Same semantics with base64 payload. |
| \`fs.mkdir\`         | \`recursive=true\` → \`os.MkdirAll\` (idempotent); \`false\` → \`os.Mkdir\`, existing dir is no-op, file collision returns \`Exists\`. |
| \`fs.remove\`        | File-only; directory target → \`IsADirectory\`; missing → \`FileNotFound\`. |
| \`fs.rmdir\`         | \`recursive\` gates \`os.Remove\` vs \`os.RemoveAll\`; file target → \`NotADirectory\`; **refuses \`""\` / \`"/"\`** (\`InvalidParams\`) so "wipe the vault root" is not one request away. |
| \`fs.rename\`        | Creates the destination's parent dirs so the client doesn't need a separate mkdir for a move into an archive folder. |
| \`fs.copy\`          | File-only (directory source → \`IsADirectory\`); destination goes through \`atomicWriteFile\` so a mid-copy crash leaves the old dest intact. |
| \`fs.trashLocal\`    | Moves target under \`<vaultRoot>/.trash/<path>\`; creates intermediate dirs; refuses vault root. |

All ten methods are registered through \`handlers.RequireAuth\` in \`main.go\`, bringing the full registered surface to **16 methods** (auth, server.info, 14 \`fs.*\`).

## Tests
- \`handlers/fs_write_test.go\` — 11 cases covering create-then-overwrite, auto-created parent dirs, \`expectedMtime\` success / failure / new-file acceptance, \`PathOutsideVault\`, base64 round-trip, invalid base64, append-to-new, append-to-existing, missing-parent \`FileNotFound\`, binary-append concatenation, and a no-tmp-leftovers post-condition.
- \`handlers/fs_mutate_test.go\` — 17 cases across mkdir (recursive / non-recursive / idempotent / file collision), remove (file / dir-rejection / missing), rmdir (empty / non-empty / recursive / vault-root guard / file-rejection), rename (move / auto-parent / missing source), copy (duplicate / directory rejection), trashLocal (move / nested tree / vault-root guard).
- \`server/server_test.go\` — two new end-to-end tests over the TCP loopback fixture:
  - \`TestServer_WritePipeline\` exercises \`write → append → rename → copy → trashLocal → mkdir → rmdir → remove\` in one authenticated session.
  - \`TestServer_WritePreconditionGuard\` asserts that a matching \`expectedMtime\` lets the write through, and a mismatch leaves the file untouched.

## Verification
Local Go 1.22.10 (portable):
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all 6 packages pass (28 new handler cases, 2 new integration tests)
- [x] \`go build -o bin/obsidian-remote-server.exe ./cmd/obsidian-remote-server\` — 4.09 MB static binary
- [x] Plugin untouched (no TS changes); earlier 79/79 still holds

## Follow-ups
- **Phase 5-D**: plugin transport — \`SshTunnel\` + \`RpcClient\` + \`RemoteFsClient\` interface; switch \`SftpDataAdapter\` to consume it.
- **Phase 5-E**: \`fs.watch\` / \`fs.unwatch\` (server-side fsnotify, push notifications).
- **Phase 5-F**: server-side HTTP attachment endpoint for \`getResourcePath\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)