### PR TITLE
refactor(plugin): SftpDataAdapter talks to RemoteFsClient, not SftpClient

### DIFF
--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -1,27 +1,35 @@
 import type { DataWriteOptions, ListedFiles, Stat } from 'obsidian';
-import type { SftpClient } from '../ssh/SftpClient';
+import type { RemoteFsClient } from './RemoteFsClient';
 import type { ReadCache } from '../cache/ReadCache';
 import type { DirCache } from '../cache/DirCache';
 import { logger } from '../util/logger';
 
 /**
- * Implementation of Obsidian's `DataAdapter` over SFTP.
+ * Implementation of Obsidian's `DataAdapter` over a `RemoteFsClient`.
  *
- * The class is constructed in Phase 4-E, patched onto `app.vault.adapter`
- * in Phase 4-F, and grew its write surface (write/writeBinary/append/
- * process/mkdir/remove/rmdir/rename/copy/trashSystem/trashLocal) in
- * Phase 4-G.
+ * The client can be either the direct-SFTP path (`SftpRemoteFsClient`
+ * wrapping the existing `SftpClient`) or the α path
+ * (`RpcRemoteFsClient` talking to `obsidian-remote-server`). The
+ * adapter itself stays transport-agnostic.
  *
- * `getResourcePath` is intentionally not implemented yet; Phase 4-I will
- * add a localhost HTTP bridge for binary serving.
+ * The class is constructed in Phase 4-E, patched onto
+ * `app.vault.adapter` in Phase 4-F, and grew its write surface
+ * (write/writeBinary/append/process/mkdir/remove/rmdir/rename/copy/
+ * trashSystem/trashLocal) in Phase 4-G. Phase 5-D.2 flips the client
+ * dependency from the concrete `SftpClient` to the narrow
+ * `RemoteFsClient` interface.
  *
- * Path translation is currently a straight join of `remoteBasePath` and
- * the vault-relative `normalizedPath`. The per-client user-cache rewrite
- * (Phase 4-J0 / `PathMapper`) will be inserted at this boundary later.
+ * `getResourcePath` is intentionally not implemented yet; Phase 4-I
+ * will add a localhost HTTP bridge for binary serving.
+ *
+ * Path translation is currently a straight join of `remoteBasePath`
+ * and the vault-relative `normalizedPath`. The per-client user-cache
+ * rewrite (Phase 4-J0 / `PathMapper`) will be inserted at this
+ * boundary later.
  */
 export class SftpDataAdapter {
   constructor(
-    private client: SftpClient,
+    private client: RemoteFsClient,
     /** Normalized remote base path (no trailing slash, no leading "~/"). */
     private remoteBasePath: string,
     private readCache: ReadCache,

--- a/plugin/src/adapter/SftpRemoteFsClient.ts
+++ b/plugin/src/adapter/SftpRemoteFsClient.ts
@@ -1,0 +1,67 @@
+import type { RemoteEntry, RemoteStat } from '../types';
+import type { SftpClient } from '../ssh/SftpClient';
+import type { CloseListener, RemoteFsClient } from './RemoteFsClient';
+
+/**
+ * SftpRemoteFsClient adapts the existing `SftpClient` (a direct
+ * ssh2/SFTP speaker) to the narrower `RemoteFsClient` interface the
+ * adapter now depends on.
+ *
+ * Every method is a pass-through; the translation exists only so that
+ * `SftpDataAdapter` can be agnostic about which client
+ * (direct SFTP vs. daemon RPC) is on the other end. When the
+ * α (daemon) transport proves out end-to-end, this path can be
+ * deprecated; until then it keeps the legacy SFTP code reachable from
+ * the new plugin wiring without branching inside the adapter.
+ */
+export class SftpRemoteFsClient implements RemoteFsClient {
+  constructor(private readonly client: SftpClient) {}
+
+  isAlive(): boolean {
+    return this.client.isAlive();
+  }
+
+  onClose(cb: CloseListener): () => void {
+    return this.client.onClose(cb);
+  }
+
+  stat(path: string): Promise<RemoteStat> {
+    return this.client.stat(path);
+  }
+
+  exists(path: string): Promise<boolean> {
+    return this.client.exists(path);
+  }
+
+  list(path: string): Promise<RemoteEntry[]> {
+    return this.client.list(path);
+  }
+
+  readBinary(path: string): Promise<Buffer> {
+    return this.client.readBinary(path);
+  }
+
+  writeBinary(path: string, data: Buffer): Promise<void> {
+    return this.client.writeBinary(path, data);
+  }
+
+  mkdirp(path: string): Promise<void> {
+    return this.client.mkdirp(path);
+  }
+
+  remove(path: string): Promise<void> {
+    return this.client.remove(path);
+  }
+
+  rmdir(path: string, recursive?: boolean): Promise<void> {
+    return this.client.rmdir(path, recursive);
+  }
+
+  rename(oldPath: string, newPath: string): Promise<void> {
+    return this.client.rename(oldPath, newPath);
+  }
+
+  copy(srcPath: string, destPath: string): Promise<void> {
+    return this.client.copy(srcPath, destPath);
+  }
+}

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -10,6 +10,7 @@ import { ReadCache } from './cache/ReadCache';
 import { DirCache } from './cache/DirCache';
 import { SftpDataAdapter } from './adapter/SftpDataAdapter';
 import { AdapterPatcher } from './adapter/AdapterPatcher';
+import { SftpRemoteFsClient } from './adapter/SftpRemoteFsClient';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
 import { SettingsTab } from './settings/SettingsTab';
@@ -226,8 +227,13 @@ export default class RemoteSshPlugin extends Plugin {
     const targetAdapter = this.app.vault.adapter as unknown as object;
     this.readCache = new ReadCache();
     this.dirCache = new DirCache();
+    // Wrap the raw SftpClient in the RemoteFsClient adapter so the
+    // adapter itself stays transport-agnostic (Phase 5-D.2). The α
+    // path (RpcRemoteFsClient) will be plugged in here once
+    // SshTunnel lands.
+    const fsClient = new SftpRemoteFsClient(this.client);
     this.dataAdapter = new SftpDataAdapter(
-      this.client,
+      fsClient,
       this.activeRemoteBasePath,
       this.readCache,
       this.dirCache,

--- a/plugin/tests/SftpRemoteFsClient.test.ts
+++ b/plugin/tests/SftpRemoteFsClient.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SftpRemoteFsClient } from '../src/adapter/SftpRemoteFsClient';
+import type { SftpClient } from '../src/ssh/SftpClient';
+import type { RemoteEntry, RemoteStat } from '../src/types';
+
+/**
+ * SftpRemoteFsClient is a pure delegation layer — every method forwards
+ * to the matching SftpClient method, no transformation. The tests just
+ * confirm each method name is wired through so a future rename on
+ * either side is noticed immediately.
+ */
+function mockSftp(): { client: SftpClient; calls: Record<string, unknown[]> } {
+  const calls: Record<string, unknown[]> = {};
+  const record = (name: string) => (...args: unknown[]): Promise<unknown> => {
+    calls[name] = args;
+    return Promise.resolve(undefined);
+  };
+  const client: Partial<SftpClient> = {
+    isAlive: vi.fn(() => true),
+    onClose: vi.fn(() => () => { /* disposer */ }),
+    stat: record('stat') as SftpClient['stat'],
+    exists: record('exists') as SftpClient['exists'],
+    list: record('list') as SftpClient['list'],
+    readBinary: record('readBinary') as SftpClient['readBinary'],
+    writeBinary: record('writeBinary') as SftpClient['writeBinary'],
+    mkdirp: record('mkdirp') as SftpClient['mkdirp'],
+    remove: record('remove') as SftpClient['remove'],
+    rmdir: record('rmdir') as SftpClient['rmdir'],
+    rename: record('rename') as SftpClient['rename'],
+    copy: record('copy') as SftpClient['copy'],
+  };
+  return { client: client as SftpClient, calls };
+}
+
+describe('SftpRemoteFsClient', () => {
+  it('forwards lifecycle methods', () => {
+    const { client } = mockSftp();
+    const wrap = new SftpRemoteFsClient(client);
+    expect(wrap.isAlive()).toBe(true);
+    const disposer = wrap.onClose(() => { /* noop */ });
+    expect(typeof disposer).toBe('function');
+    expect((client.isAlive as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+    expect((client.onClose as unknown as { mock: { calls: unknown[] } }).mock.calls.length).toBe(1);
+  });
+
+  it('forwards read-side methods with the same argument', async () => {
+    const { client, calls } = mockSftp();
+    // Give each return value a plausible shape so TS narrowing works downstream.
+    client.stat = vi.fn(async (_: string): Promise<RemoteStat> => ({
+      isDirectory: false, isFile: true, isSymbolicLink: false,
+      mtime: 1, size: 0, mode: 0,
+    }));
+    client.list = vi.fn(async (_: string): Promise<RemoteEntry[]> => []);
+    client.readBinary = vi.fn(async (_: string) => Buffer.alloc(0));
+    client.exists = vi.fn(async (_: string) => true);
+
+    const wrap = new SftpRemoteFsClient(client);
+    await wrap.stat('note.md');
+    await wrap.exists('note.md');
+    await wrap.list('docs');
+    await wrap.readBinary('img.png');
+
+    expect((client.stat as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]).toEqual(['note.md']);
+    expect((client.exists as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]).toEqual(['note.md']);
+    expect((client.list as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]).toEqual(['docs']);
+    expect((client.readBinary as unknown as { mock: { calls: unknown[][] } }).mock.calls[0]).toEqual(['img.png']);
+    void calls;
+  });
+
+  it('forwards write-side methods with the same arguments', async () => {
+    const { client, calls } = mockSftp();
+    const wrap = new SftpRemoteFsClient(client);
+    const buf = Buffer.from([1, 2, 3]);
+
+    await wrap.writeBinary('a.bin', buf);
+    await wrap.mkdirp('docs/sub');
+    await wrap.remove('trash.md');
+    await wrap.rmdir('empty-dir', true);
+    await wrap.rename('old.md', 'new.md');
+    await wrap.copy('src.md', 'dst.md');
+
+    expect(calls.writeBinary).toEqual(['a.bin', buf]);
+    expect(calls.mkdirp).toEqual(['docs/sub']);
+    expect(calls.remove).toEqual(['trash.md']);
+    expect(calls.rmdir).toEqual(['empty-dir', true]);
+    expect(calls.rename).toEqual(['old.md', 'new.md']);
+    expect(calls.copy).toEqual(['src.md', 'dst.md']);
+  });
+
+  it('rmdir defaults recursive to undefined when caller omits it', async () => {
+    const { client, calls } = mockSftp();
+    const wrap = new SftpRemoteFsClient(client);
+    await wrap.rmdir('empty-dir');
+    expect(calls.rmdir).toEqual(['empty-dir', undefined]);
+  });
+});


### PR DESCRIPTION
## Summary
Flips the adapter's transport dependency from the concrete \`SftpClient\` to the narrow \`RemoteFsClient\` interface introduced in #31. The legacy SFTP path continues to work end-to-end via a thin \`SftpRemoteFsClient\` wrapper; **no behaviour change**.

## What moves

Before:
\`\`\`
ssh2 Client → SftpClient ─────────→ SftpDataAdapter
\`\`\`

After:
\`\`\`
ssh2 Client → SftpClient → SftpRemoteFsClient → SftpDataAdapter
\`\`\`

When the α path lands, the only change in the slot is:
\`\`\`
                   RpcClient → RpcRemoteFsClient → SftpDataAdapter
\`\`\`

The adapter itself stays out of the swap. The decision of whether to go via direct SFTP or the daemon RPC moves into \`main.ts\` (future PR).

## Changes
- \`plugin/src/adapter/SftpRemoteFsClient.ts\` (new) — pure pass-through wrapper. Every method is a single-line forward; no translation.
- \`plugin/src/adapter/SftpDataAdapter.ts\` — \`client\` field typed as \`RemoteFsClient\` instead of \`SftpClient\`. The class body was already calling only methods present on the interface, so no logic changed.
- \`plugin/src/main.ts\` — wraps the plugin's \`SftpClient\` inside \`SftpRemoteFsClient\` at the single adapter-construction site (\`debugPatchAdapter\`).
- \`plugin/tests/SftpRemoteFsClient.test.ts\` — 4 cases confirming each method name forwards through, so a rename on either side of the wrapper is noticed immediately.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 112 / 112 pass (4 new)
- [x] \`cd plugin && npm run build:install\` — 370 KB (+550 bytes over #31, SftpRemoteFsClient is now reachable from the runtime)

## Follow-up
**Phase 5-D.3**: \`SshTunnel\` (\`ssh2.openssh_forwardOutStreamLocal\` wrap) + a debug command that opens the full RPC stack against a manually-started daemon on Panza, so the α path gets its first live round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)