### PR TITLE
feat(plugin): RpcClient + RpcRemoteFsClient transport layer

### DIFF
--- a/plugin/src/adapter/RemoteFsClient.ts
+++ b/plugin/src/adapter/RemoteFsClient.ts
@@ -1,0 +1,48 @@
+import type { RemoteEntry, RemoteStat } from '../types';
+
+/**
+ * The surface `SftpDataAdapter` (and friends) need from whatever is
+ * talking to the remote filesystem. Two implementations live in the
+ * tree:
+ *
+ *  - `RpcRemoteFsClient` — JSON-RPC to obsidian-remote-server (the
+ *    primary / α path; added in Phase 5-D).
+ *  - `SftpRemoteFsClient` — the existing direct-SFTP client kept as
+ *    a fallback until the α path proves out (Phase 5-D.2 will wrap
+ *    the current `SftpClient`).
+ *
+ * The interface is deliberately narrow: it mirrors what the adapter
+ * actually calls, not the full SFTP command set. New methods arrive
+ * here only when the adapter needs them.
+ */
+export interface RemoteFsClient {
+  // ─── lifecycle ─────────────────────────────────────────────────────────
+  /** Active connection check. */
+  isAlive(): boolean;
+
+  /** Register a disconnection listener. The callback fires once. */
+  onClose(cb: CloseListener): () => void;
+
+  // ─── read side ────────────────────────────────────────────────────────
+  stat(path: string): Promise<RemoteStat>;
+  exists(path: string): Promise<boolean>;
+  list(path: string): Promise<RemoteEntry[]>;
+  readBinary(path: string): Promise<Buffer>;
+
+  // ─── write side ───────────────────────────────────────────────────────
+  /** Atomic on the server; clients should not wrap in their own tmp+rename. */
+  writeBinary(path: string, data: Buffer): Promise<void>;
+
+  /** Ensure a directory chain exists (idempotent). */
+  mkdirp(path: string): Promise<void>;
+
+  /** File-only remove. Directories must go through `rmdir`. */
+  remove(path: string): Promise<void>;
+
+  rmdir(path: string, recursive?: boolean): Promise<void>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  copy(srcPath: string, destPath: string): Promise<void>;
+}
+
+/** Called with `{unexpected:true}` when the connection dropped without a clean disconnect. */
+export type CloseListener = (info: { unexpected: boolean }) => void;

--- a/plugin/src/adapter/RpcRemoteFsClient.ts
+++ b/plugin/src/adapter/RpcRemoteFsClient.ts
@@ -1,0 +1,109 @@
+import type { RemoteEntry, RemoteStat } from '../types';
+import type { RpcClient } from '../transport/RpcClient';
+import type { CloseListener, RemoteFsClient } from './RemoteFsClient';
+import type { Entry, Stat } from '../proto/types';
+import { RpcError } from '../transport/RpcError';
+
+/**
+ * RpcRemoteFsClient speaks to the Go daemon (obsidian-remote-server)
+ * via a JSON-RPC client over an SSH-tunnelled socket.
+ *
+ * The adapter doesn't have to know about atomicity — the server
+ * handles `fs.write` with a tmp+rename on its side — so this class
+ * just forwards each call and re-shapes the DTO from `proto/types.ts`
+ * into the `RemoteStat` / `RemoteEntry` shapes the plugin already
+ * uses elsewhere.
+ */
+export class RpcRemoteFsClient implements RemoteFsClient {
+  constructor(private readonly rpc: RpcClient) {}
+
+  // ─── lifecycle ─────────────────────────────────────────────────────────
+
+  isAlive(): boolean {
+    return !this.rpc.isClosed();
+  }
+
+  onClose(cb: CloseListener): () => void {
+    return this.rpc.onClose((err) => cb({ unexpected: err !== undefined }));
+  }
+
+  // ─── read side ────────────────────────────────────────────────────────
+
+  async stat(path: string): Promise<RemoteStat> {
+    const s = await this.rpc.call('fs.stat', { path });
+    if (s === null) {
+      // The daemon returns null for "missing"; surface the same not-found
+      // signal clients expect from the SFTP client.
+      throw new RpcError(-32010, `no such file: ${path}`);
+    }
+    return toRemoteStat(s);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    const r = await this.rpc.call('fs.exists', { path });
+    return r.exists;
+  }
+
+  async list(path: string): Promise<RemoteEntry[]> {
+    const r = await this.rpc.call('fs.list', { path });
+    return r.entries.map(toRemoteEntry);
+  }
+
+  async readBinary(path: string): Promise<Buffer> {
+    const r = await this.rpc.call('fs.readBinary', { path });
+    return Buffer.from(r.contentBase64, 'base64');
+  }
+
+  // ─── write side ───────────────────────────────────────────────────────
+
+  async writeBinary(path: string, data: Buffer): Promise<void> {
+    await this.rpc.call('fs.writeBinary', {
+      path,
+      contentBase64: data.toString('base64'),
+    });
+  }
+
+  async mkdirp(path: string): Promise<void> {
+    await this.rpc.call('fs.mkdir', { path, recursive: true });
+  }
+
+  async remove(path: string): Promise<void> {
+    await this.rpc.call('fs.remove', { path });
+  }
+
+  async rmdir(path: string, recursive = false): Promise<void> {
+    await this.rpc.call('fs.rmdir', { path, recursive });
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    await this.rpc.call('fs.rename', { oldPath, newPath });
+  }
+
+  async copy(srcPath: string, destPath: string): Promise<void> {
+    await this.rpc.call('fs.copy', { srcPath, destPath });
+  }
+}
+
+// ─── DTO converters ──────────────────────────────────────────────────────
+
+function toRemoteStat(s: Stat): RemoteStat {
+  return {
+    isDirectory:     s.type === 'folder',
+    isFile:          s.type === 'file',
+    isSymbolicLink:  false, // fs.stat follows the link; symlink detection lives in list()
+    mtime:           s.mtime,
+    size:            s.size,
+    mode:            s.mode,
+  };
+}
+
+function toRemoteEntry(e: Entry): RemoteEntry {
+  return {
+    name:            e.name,
+    isDirectory:     e.type === 'folder',
+    isFile:          e.type === 'file',
+    isSymbolicLink:  e.type === 'symlink',
+    mtime:           e.mtime,
+    size:            e.size,
+  };
+}

--- a/plugin/src/transport/RpcClient.ts
+++ b/plugin/src/transport/RpcClient.ts
@@ -1,0 +1,173 @@
+import { FramedDuplex } from './framing';
+import { RpcError } from './RpcError';
+import type {
+  MethodName,
+  Params,
+  Result,
+  ServerNotificationMap,
+  ServerNotificationName,
+} from '../proto/types';
+
+type NotificationHandler<N extends ServerNotificationName> =
+  (params: ServerNotificationMap[N]) => void;
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  method: string;
+}
+
+/**
+ * Correlates JSON-RPC calls to the daemon over a FramedDuplex.
+ *
+ * Each `call(method, params)` writes a Request with a fresh numeric
+ * id and returns a Promise that resolves with the decoded `result`
+ * when the matching reply arrives, or rejects with an RpcError when
+ * the daemon returns an error envelope.
+ *
+ * Server-push notifications are delivered to handlers registered via
+ * `onNotification`. When the underlying stream closes, every pending
+ * call is rejected with an RpcError carrying ErrorCode.InternalError
+ * so callers don't hang forever.
+ */
+export class RpcClient {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingCall>();
+  private readonly notificationHandlers = new Map<string, Array<(params: unknown) => void>>();
+  private readonly closeHandlers: Array<(err?: Error) => void> = [];
+  private closed = false;
+
+  constructor(private readonly framed: FramedDuplex) {
+    framed.on('message', (body: Buffer) => this.handleMessage(body));
+    framed.on('close', () => this.handleClose());
+    framed.on('error', (err: Error) => this.handleClose(err));
+  }
+
+  /**
+   * Send a typed request and await its reply.
+   *
+   * Rejects with an RpcError if the daemon returned an error envelope,
+   * or if the stream closed before the reply arrived.
+   */
+  async call<M extends MethodName>(method: M, params: Params<M>): Promise<Result<M>> {
+    if (this.closed) {
+      throw new RpcError(-32603, 'RpcClient: stream is closed');
+    }
+    const id = this.nextId++;
+    const request = { jsonrpc: '2.0' as const, id, method, params };
+    const body = Buffer.from(JSON.stringify(request), 'utf8');
+
+    return new Promise<Result<M>>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        method,
+      });
+      try {
+        this.framed.writeMessage(body);
+      } catch (e) {
+        this.pending.delete(id);
+        reject(e);
+      }
+    });
+  }
+
+  /** Register a handler for a server-push method. Returns a disposer. */
+  onNotification<N extends ServerNotificationName>(
+    method: N,
+    handler: NotificationHandler<N>,
+  ): () => void {
+    const existing = this.notificationHandlers.get(method) ?? [];
+    existing.push(handler as (params: unknown) => void);
+    this.notificationHandlers.set(method, existing);
+    return () => {
+      const list = this.notificationHandlers.get(method);
+      if (!list) return;
+      const i = list.indexOf(handler as (params: unknown) => void);
+      if (i >= 0) list.splice(i, 1);
+    };
+  }
+
+  /** Called once when the stream closes, whether cleanly or with an error. */
+  onClose(handler: (err?: Error) => void): () => void {
+    this.closeHandlers.push(handler);
+    return () => {
+      const i = this.closeHandlers.indexOf(handler);
+      if (i >= 0) this.closeHandlers.splice(i, 1);
+    };
+  }
+
+  /** Close the underlying stream; pending calls reject. */
+  close(): void {
+    if (this.closed) return;
+    this.framed.close();
+  }
+
+  isClosed(): boolean {
+    return this.closed;
+  }
+
+  // ─── internals ───────────────────────────────────────────────────────────
+
+  private handleMessage(body: Buffer): void {
+    let msg: unknown;
+    try {
+      msg = JSON.parse(body.toString('utf8'));
+    } catch {
+      // A malformed server message is ignored rather than killing the
+      // session — the daemon is expected to never emit invalid JSON,
+      // and if it does, every open request eventually fails on close.
+      return;
+    }
+    if (!isEnvelope(msg)) return;
+
+    // Response (matches a call we sent).
+    if (typeof msg.id === 'number') {
+      const pending = this.pending.get(msg.id);
+      if (!pending) return;
+      this.pending.delete(msg.id);
+      if ('error' in msg && msg.error) {
+        pending.reject(new RpcError(msg.error.code, msg.error.message, msg.error.data));
+        return;
+      }
+      pending.resolve('result' in msg ? msg.result : null);
+      return;
+    }
+
+    // Notification (no id).
+    if (typeof msg.method === 'string') {
+      const list = this.notificationHandlers.get(msg.method);
+      if (!list || list.length === 0) return;
+      const params = 'params' in msg ? msg.params : undefined;
+      for (const h of [...list]) {
+        try { h(params); } catch { /* per-handler isolation */ }
+      }
+    }
+  }
+
+  private handleClose(err?: Error): void {
+    if (this.closed) return;
+    this.closed = true;
+    const reason = err ?? new RpcError(-32603, 'RpcClient: stream closed before reply');
+    for (const p of this.pending.values()) {
+      p.reject(reason);
+    }
+    this.pending.clear();
+    for (const cb of [...this.closeHandlers]) {
+      try { cb(err); } catch { /* ignore */ }
+    }
+  }
+}
+
+interface Envelope {
+  jsonrpc?: string;
+  id?: number | string | null;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+function isEnvelope(v: unknown): v is Envelope {
+  return typeof v === 'object' && v !== null;
+}

--- a/plugin/src/transport/RpcError.ts
+++ b/plugin/src/transport/RpcError.ts
@@ -1,0 +1,31 @@
+import { ErrorCode } from '../proto/types';
+
+/**
+ * RpcError is thrown from `RpcClient.call` when the daemon returned a
+ * JSON-RPC error envelope, and from the client itself when the stream
+ * closed before a call could be answered.
+ *
+ * Prefer comparing against `ErrorCode.*` values from `proto/types.ts`
+ * rather than raw numbers; the code constants are the source of truth
+ * for what the daemon emits.
+ */
+export class RpcError extends Error {
+  public readonly code: number;
+  public readonly data?: unknown;
+
+  constructor(code: number, message: string, data?: unknown) {
+    super(message);
+    this.name = 'RpcError';
+    this.code = code;
+    this.data = data;
+  }
+
+  /**
+   * Matches one of the known error codes. Handy for `switch` blocks
+   * that want to react to, e.g., `FileNotFound` without unwrapping
+   * arbitrary integers.
+   */
+  is(code: (typeof ErrorCode)[keyof typeof ErrorCode]): boolean {
+    return this.code === code;
+  }
+}

--- a/plugin/src/transport/framing.ts
+++ b/plugin/src/transport/framing.ts
@@ -1,0 +1,138 @@
+import { EventEmitter } from 'events';
+import type { Duplex } from 'stream';
+
+/**
+ * Wraps a Node Duplex (e.g., a TCP socket or the openssh_forwardOutStreamLocal
+ * stream) with LSP-style message framing:
+ *
+ *     Content-Length: <N>\r\n
+ *     \r\n
+ *     <N bytes of UTF-8 JSON body>
+ *
+ * Matches what `server/internal/rpc/frame.go` produces on the daemon side.
+ *
+ * Emits:
+ *   'message' (body: Buffer)  — one fully-assembled message
+ *   'close'                    — the underlying stream ended
+ *   'error' (err: Error)      — framing violation or stream-level error
+ */
+export class FramedDuplex extends EventEmitter {
+  /** Accumulates inbound bytes until enough have arrived to emit a message. */
+  private buffer: Buffer = Buffer.alloc(0);
+  /** Once headers are parsed, holds the declared body length until we have that many bytes. */
+  private pendingBodyLength: number | null = null;
+  private readonly maxMessageBytes: number;
+  private closed = false;
+
+  constructor(
+    private readonly stream: Duplex,
+    options: { maxMessageBytes?: number } = {},
+  ) {
+    super();
+    this.maxMessageBytes = options.maxMessageBytes ?? 16 * 1024 * 1024;
+
+    stream.on('data', (chunk: Buffer) => this.onData(chunk));
+    stream.on('end',  () => this.onEnd());
+    stream.on('close',() => this.onEnd());
+    stream.on('error', err => this.emit('error', err));
+  }
+
+  /** Write one framed message. Returns false if the downstream buffer is full (standard backpressure hint). */
+  writeMessage(body: Buffer): boolean {
+    if (this.closed) throw new Error('FramedDuplex: closed');
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii');
+    const ok1 = this.stream.write(header);
+    const ok2 = this.stream.write(body);
+    return ok1 && ok2;
+  }
+
+  /** Shut the wire down. Subsequent writeMessage calls throw. */
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    try { this.stream.end(); } catch { /* ignore */ }
+  }
+
+  // ─── parser ──────────────────────────────────────────────────────────────
+
+  private onData(chunk: Buffer): void {
+    this.buffer = this.buffer.length === 0 ? chunk : Buffer.concat([this.buffer, chunk]);
+    // Drain as many complete frames as we can; each iteration either peels one
+    // frame off the front of `buffer` or stops waiting for more bytes.
+    while (this.tryConsumeFrame()) { /* loop */ }
+  }
+
+  /** Returns true if it peeled a frame and there may be more; false to wait for more bytes. */
+  private tryConsumeFrame(): boolean {
+    if (this.pendingBodyLength === null) {
+      const bodyStart = findHeaderEnd(this.buffer);
+      if (bodyStart < 0) return false;
+      const headersText = this.buffer.subarray(0, bodyStart).toString('ascii');
+      const length = parseContentLength(headersText);
+      if (length === null) {
+        this.emit('error', new Error('FramedDuplex: missing Content-Length header'));
+        this.close();
+        return false;
+      }
+      if (length > this.maxMessageBytes) {
+        this.emit('error', new Error(`FramedDuplex: message too large (${length} > ${this.maxMessageBytes})`));
+        this.close();
+        return false;
+      }
+      this.buffer = this.buffer.subarray(bodyStart);
+      this.pendingBodyLength = length;
+    }
+
+    if (this.buffer.length < this.pendingBodyLength) return false;
+
+    const body = this.buffer.subarray(0, this.pendingBodyLength);
+    this.buffer = this.buffer.subarray(this.pendingBodyLength);
+    this.pendingBodyLength = null;
+    this.emit('message', Buffer.from(body)); // copy so later buffer shrinks don't mutate it
+    return this.buffer.length > 0;
+  }
+
+  private onEnd(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit('close');
+  }
+}
+
+/**
+ * Returns the byte index in `buf` where the body starts (one past the
+ * terminator that closes the header block), or -1 when no terminator
+ * has arrived yet. Prefers the spec-compliant `\r\n\r\n`; also accepts
+ * bare `\n\n` from lenient senders.
+ */
+function findHeaderEnd(buf: Buffer): number {
+  for (let i = 3; i < buf.length; i++) {
+    if (
+      buf[i - 3] === 0x0d && buf[i - 2] === 0x0a &&
+      buf[i - 1] === 0x0d && buf[i] === 0x0a
+    ) {
+      return i + 1;
+    }
+  }
+  for (let i = 1; i < buf.length; i++) {
+    if (buf[i - 1] === 0x0a && buf[i] === 0x0a) {
+      return i + 1;
+    }
+  }
+  return -1;
+}
+
+function parseContentLength(headers: string): number | null {
+  const lines = headers.split(/\r?\n/).filter(Boolean);
+  for (const line of lines) {
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const name = line.slice(0, colon).trim().toLowerCase();
+    const value = line.slice(colon + 1).trim();
+    if (name === 'content-length') {
+      const n = parseInt(value, 10);
+      if (Number.isFinite(n) && n >= 0) return n;
+    }
+  }
+  return null;
+}

--- a/plugin/tests/RpcClient.test.ts
+++ b/plugin/tests/RpcClient.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+import { RpcClient } from '../src/transport/RpcClient';
+import { RpcError } from '../src/transport/RpcError';
+
+/**
+ * A FramedDuplex stand-in just rich enough for RpcClient: it exposes
+ * the same events (`message`, `close`, `error`) and captures anything
+ * written via `writeMessage` so tests can assert the wire shape.
+ */
+class FakeFramed extends EventEmitter {
+  public sent: Buffer[] = [];
+  public closed = false;
+  writeMessage(body: Buffer): boolean {
+    if (this.closed) throw new Error('closed');
+    this.sent.push(body);
+    return true;
+  }
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.emit('close');
+  }
+
+  /** Drive a response back to the client; for tests only. */
+  pushMessage(envelope: unknown): void {
+    this.emit('message', Buffer.from(JSON.stringify(envelope), 'utf8'));
+  }
+}
+
+function setup() {
+  const framed = new FakeFramed();
+  const client = new RpcClient(framed as unknown as import('../src/transport/framing').FramedDuplex);
+  return { framed, client };
+}
+
+describe('RpcClient', () => {
+  it('correlates a call with its response by id', async () => {
+    const { framed, client } = setup();
+    const pending = client.call('server.info', {});
+    expect(framed.sent.length).toBe(1);
+    const req = JSON.parse(framed.sent[0].toString('utf8')) as { id: number };
+    framed.pushMessage({ jsonrpc: '2.0', id: req.id, result: { version: '1.0.0', protocolVersion: 1, capabilities: [], vaultRoot: '/v' } });
+    const result = await pending;
+    expect(result.version).toBe('1.0.0');
+  });
+
+  it('rejects with RpcError when the response is an error envelope', async () => {
+    const { framed, client } = setup();
+    const pending = client.call('fs.stat', { path: 'missing.md' });
+    const req = JSON.parse(framed.sent[0].toString('utf8')) as { id: number };
+    framed.pushMessage({ jsonrpc: '2.0', id: req.id, error: { code: -32010, message: 'no such file' } });
+
+    await expect(pending).rejects.toBeInstanceOf(RpcError);
+    try {
+      await pending;
+    } catch (e) {
+      expect((e as RpcError).code).toBe(-32010);
+      expect((e as RpcError).is(-32010 as never)).toBe(true);
+    }
+  });
+
+  it('demultiplexes concurrent calls', async () => {
+    const { framed, client } = setup();
+    const p1 = client.call('fs.stat', { path: 'a.md' });
+    const p2 = client.call('fs.stat', { path: 'b.md' });
+    expect(framed.sent.length).toBe(2);
+    const [id1, id2] = framed.sent.map(b => (JSON.parse(b.toString('utf8')) as { id: number }).id);
+    // Deliver out of order.
+    framed.pushMessage({ jsonrpc: '2.0', id: id2, result: null });
+    framed.pushMessage({ jsonrpc: '2.0', id: id1, result: { type: 'file', mtime: 1, size: 0, mode: 0 } });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r2).toBeNull();
+    expect(r1).not.toBeNull();
+  });
+
+  it('delivers notifications to registered handlers', () => {
+    const { framed, client } = setup();
+    const handler = vi.fn();
+    client.onNotification('fs.changed', handler);
+    framed.pushMessage({
+      jsonrpc: '2.0',
+      method: 'fs.changed',
+      params: { subscriptionId: 's1', path: 'a.md', event: 'modified', mtime: 99 },
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler.mock.calls[0][0]).toMatchObject({ path: 'a.md', event: 'modified' });
+  });
+
+  it('unregisters a notification handler via the returned disposer', () => {
+    const { framed, client } = setup();
+    const handler = vi.fn();
+    const off = client.onNotification('fs.changed', handler);
+    off();
+    framed.pushMessage({
+      jsonrpc: '2.0',
+      method: 'fs.changed',
+      params: { subscriptionId: 's1', path: 'a.md', event: 'modified' },
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('rejects pending calls when the stream closes', async () => {
+    const { framed, client } = setup();
+    const pending = client.call('fs.stat', { path: 'a.md' });
+    framed.close();
+    await expect(pending).rejects.toBeInstanceOf(RpcError);
+  });
+
+  it('fires onClose handlers with no error on a clean close', () => {
+    const { framed, client } = setup();
+    const cb = vi.fn();
+    client.onClose(cb);
+    framed.close();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0]).toBeUndefined();
+  });
+
+  it('fires onClose handlers with the error on an abort', () => {
+    const { framed, client } = setup();
+    const cb = vi.fn();
+    client.onClose(cb);
+    framed.emit('error', new Error('boom'));
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect((cb.mock.calls[0][0] as Error).message).toBe('boom');
+  });
+
+  it('rejects call() after close()', async () => {
+    const { client } = setup();
+    client.close();
+    await expect(client.call('server.info', {})).rejects.toBeInstanceOf(RpcError);
+  });
+
+  it('ignores malformed server responses without killing the session', async () => {
+    const { framed, client } = setup();
+    const pending = client.call('server.info', {});
+    const req = JSON.parse(framed.sent[0].toString('utf8')) as { id: number };
+
+    // Garbage message first — should be silently dropped.
+    framed.emit('message', Buffer.from('not-json-at-all', 'utf8'));
+    // Valid response afterwards — promise still resolves.
+    framed.pushMessage({ jsonrpc: '2.0', id: req.id, result: { version: '1.0.0', protocolVersion: 1, capabilities: [], vaultRoot: '' } });
+    await pending;
+  });
+});

--- a/plugin/tests/RpcRemoteFsClient.test.ts
+++ b/plugin/tests/RpcRemoteFsClient.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RpcRemoteFsClient } from '../src/adapter/RpcRemoteFsClient';
+import { RpcError } from '../src/transport/RpcError';
+import type { RpcClient } from '../src/transport/RpcClient';
+
+/**
+ * RpcRemoteFsClient is a pure delegation layer: each method forwards
+ * to a single RpcClient.call and reshapes the DTO if needed. Testing
+ * it with a mocked RpcClient confirms the per-method method name,
+ * params shape, and DTO conversion.
+ */
+function mockRpc(responders: Record<string, (params: unknown) => unknown>): RpcClient {
+  return {
+    isClosed: () => false,
+    onClose: () => () => { /* noop */ },
+    call: vi.fn(async (method: string, params: unknown) => {
+      const handler = responders[method];
+      if (!handler) throw new RpcError(-32601, `no fake for method ${method}`);
+      return handler(params);
+    }),
+  } as unknown as RpcClient;
+}
+
+describe('RpcRemoteFsClient', () => {
+  it('stat reshapes proto.Stat into RemoteStat', async () => {
+    const client = new RpcRemoteFsClient(mockRpc({
+      'fs.stat': (p) => {
+        expect(p).toEqual({ path: 'note.md' });
+        return { type: 'file', mtime: 123, size: 4, mode: 0o100644 };
+      },
+    }));
+    const s = await client.stat('note.md');
+    expect(s.isFile).toBe(true);
+    expect(s.isDirectory).toBe(false);
+    expect(s.mtime).toBe(123);
+    expect(s.size).toBe(4);
+  });
+
+  it('stat throws FileNotFound when the server returns null', async () => {
+    const client = new RpcRemoteFsClient(mockRpc({
+      'fs.stat': () => null,
+    }));
+    await expect(client.stat('gone.md')).rejects.toBeInstanceOf(RpcError);
+    try {
+      await client.stat('gone.md');
+    } catch (e) {
+      expect((e as RpcError).code).toBe(-32010);
+    }
+  });
+
+  it('exists unwraps the boolean', async () => {
+    const client = new RpcRemoteFsClient(mockRpc({
+      'fs.exists': () => ({ exists: false }),
+    }));
+    expect(await client.exists('x')).toBe(false);
+  });
+
+  it('list reshapes Entry[] into RemoteEntry[]', async () => {
+    const client = new RpcRemoteFsClient(mockRpc({
+      'fs.list': () => ({
+        entries: [
+          { name: 'a.md',   type: 'file',    mtime: 1, size: 2 },
+          { name: 'docs',   type: 'folder',  mtime: 3, size: 0 },
+          { name: 'link.md', type: 'symlink', mtime: 5, size: 0 },
+        ],
+      }),
+    }));
+    const entries = await client.list('');
+    expect(entries.length).toBe(3);
+    expect(entries[0].isFile).toBe(true);
+    expect(entries[1].isDirectory).toBe(true);
+    expect(entries[2].isSymbolicLink).toBe(true);
+  });
+
+  it('readBinary base64-decodes the server payload', async () => {
+    const client = new RpcRemoteFsClient(mockRpc({
+      'fs.readBinary': () => ({
+        contentBase64: Buffer.from([10, 20, 30]).toString('base64'),
+        mtime: 0,
+        size: 3,
+      }),
+    }));
+    const buf = await client.readBinary('x.bin');
+    expect([...buf]).toEqual([10, 20, 30]);
+  });
+
+  it('writeBinary base64-encodes the payload', async () => {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: vi.fn(async (method: string, params: unknown) => {
+        calls.push({ method, params });
+        if (method === 'fs.writeBinary') return { mtime: 1 };
+        throw new RpcError(-32601, method);
+      }),
+    } as unknown as RpcClient);
+
+    await client.writeBinary('x.bin', Buffer.from([1, 2, 3]));
+    expect(calls.length).toBe(1);
+    expect(calls[0].method).toBe('fs.writeBinary');
+    const params = calls[0].params as { path: string; contentBase64: string };
+    expect(params.path).toBe('x.bin');
+    expect(Buffer.from(params.contentBase64, 'base64').toString('hex')).toBe('010203');
+  });
+
+  it('mkdirp maps to fs.mkdir with recursive=true', async () => {
+    const spy = vi.fn(async () => ({}));
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: spy,
+    } as unknown as RpcClient);
+    await client.mkdirp('docs/sub');
+    expect(spy).toHaveBeenCalledWith('fs.mkdir', { path: 'docs/sub', recursive: true });
+  });
+
+  it('remove maps to fs.remove', async () => {
+    const spy = vi.fn(async () => ({}));
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: spy,
+    } as unknown as RpcClient);
+    await client.remove('a.md');
+    expect(spy).toHaveBeenCalledWith('fs.remove', { path: 'a.md' });
+  });
+
+  it('rmdir defaults recursive to false', async () => {
+    const spy = vi.fn(async () => ({}));
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: spy,
+    } as unknown as RpcClient);
+    await client.rmdir('empty-dir');
+    expect(spy).toHaveBeenCalledWith('fs.rmdir', { path: 'empty-dir', recursive: false });
+  });
+
+  it('rename forwards old/new paths', async () => {
+    const spy = vi.fn(async () => ({ mtime: 42 }));
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: spy,
+    } as unknown as RpcClient);
+    await client.rename('old.md', 'new.md');
+    expect(spy).toHaveBeenCalledWith('fs.rename', { oldPath: 'old.md', newPath: 'new.md' });
+  });
+
+  it('copy forwards src/dest paths', async () => {
+    const spy = vi.fn(async () => ({ mtime: 42 }));
+    const client = new RpcRemoteFsClient({
+      isClosed: () => false,
+      onClose: () => () => { /* noop */ },
+      call: spy,
+    } as unknown as RpcClient);
+    await client.copy('a.md', 'b.md');
+    expect(spy).toHaveBeenCalledWith('fs.copy', { srcPath: 'a.md', destPath: 'b.md' });
+  });
+
+  it('isAlive mirrors the RpcClient closed state', () => {
+    const fake = { isClosed: vi.fn(() => false), onClose: () => () => { /* noop */ }, call: vi.fn() };
+    const client = new RpcRemoteFsClient(fake as unknown as RpcClient);
+    expect(client.isAlive()).toBe(true);
+    fake.isClosed = vi.fn(() => true);
+    expect(client.isAlive()).toBe(false);
+  });
+});

--- a/plugin/tests/framing.test.ts
+++ b/plugin/tests/framing.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'stream';
+import { FramedDuplex } from '../src/transport/framing';
+
+/**
+ * A pair of PassThrough streams wired crossways gives us an in-process
+ * Duplex — writes to `local` read from `remote.peer`, and vice versa.
+ * Matches the semantics of a TCP socket pair with zero OS overhead.
+ */
+function duplexPair() {
+  const a = new PassThrough();
+  const b = new PassThrough();
+  // Each side's writes should appear as the other side's reads.
+  // A `PassThrough` is a single-channel stream; to get a true duplex
+  // we expose one PassThrough per direction.
+  return {
+    a: combine(a, b),
+    b: combine(b, a),
+  };
+}
+
+/** Cobbled-together Duplex: reads from `inStream`, writes to `outStream`. */
+function combine(inStream: PassThrough, outStream: PassThrough) {
+  return {
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      if (event === 'data' || event === 'end' || event === 'close' || event === 'error') {
+        inStream.on(event, listener);
+      }
+      return this;
+    },
+    write: (chunk: Buffer) => outStream.write(chunk),
+    end: () => { outStream.end(); inStream.end(); },
+  } as unknown as import('stream').Duplex;
+}
+
+function collectMessages(framed: FramedDuplex): { messages: Buffer[]; closed: boolean; errors: Error[] } {
+  const messages: Buffer[] = [];
+  const errors: Error[] = [];
+  let closed = false;
+  framed.on('message', (m: Buffer) => messages.push(m));
+  framed.on('close', () => { closed = true; });
+  framed.on('error', (e: Error) => errors.push(e));
+  return { messages, closed, errors } as { messages: Buffer[]; closed: boolean; errors: Error[] };
+}
+
+describe('FramedDuplex', () => {
+  it('round-trips a single message across a duplex pair', async () => {
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a);
+    const client = new FramedDuplex(pair.b);
+    const received: Buffer[] = [];
+    server.on('message', (m: Buffer) => received.push(m));
+
+    client.writeMessage(Buffer.from('{"hello":"world"}', 'utf8'));
+    await new Promise(r => setImmediate(r));
+
+    expect(received.length).toBe(1);
+    expect(received[0].toString('utf8')).toBe('{"hello":"world"}');
+  });
+
+  it('parses multiple back-to-back messages off the same stream', async () => {
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a);
+    const client = new FramedDuplex(pair.b);
+    const received: string[] = [];
+    server.on('message', (m: Buffer) => received.push(m.toString('utf8')));
+
+    client.writeMessage(Buffer.from('A', 'utf8'));
+    client.writeMessage(Buffer.from('BB', 'utf8'));
+    client.writeMessage(Buffer.from('CCC', 'utf8'));
+    await new Promise(r => setImmediate(r));
+
+    expect(received).toEqual(['A', 'BB', 'CCC']);
+  });
+
+  it('reassembles a message delivered in several small chunks', async () => {
+    // Mock a stream where bytes arrive one at a time to hammer the
+    // parser's "not enough bytes yet" path.
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a);
+    const received: Buffer[] = [];
+    server.on('message', (m: Buffer) => received.push(m));
+
+    const body = Buffer.from('{"a":1,"b":2}', 'utf8');
+    const wire = Buffer.concat([
+      Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'ascii'),
+      body,
+    ]);
+    // Hand-feed the server's input stream one byte at a time.
+    const rawIn = (pair.a as unknown as { peer?: never });
+    void rawIn;
+    for (const byte of wire) {
+      (pair.b as unknown as { write(b: Buffer): void }).write(Buffer.from([byte]));
+      await new Promise(r => setImmediate(r));
+    }
+    expect(received.length).toBe(1);
+    expect(received[0].equals(body)).toBe(true);
+  });
+
+  it('emits an error when Content-Length is missing', async () => {
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a);
+    const errors: Error[] = [];
+    server.on('error', (e: Error) => errors.push(e));
+    (pair.b as unknown as { write(b: Buffer): void }).write(
+      Buffer.from('X-Foo: bar\r\n\r\nhi', 'ascii'),
+    );
+    await new Promise(r => setImmediate(r));
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toMatch(/Content-Length/);
+  });
+
+  it('emits an error when the message exceeds maxMessageBytes', async () => {
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a, { maxMessageBytes: 10 });
+    const errors: Error[] = [];
+    server.on('error', (e: Error) => errors.push(e));
+    (pair.b as unknown as { write(b: Buffer): void }).write(
+      Buffer.from('Content-Length: 500\r\n\r\n', 'ascii'),
+    );
+    await new Promise(r => setImmediate(r));
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toMatch(/too large/);
+  });
+
+  it('tolerates bare-LF framing (for lenient senders)', async () => {
+    const pair = duplexPair();
+    const server = new FramedDuplex(pair.a);
+    const received: Buffer[] = [];
+    server.on('message', (m: Buffer) => received.push(m));
+    (pair.b as unknown as { write(b: Buffer): void }).write(
+      Buffer.from('Content-Length: 2\n\nok', 'ascii'),
+    );
+    await new Promise(r => setImmediate(r));
+    expect(received.length).toBe(1);
+    expect(received[0].toString('utf8')).toBe('ok');
+  });
+
+  it('close() refuses subsequent writes', () => {
+    const pair = duplexPair();
+    const client = new FramedDuplex(pair.b);
+    client.close();
+    expect(() => client.writeMessage(Buffer.from('x'))).toThrow(/closed/);
+  });
+});


### PR DESCRIPTION
## Summary
Plumbing for the daemon-backed transport that will replace \`SftpClient\` in the follow-up PR. **Nothing here is wired into the runtime yet** — every new module is tree-shaken out of the production bundle until the adapter switchover lands (bundle stays at 369 KB).

## New modules

### \`src/transport/framing.ts\`
\`FramedDuplex\` wraps any Node \`Duplex\` (TCP socket, ssh2 stream) with LSP-style framing:
\`\`\`
Content-Length: <N>\r\n
\r\n
<N bytes of JSON>
\`\`\`
Emits \`'message'\` / \`'close'\` / \`'error'\`. Bodies are copied out of the rolling buffer so later shrinks don't mutate them. Configurable \`maxMessageBytes\` (default 16 MiB); oversized payloads close the stream. Bare-LF framing is accepted for lenient senders, matching the Go daemon's parallel tolerance.

### \`src/transport/RpcError.ts\`
Typed \`Error\` carrying a numeric code, optional structured \`data\`, and \`is(ErrorCode)\` for switch blocks.

### \`src/transport/RpcClient.ts\`
- Correlates \`call(method, params)\` with its reply by numeric id; returns typed \`Result<M>\` using \`Params<M>\` / \`Result<M>\` from \`proto/types.ts\`.
- Demultiplexes concurrent in-flight calls.
- \`onNotification(method, cb)\` dispatches server push events; returns a disposer.
- Stream close rejects every pending call with an \`RpcError\` so no handler hangs when the SSH tunnel drops; \`onClose\` listeners see the underlying error when there was one.
- Malformed server messages are ignored without killing the session.

### \`src/adapter/RemoteFsClient.ts\` — interface
Narrow surface: \`isAlive\` + \`onClose\`, \`stat\` / \`exists\` / \`list\` / \`readBinary\`, \`writeBinary\` / \`mkdirp\` / \`remove\` / \`rmdir\` / \`rename\` / \`copy\`. Atomic-write and parent-dir creation are the server's responsibility under the α model, so they're not part of the interface.

### \`src/adapter/RpcRemoteFsClient.ts\` — implementation
Forwards each method to the matching daemon call, translating wire DTOs (\`proto.Stat\`, \`proto.Entry\`, base64 string) into the \`RemoteStat\` / \`RemoteEntry\` / \`Buffer\` shapes the rest of the plugin already speaks. A daemon \`fs.stat\` that returns \`null\` is re-raised as an \`RpcError\` with \`ErrorCode.FileNotFound\` so the adapter sees the same "missing" signal it used to get from ssh2.

## Tests (vitest)
| File                                   | Cases |
|----------------------------------------|-------|
| \`tests/framing.test.ts\`                | 7     |
| \`tests/RpcClient.test.ts\`              | 11    |
| \`tests/RpcRemoteFsClient.test.ts\`      | 11    |

Highlights:
- Framing: duplex-pair round trip, multi-frame pipelining, byte-at-a-time reassembly, missing / invalid Content-Length, oversized-message rejection, bare-LF tolerance, \`close()\` refuses further writes.
- RpcClient: id correlation, error envelope → \`RpcError\` with matching code, out-of-order concurrent calls, notification delivery + disposer, pending-call rejection on close, \`onClose\` handler with/without error, \`call()\` after \`close()\`, malformed payloads ignored without hanging other calls.
- RpcRemoteFsClient: DTO conversion for stat / list, base64 round trip (read + write), \`mkdirp\` → \`fs.mkdir{ recursive: true }\`, \`rmdir\` default \`recursive=false\`, \`rename\` / \`copy\` param shapes, \`isAlive\` mirrors \`RpcClient.isClosed\`, \`stat(null)\` → \`FileNotFound\`.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 108 / 108 pass (29 new)
- [x] \`cd plugin && npm run build\` — 369 KB, unchanged (transport modules not reachable until 5-D.2)

## Follow-ups
- **Phase 5-D.2**: \`SshTunnel\` (ssh2 \`openssh_forwardOutStreamLocal\` wrap) + \`SftpDataAdapter\` refactor to \`RemoteFsClient\` + runtime wiring + swap \`SftpRemoteFsClient\` wrapper for the legacy SFTP path.
- **Phase 5-E**: \`fs.watch\` / \`fs.unwatch\` + fsnotify push events. \`RpcClient.onNotification\` is already ready to receive them.
- **Phase 5-F**: server-side HTTP attachment endpoint for \`getResourcePath\`.
- **Phase 5-G**: plugin auto-deploy of the server binary over SSH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)