### PR TITLE
feat(plugin): SSH-tunnelled RPC handshake + debug command

### DIFF
--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -11,6 +11,8 @@ import { DirCache } from './cache/DirCache';
 import { SftpDataAdapter } from './adapter/SftpDataAdapter';
 import { AdapterPatcher } from './adapter/AdapterPatcher';
 import { SftpRemoteFsClient } from './adapter/SftpRemoteFsClient';
+import { RpcRemoteFsClient } from './adapter/RpcRemoteFsClient';
+import { establishRpcConnection } from './transport/RpcConnection';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
 import { SettingsTab } from './settings/SettingsTab';
@@ -95,6 +97,12 @@ export default class RemoteSshPlugin extends Plugin {
       id: 'debug-list-root',
       name: 'Debug: list vault root via current adapter',
       callback: () => this.debugListRoot(),
+    });
+
+    this.addCommand({
+      id: 'debug-test-rpc-tunnel',
+      name: 'Debug: test RPC tunnel against obsidian-remote-server',
+      callback: () => this.debugTestRpcTunnel(),
     });
   }
 
@@ -289,6 +297,67 @@ export default class RemoteSshPlugin extends Plugin {
     } catch (e) {
       logger.error(`debugListRoot failed: ${(e as Error).message}`);
       new Notice(`debugListRoot failed: ${(e as Error).message}`);
+    }
+  }
+
+  /**
+   * Round-trips a JSON-RPC session against `obsidian-remote-server` running
+   * on the remote: reads the daemon's token via SFTP, opens a Duplex through
+   * the same SSH connection, runs the framed `auth` + `server.info`
+   * handshake, then lists the configured remote vault root via the new
+   * `RpcRemoteFsClient`. Logs every step so the daemon and plugin can be
+   * debugged together from `console.log`.
+   *
+   * Pre-requisites that the user has to set up by hand for now (auto-deploy
+   * lands in a later phase): start `obsidian-remote-server --vault-root=…`
+   * on the remote, then fill in `rpcSocketPath` and (optionally)
+   * `rpcTokenPath` on the active profile.
+   */
+  private async debugTestRpcTunnel(): Promise<void> {
+    if (this.state !== SyncState.CONNECTED || !this.client.isAlive()) {
+      new Notice('Remote SSH: connect first (the RPC tunnel rides the SFTP session)');
+      return;
+    }
+    const activeId = this.settings.activeProfileId;
+    const profile = this.settings.profiles.find(p => p.id === activeId);
+    if (!profile) {
+      new Notice('Remote SSH: no active profile');
+      return;
+    }
+    const socketPath = profile.rpcSocketPath?.trim();
+    if (!socketPath) {
+      new Notice('Remote SSH: profile.rpcSocketPath is empty (set it in Settings)');
+      return;
+    }
+    const tokenPath = profile.rpcTokenPath?.trim() || '.obsidian-remote/token';
+
+    logger.info(`debugTestRpcTunnel: token <- ${tokenPath}, socket -> ${socketPath}`);
+    let connection: Awaited<ReturnType<typeof establishRpcConnection>> | null = null;
+    try {
+      const tokenBuf = await this.client.readRemoteFile(tokenPath);
+      const token = tokenBuf.toString('utf8').trim();
+      if (!token) throw new Error(`token file at ${tokenPath} is empty`);
+
+      const stream = await this.client.openUnixStream(socketPath);
+      connection = await establishRpcConnection({ stream, token });
+
+      const fs = new RpcRemoteFsClient(connection.rpc);
+      const effectiveRoot = this.activeRemoteBasePath ?? '';
+      const entries = await fs.list(effectiveRoot);
+      logger.info(`debugTestRpcTunnel: list("${effectiveRoot}") returned ${entries.length} entries`);
+      for (const e of entries.slice(0, 5)) {
+        logger.info(`  - ${e.name} (${e.isDirectory ? 'dir' : 'file'}, ${e.size}B, mtime ${e.mtime})`);
+      }
+      new Notice(
+        `RPC OK: daemon ${connection.info.version}, ${entries.length} entries at "${effectiveRoot}" ` +
+        `(see console.log)`,
+      );
+    } catch (e) {
+      const msg = (e as Error).message;
+      logger.error(`debugTestRpcTunnel failed: ${msg}`);
+      new Notice(`RPC test failed: ${msg}`);
+    } finally {
+      try { connection?.close(); } catch { /* ignore */ }
     }
   }
 

--- a/plugin/src/settings/ProfileForm.ts
+++ b/plugin/src/settings/ProfileForm.ts
@@ -92,6 +92,28 @@ export class ProfileForm extends Modal {
       .addText(t => t.setPlaceholder('/home/user/vault').setValue(this.profile.remotePath)
         .onChange(v => { this.profile.remotePath = v; }));
 
+    contentEl.createEl('h3', { text: 'Remote daemon (experimental)' });
+    contentEl.createEl('p', {
+      cls: 'setting-item-description',
+      text:
+        'Optional: when obsidian-remote-server is running on the remote, fill these in to enable ' +
+        'the "Debug: test RPC tunnel" command. Auto-deploy of the binary lands in a later phase.',
+    });
+
+    new Setting(contentEl)
+      .setName('Daemon socket path')
+      .setDesc('e.g. .obsidian-remote/server.sock (home-relative is fine)')
+      .addText(t => t.setPlaceholder('.obsidian-remote/server.sock')
+        .setValue(this.profile.rpcSocketPath ?? '')
+        .onChange(v => { this.profile.rpcSocketPath = v.trim() || undefined; }));
+
+    new Setting(contentEl)
+      .setName('Daemon token path')
+      .setDesc('Default: .obsidian-remote/token (home-relative)')
+      .addText(t => t.setPlaceholder('.obsidian-remote/token')
+        .setValue(this.profile.rpcTokenPath ?? '')
+        .onChange(v => { this.profile.rpcTokenPath = v.trim() || undefined; }));
+
     const footer = contentEl.createDiv('conflict-footer');
     footer.createEl('button', { text: 'Cancel' }).onclick = () => this.close();
     footer.createEl('button', { text: 'Save', cls: 'mod-cta' }).onclick = () => {

--- a/plugin/src/ssh/SftpClient.ts
+++ b/plugin/src/ssh/SftpClient.ts
@@ -120,6 +120,38 @@ export class SftpClient {
     logger.info(`SftpClient: SFTP channel open`);
   }
 
+  /**
+   * Forward a local Duplex to a unix-domain socket on the remote host.
+   *
+   * Used by the α transport to reach `obsidian-remote-server`'s
+   * listening socket (e.g. `~/.obsidian-remote/server.sock`) through
+   * the same SSH connection that already carries the SFTP channel.
+   * Requires OpenSSH's `direct-streamlocal@openssh.com` extension,
+   * which every mainstream sshd has shipped since OpenSSH 6.7.
+   */
+  async openUnixStream(socketPath: string): Promise<Duplex> {
+    const client = this.requireClient();
+    return new Promise((resolve, reject) => {
+      client.openssh_forwardOutStreamLocal(socketPath, (err: Error | undefined, stream: Duplex) => {
+        if (err) reject(err);
+        else resolve(stream);
+      });
+    });
+  }
+
+  /**
+   * Read a small file off the remote via SFTP. Intended for reading
+   * one-shot state like the daemon's session token; for vault files
+   * use `readBinary`/`readText` which go through the same channel
+   * but return typed buffers directly.
+   */
+  async readRemoteFile(remotePath: string): Promise<Buffer> {
+    const sftp = this.requireSftp();
+    return new Promise((resolve, reject) => {
+      sftp.readFile(remotePath, (err, buf) => err ? reject(err) : resolve(buf));
+    });
+  }
+
   async disconnect(): Promise<void> {
     this.intentionalDisconnect = true;
     const client = this.client;
@@ -331,6 +363,11 @@ export class SftpClient {
   private requireSftp(): SFTPWrapper {
     if (!this.sftp) throw new Error('SftpClient: not connected');
     return this.sftp;
+  }
+
+  private requireClient(): Client {
+    if (!this.client) throw new Error('SftpClient: not connected');
+    return this.client;
   }
 }
 

--- a/plugin/src/transport/RpcConnection.ts
+++ b/plugin/src/transport/RpcConnection.ts
@@ -1,0 +1,89 @@
+import type { Duplex } from 'stream';
+import { FramedDuplex } from './framing';
+import { RpcClient } from './RpcClient';
+import { RpcError } from './RpcError';
+import { PROTOCOL_VERSION, ErrorCode } from '../proto/types';
+import type { ServerInfo } from '../proto/types';
+import { logger } from '../util/logger';
+
+/**
+ * Concrete transport the α path needs: a Duplex stream reaching the
+ * daemon, plus the session token the daemon wrote to disk at startup.
+ *
+ * Typical construction uses `SftpClient.openUnixStream` +
+ * `SftpClient.readRemoteFile`, but the shape is abstract so tests can
+ * pass an in-memory duplex + a literal token.
+ */
+export interface RpcConnectionInputs {
+  stream: Duplex;
+  token: string;
+}
+
+/**
+ * Full result of a successful RPC handshake: the authenticated client
+ * plus the daemon's advertised capabilities.
+ */
+export interface RpcConnection {
+  rpc: RpcClient;
+  info: ServerInfo;
+  close(): void;
+}
+
+/**
+ * Open an authenticated RPC session on a stream already pointing at
+ * the daemon's unix socket.
+ *
+ * Steps, in order:
+ *   1. Wrap the stream in a FramedDuplex.
+ *   2. Wrap that in an RpcClient.
+ *   3. Call `auth { token }`.
+ *   4. Call `server.info` and verify the protocol version.
+ *   5. Return the client + info.
+ *
+ * If any step fails, the stream is closed before the error is
+ * re-thrown so the caller never has to clean up partial state.
+ */
+export async function establishRpcConnection(inputs: RpcConnectionInputs): Promise<RpcConnection> {
+  const framed = new FramedDuplex(inputs.stream);
+  const rpc = new RpcClient(framed);
+  const cleanupOnFailure = (e: unknown): never => {
+    try { rpc.close(); } catch { /* ignore */ }
+    throw e;
+  };
+
+  try {
+    const authResult = await rpc.call('auth', { token: inputs.token });
+    if (!authResult.ok) {
+      throw new RpcError(ErrorCode.AuthInvalid, 'daemon refused auth token');
+    }
+    logger.info('RpcConnection: auth accepted');
+  } catch (e) {
+    return cleanupOnFailure(e);
+  }
+
+  let info: ServerInfo;
+  try {
+    info = await rpc.call('server.info', {});
+  } catch (e) {
+    return cleanupOnFailure(e);
+  }
+
+  if (info.protocolVersion !== PROTOCOL_VERSION) {
+    cleanupOnFailure(
+      new RpcError(
+        ErrorCode.ProtocolVersionTooOld,
+        `daemon speaks protocol v${info.protocolVersion}, client needs v${PROTOCOL_VERSION}`,
+      ),
+    );
+  }
+  logger.info(
+    `RpcConnection: daemon ${info.version} (protocol v${info.protocolVersion}); ` +
+    `capabilities=[${info.capabilities.join(', ')}]`,
+  );
+
+  return {
+    rpc,
+    info,
+    close: () => rpc.close(),
+  };
+}

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -33,6 +33,21 @@ export interface SshProfile {
   keepaliveCountMax: number;
   hostKeyFingerprint?: string;
   jumpHost?: JumpHostConfig;
+
+  /**
+   * α-path daemon socket on the remote host
+   * (e.g. `~/.obsidian-remote/server.sock`). When unset, the plugin's
+   * RPC debug command cannot run and the adapter stays on the direct
+   * SFTP path. Auto-populated by the upcoming server auto-deploy
+   * phase; for now the user fills it in by hand after starting
+   * `obsidian-remote-server` on the remote.
+   */
+  rpcSocketPath?: string;
+  /**
+   * Path on the remote host holding the session token the daemon
+   * writes at startup (default `~/.obsidian-remote/token`).
+   */
+  rpcTokenPath?: string;
 }
 
 export interface PluginSettings {

--- a/plugin/tests/RpcConnection.test.ts
+++ b/plugin/tests/RpcConnection.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import { PassThrough } from 'stream';
+import type { Duplex } from 'stream';
+import { establishRpcConnection } from '../src/transport/RpcConnection';
+import { FramedDuplex } from '../src/transport/framing';
+import { RpcError } from '../src/transport/RpcError';
+import { ErrorCode, PROTOCOL_VERSION } from '../src/proto/types';
+
+/**
+ * Builds a duplex pair where writes to `clientSide` show up as reads
+ * on `serverSide`, and vice versa. The "server" mocks the daemon by
+ * watching incoming framed JSON-RPC requests and responding directly.
+ */
+function duplexPair(): { clientSide: Duplex; serverSide: Duplex } {
+  const clientToServer = new PassThrough();
+  const serverToClient = new PassThrough();
+  const clientSide = combine(serverToClient, clientToServer);
+  const serverSide = combine(clientToServer, serverToClient);
+  return { clientSide, serverSide };
+}
+
+function combine(reads: PassThrough, writes: PassThrough): Duplex {
+  return {
+    on: (event: string, listener: (...args: unknown[]) => void) => {
+      if (event === 'data' || event === 'end' || event === 'close' || event === 'error') {
+        reads.on(event, listener);
+      }
+      return this;
+    },
+    write: (chunk: Buffer) => writes.write(chunk),
+    end: () => { writes.end(); reads.end(); },
+  } as unknown as Duplex;
+}
+
+interface ServerScript {
+  /** Optional override for server.info; defaults to the protocol's version. */
+  info?: { protocolVersion: number };
+  /** Make `auth` reject with a custom error envelope. */
+  authReject?: { code: number; message: string };
+}
+
+/**
+ * Wires a FramedDuplex on the "server" side of a duplex pair and
+ * answers `auth` + `server.info` according to a tiny script. Returns
+ * a disposer to release event listeners after the test.
+ */
+function startFakeDaemon(serverSide: Duplex, script: ServerScript = {}): () => void {
+  const framed = new FramedDuplex(serverSide);
+  framed.on('message', (body: Buffer) => {
+    const req = JSON.parse(body.toString('utf8')) as { id: number; method: string };
+    if (req.method === 'auth') {
+      if (script.authReject) {
+        framed.writeMessage(Buffer.from(JSON.stringify({
+          jsonrpc: '2.0', id: req.id, error: script.authReject,
+        }), 'utf8'));
+      } else {
+        framed.writeMessage(Buffer.from(JSON.stringify({
+          jsonrpc: '2.0', id: req.id, result: { ok: true },
+        }), 'utf8'));
+      }
+      return;
+    }
+    if (req.method === 'server.info') {
+      const info = script.info ?? { protocolVersion: PROTOCOL_VERSION };
+      framed.writeMessage(Buffer.from(JSON.stringify({
+        jsonrpc: '2.0', id: req.id,
+        result: {
+          version: 'test-1.0', protocolVersion: info.protocolVersion,
+          capabilities: ['auth', 'server.info'], vaultRoot: '/v',
+        },
+      }), 'utf8'));
+      return;
+    }
+    framed.writeMessage(Buffer.from(JSON.stringify({
+      jsonrpc: '2.0', id: req.id, error: { code: -32601, message: `unknown method ${req.method}` },
+    }), 'utf8'));
+  });
+  return () => framed.close();
+}
+
+describe('establishRpcConnection', () => {
+  it('completes auth → server.info and returns the daemon info', async () => {
+    const pair = duplexPair();
+    const stop = startFakeDaemon(pair.serverSide);
+    const conn = await establishRpcConnection({ stream: pair.clientSide, token: 'good' });
+    expect(conn.info.version).toBe('test-1.0');
+    expect(conn.info.protocolVersion).toBe(PROTOCOL_VERSION);
+    expect(conn.info.capabilities).toContain('auth');
+    conn.close();
+    stop();
+  });
+
+  it('rejects with the daemon-supplied error code when auth fails', async () => {
+    const pair = duplexPair();
+    const stop = startFakeDaemon(pair.serverSide, {
+      authReject: { code: ErrorCode.AuthInvalid, message: 'wrong token' },
+    });
+    await expect(
+      establishRpcConnection({ stream: pair.clientSide, token: 'bad' }),
+    ).rejects.toMatchObject({ code: ErrorCode.AuthInvalid });
+    stop();
+  });
+
+  it('rejects with ProtocolVersionTooOld when versions disagree', async () => {
+    const pair = duplexPair();
+    const stop = startFakeDaemon(pair.serverSide, { info: { protocolVersion: 999 } });
+    try {
+      await establishRpcConnection({ stream: pair.clientSide, token: 'good' });
+      expect.fail('expected handshake to reject for protocol mismatch');
+    } catch (e) {
+      expect(e).toBeInstanceOf(RpcError);
+      expect((e as RpcError).code).toBe(ErrorCode.ProtocolVersionTooOld);
+    }
+    stop();
+  });
+});


### PR DESCRIPTION
## Summary
End-to-end JSON-RPC plumbing the user can exercise against a manually-started \`obsidian-remote-server\` daemon, before auto-deploy lands in a later phase. **No production code path uses the new transport yet** — the debug command is the only consumer.

## What's new
### \`SftpClient\` — two SSH primitives the α path needs
- \`openUnixStream(socketPath)\` wraps \`openssh_forwardOutStreamLocal\` so the SSH session that already carries SFTP can also reach a unix-domain socket on the remote (the daemon's listener).
- \`readRemoteFile(path)\` is a one-shot SFTP read used to slurp the daemon's session token from disk.

### \`transport/RpcConnection.ts\`
\`establishRpcConnection({ stream, token })\` wraps a Duplex in \`FramedDuplex\` → \`RpcClient\`, runs \`auth → server.info\`, verifies the protocol version, and returns the authenticated client + the daemon's info. Closes the stream on any handshake failure so the caller never sees half-state.

### Profile schema + UI
\`SshProfile\` gains optional \`rpcSocketPath\` / \`rpcTokenPath\`. \`ProfileForm\` grows a "Remote daemon (experimental)" section with inputs for both, including a note that auto-deploy is pending.

### Debug command — \`Debug: test RPC tunnel against obsidian-remote-server\`
1. Reads the token via \`SftpClient.readRemoteFile\`.
2. Opens the unix socket via \`SftpClient.openUnixStream\`.
3. Runs the handshake through \`establishRpcConnection\`.
4. Wraps the resulting \`RpcClient\` in \`RpcRemoteFsClient\` and calls \`list(activeRemoteBasePath)\` to confirm the round-trip.
5. Logs every step into \`console.log\`, plus a Notice with daemon version + entry count.

### Tests
\`tests/RpcConnection.test.ts\` (3 cases) drives \`establishRpcConnection\` against an in-process \`FramedDuplex\` pair acting as a tiny daemon:
- successful \`auth\` → \`server.info\`,
- daemon-rejected \`auth\` surfaces \`AuthInvalid\`,
- protocol-version mismatch raises \`ProtocolVersionTooOld\` and closes the stream.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 115 / 115 pass (3 new)
- [x] \`cd plugin && npm run build:install\` — 379 KB (+9 KB; transport modules now reachable from runtime)
- [x] \`cd server && GOOS=linux GOARCH=amd64 go build\` — Linux binary ready at \`server/bin/obsidian-remote-server-linux-amd64\` (3.94 MB)

## Dogfood (manual, after merge)
1. \`scp server/bin/obsidian-remote-server-linux-amd64 panza:~/.obsidian-remote/server\` (and \`chmod +x\`).
2. \`ssh panza\` then start: \`./.obsidian-remote/server --vault-root=~/work/VaultDev --verbose &\`.
3. In Obsidian → Settings → Remote SSH → edit the Panza profile and fill:
   - **Daemon socket path**: \`.obsidian-remote/server.sock\`
   - **Daemon token path**: \`.obsidian-remote/token\`
4. Run \`Connect to remote vault\` (existing SFTP path) on the Panza profile.
5. Run \`Debug: test RPC tunnel against obsidian-remote-server\`.

Expected: a Notice with daemon version + entry count for \`~/work/VaultDev\`, plus a per-step trace in \`SelfArchive-dev/.obsidian/plugins/remote-ssh/console.log\`.

## Follow-ups
- **Phase 5-D.4**: switch \`SftpDataAdapter\`'s client over to \`RpcRemoteFsClient\` automatically when the active profile carries an \`rpcSocketPath\`; SFTP path stays as fallback.
- **Phase 5-G**: server auto-deploy over SSH (scp + start + token) so steps 1–3 above happen at \`Connect\` time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)