### PR TITLE
feat(plugin): auto-deploy obsidian-remote-server over SSH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ main.js
 .DS_Store
 coverage/
 cdp-console.log
+plugin/server-bin/

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -8,6 +8,8 @@
     "build": "node esbuild.config.mjs production",
     "dev:install": "node scripts/dev-install.mjs",
     "build:install": "node esbuild.config.mjs production && node scripts/dev-install.mjs",
+    "build:server": "node scripts/build-server.mjs",
+    "build:full": "node scripts/build-server.mjs && node esbuild.config.mjs production && node scripts/dev-install.mjs",
     "cdp:tail": "node scripts/cdp-tail.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/plugin/scripts/build-server.mjs
+++ b/plugin/scripts/build-server.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/*
+ * build-server — cross-compile the obsidian-remote-server Go daemon
+ * for linux/amd64 and stage the resulting binary into
+ * <plugin>/server-bin/ so dev-install.mjs picks it up alongside
+ * main.js / manifest.json / styles.css.
+ *
+ * Usage:
+ *   node scripts/build-server.mjs
+ *   node scripts/build-server.mjs --goos=linux --goarch=arm64
+ *
+ * Locating Go:
+ *   1. `go` on PATH (preferred).
+ *   2. `~/tools/go-portable/go/bin/go(.exe)` — useful for the dev box
+ *      where Go isn't installed system-wide; ignored elsewhere.
+ *   3. Otherwise the script exits with a clear error.
+ *
+ * Skipping:
+ *   Set REMOTE_SSH_SKIP_SERVER_BUILD=1 to no-op (build:install can
+ *   then run on machines that don't have Go and don't need a fresh
+ *   binary).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const __dirname  = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.resolve(__dirname, '..');
+const repoRoot   = path.resolve(pluginRoot, '..');
+const serverDir  = path.join(repoRoot, 'server');
+const stageDir   = path.join(pluginRoot, 'server-bin');
+
+if (process.env.REMOTE_SSH_SKIP_SERVER_BUILD === '1') {
+  console.log('build-server: REMOTE_SSH_SKIP_SERVER_BUILD set, skipping');
+  process.exit(0);
+}
+
+// Parse flags.
+const args = process.argv.slice(2);
+const flag = (name) => {
+  const hit = args.find(a => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : undefined;
+};
+const goos   = flag('goos')   ?? 'linux';
+const goarch = flag('goarch') ?? 'amd64';
+const outName = `obsidian-remote-server-${goos}-${goarch}` + (goos === 'windows' ? '.exe' : '');
+
+const goExe = locateGo();
+if (!goExe) {
+  console.error('build-server: could not locate the Go toolchain.');
+  console.error('  Install Go (https://go.dev/dl/) or set REMOTE_SSH_SKIP_SERVER_BUILD=1.');
+  process.exit(1);
+}
+
+if (!fs.existsSync(serverDir)) {
+  console.error(`build-server: ${serverDir} does not exist`);
+  process.exit(1);
+}
+
+fs.mkdirSync(stageDir, { recursive: true });
+const outPath = path.join(stageDir, outName);
+
+console.log(`build-server: ${goExe} build -o ${path.relative(repoRoot, outPath)}  (GOOS=${goos} GOARCH=${goarch})`);
+
+const result = spawnSync(
+  goExe,
+  ['build', '-o', outPath, './cmd/obsidian-remote-server'],
+  {
+    cwd: serverDir,
+    stdio: 'inherit',
+    env: { ...process.env, GOOS: goos, GOARCH: goarch, CGO_ENABLED: '0' },
+  },
+);
+
+if (result.status !== 0) {
+  console.error(`build-server: go build exited ${result.status}`);
+  process.exit(result.status ?? 1);
+}
+
+console.log(`build-server: staged ${path.relative(repoRoot, outPath)} (${prettySize(fs.statSync(outPath).size)})`);
+
+function locateGo() {
+  const fromPath = which('go') ?? which('go.exe');
+  if (fromPath) return fromPath;
+
+  // Fallback: the portable Go on the dev box.
+  const portableCandidates = [
+    path.join(os.homedir(), 'tools', 'go-portable', 'go', 'bin', 'go.exe'),
+    path.join(os.homedir(), 'tools', 'go-portable', 'go', 'bin', 'go'),
+  ];
+  for (const c of portableCandidates) {
+    if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+
+function which(cmd) {
+  const sep = process.platform === 'win32' ? ';' : ':';
+  const exts = process.platform === 'win32'
+    ? (process.env.PATHEXT?.split(';') ?? ['.EXE', '.CMD', '.BAT'])
+    : [''];
+  for (const dir of (process.env.PATH ?? '').split(sep)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const p = path.join(dir, cmd + ext);
+      if (fs.existsSync(p)) return p;
+    }
+  }
+  return null;
+}
+
+function prettySize(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`;
+  return `${(n / 1024 / 1024).toFixed(2)} MiB`;
+}

--- a/plugin/scripts/dev-install.mjs
+++ b/plugin/scripts/dev-install.mjs
@@ -53,5 +53,24 @@ for (const f of files) {
   console.log(`copied ${f} -> ${dst}`);
 }
 
+// Stage the obsidian-remote-server binaries (if any) so the plugin
+// can ship one to the remote at connect time. Built by
+// `npm run build:server`; missing means "no auto-deploy this run",
+// not an error.
+const serverBinDir = path.join(pluginRoot, 'server-bin');
+if (fs.existsSync(serverBinDir)) {
+  const binTarget = path.join(targetDir, 'server-bin');
+  fs.mkdirSync(binTarget, { recursive: true });
+  for (const f of fs.readdirSync(serverBinDir)) {
+    const src = path.join(serverBinDir, f);
+    if (!fs.statSync(src).isFile()) continue;
+    const dst = path.join(binTarget, f);
+    fs.copyFileSync(src, dst);
+    console.log(`copied server-bin/${f} -> ${dst}`);
+  }
+} else {
+  console.log('server-bin/ not present — skipping daemon staging (run `npm run build:server` to build it)');
+}
+
 console.log(`\nplugin '${manifest.id}' v${manifest.version} installed to ${targetDir}`);
 console.log('Reload the plugin in Obsidian (Settings → Community plugins → toggle off/on).');

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -13,6 +13,8 @@ import { AdapterPatcher } from './adapter/AdapterPatcher';
 import { SftpRemoteFsClient } from './adapter/SftpRemoteFsClient';
 import { RpcRemoteFsClient } from './adapter/RpcRemoteFsClient';
 import { establishRpcConnection } from './transport/RpcConnection';
+import { ServerDeployer } from './transport/ServerDeployer';
+import * as fs from 'fs';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
 import { SettingsTab } from './settings/SettingsTab';
@@ -301,17 +303,19 @@ export default class RemoteSshPlugin extends Plugin {
   }
 
   /**
-   * Round-trips a JSON-RPC session against `obsidian-remote-server` running
-   * on the remote: reads the daemon's token via SFTP, opens a Duplex through
-   * the same SSH connection, runs the framed `auth` + `server.info`
-   * handshake, then lists the configured remote vault root via the new
-   * `RpcRemoteFsClient`. Logs every step so the daemon and plugin can be
-   * debugged together from `console.log`.
+   * Full α-path round-trip with auto-deploy:
+   *   1. Locate the staged daemon binary inside the plugin folder.
+   *   2. Upload it over the existing SFTP session, kill any prior
+   *      daemon, start the new one with `nohup`, wait for the token
+   *      to land on disk.
+   *   3. Open a unix-socket Duplex through the same SSH connection.
+   *   4. Run `auth` + `server.info`.
+   *   5. Smoke-list `activeRemoteBasePath` via `RpcRemoteFsClient`.
    *
-   * Pre-requisites that the user has to set up by hand for now (auto-deploy
-   * lands in a later phase): start `obsidian-remote-server --vault-root=…`
-   * on the remote, then fill in `rpcSocketPath` and (optionally)
-   * `rpcTokenPath` on the active profile.
+   * Each step logs to `console.log` so the daemon and plugin can be
+   * debugged in tandem. Optional overrides on the active profile
+   * (`rpcSocketPath`, `rpcTokenPath`) are honoured; both default to
+   * `.obsidian-remote/{server.sock,token}` (home-relative).
    */
   private async debugTestRpcTunnel(): Promise<void> {
     if (this.state !== SyncState.CONNECTED || !this.client.isAlive()) {
@@ -324,32 +328,48 @@ export default class RemoteSshPlugin extends Plugin {
       new Notice('Remote SSH: no active profile');
       return;
     }
-    const socketPath = profile.rpcSocketPath?.trim();
-    if (!socketPath) {
-      new Notice('Remote SSH: profile.rpcSocketPath is empty (set it in Settings)');
+
+    const localBinaryPath = this.locateDaemonBinary();
+    if (!localBinaryPath) {
+      new Notice(
+        'Remote SSH: daemon binary not staged. ' +
+        'Run `npm run build:server` (or `build:full`) and reload the plugin.',
+      );
       return;
     }
-    const tokenPath = profile.rpcTokenPath?.trim() || '.obsidian-remote/token';
 
-    logger.info(`debugTestRpcTunnel: token <- ${tokenPath}, socket -> ${socketPath}`);
+    const remoteVaultRoot = normalizeRemotePath(profile.remotePath);
+    const remoteBinaryPath = '.obsidian-remote/server';
+    const remoteSocketPath = profile.rpcSocketPath?.trim() || '.obsidian-remote/server.sock';
+    const remoteTokenPath  = profile.rpcTokenPath?.trim()  || '.obsidian-remote/token';
+
+    logger.info(`debugTestRpcTunnel: local binary = ${localBinaryPath}`);
+    logger.info(`debugTestRpcTunnel: remote vault = ${remoteVaultRoot}`);
+    logger.info(`debugTestRpcTunnel: remote socket = ${remoteSocketPath}`);
+
     let connection: Awaited<ReturnType<typeof establishRpcConnection>> | null = null;
     try {
-      const tokenBuf = await this.client.readRemoteFile(tokenPath);
-      const token = tokenBuf.toString('utf8').trim();
-      if (!token) throw new Error(`token file at ${tokenPath} is empty`);
+      const deployer = new ServerDeployer(this.client);
+      const deploy = await deployer.deploy({
+        localBinaryPath,
+        remoteBinaryPath,
+        remoteVaultRoot,
+        remoteSocketPath,
+        remoteTokenPath,
+      });
+      logger.info(`debugTestRpcTunnel: daemon up; token len=${deploy.token.length}`);
 
-      const stream = await this.client.openUnixStream(socketPath);
-      connection = await establishRpcConnection({ stream, token });
+      const stream = await this.client.openUnixStream(deploy.remoteSocketPath);
+      connection = await establishRpcConnection({ stream, token: deploy.token });
 
-      const fs = new RpcRemoteFsClient(connection.rpc);
-      const effectiveRoot = this.activeRemoteBasePath ?? '';
-      const entries = await fs.list(effectiveRoot);
-      logger.info(`debugTestRpcTunnel: list("${effectiveRoot}") returned ${entries.length} entries`);
+      const rpcFs = new RpcRemoteFsClient(connection.rpc);
+      const entries = await rpcFs.list(remoteVaultRoot);
+      logger.info(`debugTestRpcTunnel: list("${remoteVaultRoot}") returned ${entries.length} entries`);
       for (const e of entries.slice(0, 5)) {
         logger.info(`  - ${e.name} (${e.isDirectory ? 'dir' : 'file'}, ${e.size}B, mtime ${e.mtime})`);
       }
       new Notice(
-        `RPC OK: daemon ${connection.info.version}, ${entries.length} entries at "${effectiveRoot}" ` +
+        `RPC OK: daemon ${connection.info.version}, ${entries.length} entries at "${remoteVaultRoot}" ` +
         `(see console.log)`,
       );
     } catch (e) {
@@ -359,6 +379,24 @@ export default class RemoteSshPlugin extends Plugin {
     } finally {
       try { connection?.close(); } catch { /* ignore */ }
     }
+  }
+
+  /**
+   * Resolve the staged Linux/amd64 daemon binary that lives next to
+   * `main.js` in the plugin's vault folder. Returns the absolute path
+   * or `null` if the binary hasn't been built (run `npm run
+   * build:server` to populate it). Other architectures land in
+   * follow-up phases.
+   */
+  private locateDaemonBinary(): string | null {
+    const adapter = this.app.vault.adapter;
+    if (!(adapter instanceof FileSystemAdapter)) return null;
+    const candidate = path.join(
+      adapter.getBasePath(),
+      '.obsidian', 'plugins', this.manifest.id,
+      'server-bin', 'obsidian-remote-server-linux-amd64',
+    );
+    return fs.existsSync(candidate) ? candidate : null;
   }
 
   isConnected(): boolean {

--- a/plugin/src/ssh/SftpClient.ts
+++ b/plugin/src/ssh/SftpClient.ts
@@ -152,6 +152,41 @@ export class SftpClient {
     });
   }
 
+  /**
+   * Upload a local file to the remote via SFTP, like scp. Used by the
+   * auto-deploy flow to ship `obsidian-remote-server` on connect. The
+   * destination directory must already exist; create it via `exec`
+   * first if you can't be sure.
+   */
+  async uploadFile(localPath: string, remotePath: string): Promise<void> {
+    const sftp = this.requireSftp();
+    return new Promise((resolve, reject) => {
+      sftp.fastPut(localPath, remotePath, { concurrency: 4 }, err => err ? reject(err) : resolve());
+    });
+  }
+
+  /**
+   * Run a one-shot command on the remote and collect its stdout, stderr,
+   * and exit code. Long-running streams (interactive shells, the daemon
+   * process itself) should not go through here — they'd never close.
+   */
+  async exec(cmd: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const client = this.requireClient();
+    return new Promise((resolve, reject) => {
+      client.exec(cmd, (err, stream) => {
+        if (err) { reject(err); return; }
+        let stdout = '';
+        let stderr = '';
+        let exitCode = -1;
+        stream.on('data', (d: Buffer) => { stdout += d.toString('utf8'); });
+        stream.stderr.on('data', (d: Buffer) => { stderr += d.toString('utf8'); });
+        stream.on('exit', (code: number) => { exitCode = code; });
+        stream.on('close', () => resolve({ stdout, stderr, exitCode }));
+        stream.on('error', (e: Error) => reject(e));
+      });
+    });
+  }
+
   async disconnect(): Promise<void> {
     this.intentionalDisconnect = true;
     const client = this.client;

--- a/plugin/src/transport/ServerDeployer.ts
+++ b/plugin/src/transport/ServerDeployer.ts
@@ -1,0 +1,201 @@
+import { logger } from '../util/logger';
+
+/**
+ * The thin slice of SftpClient the deployer relies on. A separate
+ * interface keeps this module free of the larger SftpClient surface
+ * area and makes it trivial to mock in unit tests.
+ */
+export interface DeployerSshClient {
+  uploadFile(localPath: string, remotePath: string): Promise<void>;
+  readRemoteFile(remotePath: string): Promise<Buffer>;
+  exec(cmd: string): Promise<{ stdout: string; stderr: string; exitCode: number }>;
+}
+
+export interface DeployOptions {
+  /** Absolute or working-directory-relative path on the local machine. */
+  localBinaryPath: string;
+
+  /**
+   * Where to write the daemon binary on the remote. Default
+   * `.obsidian-remote/server` (home-relative).
+   */
+  remoteBinaryPath?: string;
+
+  /** Vault root the daemon should serve. Passed via --vault-root. */
+  remoteVaultRoot: string;
+
+  /**
+   * Where the daemon writes its session token. Default
+   * `.obsidian-remote/token`. Must match what the daemon was told to
+   * write — passed unchanged via --token-file.
+   */
+  remoteTokenPath?: string;
+
+  /**
+   * Where the daemon listens. Default `.obsidian-remote/server.sock`.
+   * Must match what the plugin opens via `openssh_forwardOutStreamLocal`.
+   */
+  remoteSocketPath?: string;
+
+  /**
+   * Where the daemon's stdout/stderr go. Default
+   * `.obsidian-remote/server.log`. Useful for post-mortem debugging
+   * since the launching SSH connection drops out of the daemon's
+   * lifecycle once `nohup` detaches.
+   */
+  remoteLogPath?: string;
+
+  /**
+   * If `true` (default), an existing daemon process is killed before
+   * the new one is started. Set to `false` to leave a previously
+   * running instance untouched (useful when multiple Obsidian sessions
+   * share one host and you don't want to interrupt another vault's
+   * connection).
+   */
+  killExisting?: boolean;
+
+  /** Maximum total time to wait for the daemon's token file to appear, in ms. Default 5000. */
+  waitForTokenTimeoutMs?: number;
+}
+
+export interface DeployResult {
+  remoteBinaryPath: string;
+  remoteSocketPath: string;
+  remoteTokenPath: string;
+  /** The freshly-written token, read off disk after the daemon came up. */
+  token: string;
+}
+
+const DEFAULTS = {
+  remoteBinaryPath: '.obsidian-remote/server',
+  remoteTokenPath:  '.obsidian-remote/token',
+  remoteSocketPath: '.obsidian-remote/server.sock',
+  remoteLogPath:    '.obsidian-remote/server.log',
+  killExisting:     true,
+  waitForTokenTimeoutMs: 5000,
+} as const;
+
+/**
+ * ServerDeployer ships the obsidian-remote-server binary to the remote
+ * host, makes it executable, replaces any previously-running instance,
+ * and waits for the new one to come up by watching for the token file.
+ *
+ * The class is stateless aside from its `ssh` dependency: every call
+ * to `deploy()` is a complete replace-and-restart. That's deliberately
+ * simple — the daemon is small, idempotent in its setup, and starting
+ * it costs less than fifty ms once the binary is on disk.
+ */
+export class ServerDeployer {
+  constructor(private readonly ssh: DeployerSshClient) {}
+
+  async deploy(opts: DeployOptions): Promise<DeployResult> {
+    const remoteBinaryPath = opts.remoteBinaryPath ?? DEFAULTS.remoteBinaryPath;
+    const remoteTokenPath  = opts.remoteTokenPath  ?? DEFAULTS.remoteTokenPath;
+    const remoteSocketPath = opts.remoteSocketPath ?? DEFAULTS.remoteSocketPath;
+    const remoteLogPath    = opts.remoteLogPath    ?? DEFAULTS.remoteLogPath;
+    const killExisting     = opts.killExisting     ?? DEFAULTS.killExisting;
+    const waitMs           = opts.waitForTokenTimeoutMs ?? DEFAULTS.waitForTokenTimeoutMs;
+
+    const remoteDir = parentDirOf(remoteBinaryPath);
+
+    logger.info(`ServerDeployer: ensuring ${remoteDir}/ exists`);
+    await this.run(`mkdir -p ${shellQuote(remoteDir)} && chmod 700 ${shellQuote(remoteDir)}`);
+
+    if (killExisting) {
+      logger.info('ServerDeployer: killing any prior daemon');
+      // Match by the unique --vault-root flag so we never kill an
+      // unrelated process that happens to share the binary name.
+      await this.run(`pkill -f ${shellQuote(remoteBinaryPath + ' ')} 2>/dev/null || true`);
+      // Stale socket left by a hard-killed daemon would block bind().
+      await this.run(`rm -f ${shellQuote(remoteSocketPath)} ${shellQuote(remoteTokenPath)}`);
+    }
+
+    logger.info(`ServerDeployer: uploading binary → ${remoteBinaryPath}`);
+    await this.ssh.uploadFile(opts.localBinaryPath, remoteBinaryPath);
+    await this.run(`chmod 700 ${shellQuote(remoteBinaryPath)}`);
+
+    logger.info('ServerDeployer: starting daemon');
+    const startCmd = [
+      `nohup ${shellQuote(remoteBinaryPath)}`,
+      `--vault-root=${shellQuote(opts.remoteVaultRoot)}`,
+      `--socket=${shellQuote(remoteSocketPath)}`,
+      `--token-file=${shellQuote(remoteTokenPath)}`,
+      `--verbose`,
+      `> ${shellQuote(remoteLogPath)} 2>&1 < /dev/null &`,
+    ].join(' ');
+    // The launching shell exits as soon as nohup detaches, so this
+    // exec returns almost immediately even though the daemon keeps
+    // running.
+    await this.run(startCmd);
+
+    const token = await this.waitForToken(remoteTokenPath, waitMs);
+    return { remoteBinaryPath, remoteSocketPath, remoteTokenPath, token };
+  }
+
+  /**
+   * Stop a running daemon by killing every process matching the
+   * deployed binary path. Safe to call when no daemon is up.
+   */
+  async stop(remoteBinaryPath = DEFAULTS.remoteBinaryPath,
+             remoteSocketPath = DEFAULTS.remoteSocketPath,
+             remoteTokenPath  = DEFAULTS.remoteTokenPath): Promise<void> {
+    logger.info(`ServerDeployer: stopping daemon at ${remoteBinaryPath}`);
+    await this.run(`pkill -f ${shellQuote(remoteBinaryPath + ' ')} 2>/dev/null || true`);
+    await this.run(`rm -f ${shellQuote(remoteSocketPath)} ${shellQuote(remoteTokenPath)}`);
+  }
+
+  // ─── internals ───────────────────────────────────────────────────────────
+
+  private async run(cmd: string): Promise<string> {
+    const r = await this.ssh.exec(cmd);
+    if (r.exitCode !== 0 && !cmd.includes('|| true')) {
+      throw new Error(`ServerDeployer: \`${truncate(cmd, 120)}\` exited ${r.exitCode}: ${r.stderr.trim() || r.stdout.trim()}`);
+    }
+    return r.stdout;
+  }
+
+  private async waitForToken(remoteTokenPath: string, timeoutMs: number): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    let lastErr: unknown = null;
+    while (Date.now() < deadline) {
+      try {
+        const buf = await this.ssh.readRemoteFile(remoteTokenPath);
+        const token = buf.toString('utf8').trim();
+        if (token) return token;
+      } catch (e) {
+        lastErr = e;
+        // Token not ready yet — sleep a beat and retry.
+      }
+      await sleep(150);
+    }
+    throw new Error(
+      `ServerDeployer: daemon did not write ${remoteTokenPath} within ${timeoutMs}ms` +
+      (lastErr ? ` (last error: ${(lastErr as Error).message})` : ''),
+    );
+  }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Wraps a string in single quotes for inclusion in a POSIX shell
+ * command, escaping any embedded single quotes. Sufficient for the
+ * paths and arguments we control here; do not feed user-supplied
+ * arbitrary text.
+ */
+function shellQuote(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function parentDirOf(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i <= 0 ? '.' : path.slice(0, i);
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max - 1) + '…';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/plugin/tests/ServerDeployer.test.ts
+++ b/plugin/tests/ServerDeployer.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { ServerDeployer, type DeployerSshClient } from '../src/transport/ServerDeployer';
+
+/**
+ * Recordable fake: exec commands queue up, uploadFile / readRemoteFile
+ * call user-supplied scripts. Tests assert the order + content of the
+ * commands that the deployer fires.
+ */
+function fakeSsh(opts: {
+  /** Function called whenever the deployer reads a remote file (e.g. the token). */
+  onReadFile: (path: string) => Buffer;
+  /** Optional override for exec stdout/stderr/exit per command. */
+  onExec?: (cmd: string) => { stdout?: string; stderr?: string; exitCode?: number };
+}): {
+  ssh: DeployerSshClient;
+  execLog: string[];
+  uploads: Array<{ local: string; remote: string }>;
+} {
+  const execLog: string[] = [];
+  const uploads: Array<{ local: string; remote: string }> = [];
+
+  const ssh: DeployerSshClient = {
+    async exec(cmd) {
+      execLog.push(cmd);
+      const r = opts.onExec?.(cmd);
+      return {
+        stdout:   r?.stdout ?? '',
+        stderr:   r?.stderr ?? '',
+        exitCode: r?.exitCode ?? 0,
+      };
+    },
+    async uploadFile(local, remote) {
+      uploads.push({ local, remote });
+    },
+    async readRemoteFile(remotePath) {
+      return opts.onReadFile(remotePath);
+    },
+  };
+  return { ssh, execLog, uploads };
+}
+
+describe('ServerDeployer', () => {
+  it('runs mkdir → kill → upload → chmod → start → wait-for-token in order', async () => {
+    const { ssh, execLog, uploads } = fakeSsh({
+      onReadFile: () => Buffer.from('token-abc'),
+    });
+    const deployer = new ServerDeployer(ssh);
+    const out = await deployer.deploy({
+      localBinaryPath: '/local/server',
+      remoteVaultRoot: '/srv/vault',
+      waitForTokenTimeoutMs: 1000,
+    });
+
+    expect(out.token).toBe('token-abc');
+    expect(uploads).toEqual([{ local: '/local/server', remote: '.obsidian-remote/server' }]);
+
+    // The first three commands must, in order, prep the dir, kill any
+    // prior daemon, and remove stale socket / token files.
+    expect(execLog[0]).toMatch(/mkdir -p '\.obsidian-remote'/);
+    expect(execLog[1]).toMatch(/pkill -f '\.obsidian-remote\/server '/);
+    expect(execLog[2]).toMatch(/rm -f '\.obsidian-remote\/server\.sock' '\.obsidian-remote\/token'/);
+
+    // chmod and start come after the upload.
+    expect(execLog[3]).toMatch(/chmod 700 '\.obsidian-remote\/server'/);
+    const startCmd = execLog[4];
+    expect(startCmd).toMatch(/^nohup '\.obsidian-remote\/server'/);
+    expect(startCmd).toMatch(/--vault-root='\/srv\/vault'/);
+    expect(startCmd).toMatch(/--socket='\.obsidian-remote\/server\.sock'/);
+    expect(startCmd).toMatch(/--token-file='\.obsidian-remote\/token'/);
+    expect(startCmd).toMatch(/&$/);
+  });
+
+  it('skips the kill step when killExisting is false', async () => {
+    const { ssh, execLog } = fakeSsh({ onReadFile: () => Buffer.from('tok') });
+    await new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x', remoteVaultRoot: '/y',
+      killExisting: false, waitForTokenTimeoutMs: 100,
+    });
+    expect(execLog.some(c => c.includes('pkill'))).toBe(false);
+    expect(execLog.some(c => c.includes('rm -f'))).toBe(false);
+  });
+
+  it('honours custom remote paths', async () => {
+    const { ssh, execLog, uploads } = fakeSsh({ onReadFile: () => Buffer.from('tok') });
+    await new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x', remoteVaultRoot: '/y',
+      remoteBinaryPath: 'tools/orsd/bin',
+      remoteSocketPath: 'tools/orsd/sock',
+      remoteTokenPath:  'tools/orsd/tok',
+      waitForTokenTimeoutMs: 100,
+    });
+    expect(uploads[0].remote).toBe('tools/orsd/bin');
+    const start = execLog.find(c => c.startsWith('nohup'))!;
+    expect(start).toMatch(/--socket='tools\/orsd\/sock'/);
+    expect(start).toMatch(/--token-file='tools\/orsd\/tok'/);
+  });
+
+  it('quotes paths that contain spaces', async () => {
+    const { ssh, execLog, uploads } = fakeSsh({ onReadFile: () => Buffer.from('tok') });
+    await new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x',
+      remoteVaultRoot: '/has spaces/vault',
+      remoteBinaryPath: '/with space/server',
+      waitForTokenTimeoutMs: 100,
+    });
+    expect(uploads[0].remote).toBe('/with space/server');
+    const start = execLog.find(c => c.startsWith('nohup'))!;
+    // Single-quoted, so the shell sees it as one argv entry.
+    expect(start).toMatch(/--vault-root='\/has spaces\/vault'/);
+    expect(start).toMatch(/--socket='\.obsidian-remote\/server\.sock'/);
+  });
+
+  it('throws InternalError-shaped error if a non-tolerant command exits non-zero', async () => {
+    const { ssh } = fakeSsh({
+      onReadFile: () => Buffer.from(''),
+      onExec: (cmd) => cmd.includes('mkdir') ? { exitCode: 5, stderr: 'permission denied' } : { exitCode: 0 },
+    });
+    await expect(new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x', remoteVaultRoot: '/y',
+      waitForTokenTimeoutMs: 100,
+    })).rejects.toThrow(/exited 5/);
+  });
+
+  it('retries token reads until the daemon writes one, then returns it', async () => {
+    let calls = 0;
+    const { ssh } = fakeSsh({
+      onReadFile: () => {
+        calls += 1;
+        if (calls < 3) throw new Error('ENOENT');
+        return Buffer.from('eventually-arrived');
+      },
+    });
+    const out = await new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x', remoteVaultRoot: '/y',
+      waitForTokenTimeoutMs: 5000,
+    });
+    expect(out.token).toBe('eventually-arrived');
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  it('throws after the token-wait deadline if the daemon never came up', async () => {
+    const { ssh } = fakeSsh({
+      onReadFile: () => { throw new Error('ENOENT'); },
+    });
+    await expect(new ServerDeployer(ssh).deploy({
+      localBinaryPath: '/x', remoteVaultRoot: '/y',
+      waitForTokenTimeoutMs: 200,
+    })).rejects.toThrow(/did not write/);
+  });
+
+  it('stop() kills the daemon and cleans up socket + token', async () => {
+    const { ssh, execLog } = fakeSsh({ onReadFile: () => Buffer.from('') });
+    await new ServerDeployer(ssh).stop();
+    expect(execLog.length).toBe(2);
+    expect(execLog[0]).toMatch(/pkill -f '\.obsidian-remote\/server '/);
+    expect(execLog[1]).toMatch(/rm -f '\.obsidian-remote\/server\.sock' '\.obsidian-remote\/token'/);
+  });
+});


### PR DESCRIPTION
## Summary
The "Debug: test RPC tunnel" command now ships, restarts, and verifies the daemon end-to-end without any manual \`scp\` + \`nohup\` steps. The build pipeline grew an \`npm run build:server\` that cross-compiles the Go daemon for Linux/amd64 and stages it next to \`main.js\` so the plugin can find it at runtime.

## What's new

### \`ServerDeployer\` (\`plugin/src/transport/ServerDeployer.ts\`)
1. \`mkdir -p ~/.obsidian-remote && chmod 700\` it
2. \`pkill\` any prior daemon and \`rm -f\` stale socket / token files
3. SFTP-upload the local binary, \`chmod +x\` it
4. \`nohup\` the daemon with \`--vault-root\` / \`--socket\` / \`--token-file\` / \`--verbose\`, redirect stdout+stderr to \`~/.obsidian-remote/server.log\`, detach
5. Poll the token file for up to 5 s; return the token + paths

\`stop()\` is the inverse: \`pkill\` + cleanup. Built on a tiny \`DeployerSshClient\` interface so the unit tests don't have to bring up a real SSH session. \`shellQuote\` single-quotes every argument so paths with spaces survive the shell.

### \`SftpClient\`
- \`uploadFile(localPath, remotePath)\` — \`sftp.fastPut\` wrapper.
- \`exec(cmd)\` — one-shot command runner; collects stdout / stderr / exit. Used for mkdir / pkill / chmod / nohup. **Long-running streams must not go through here** (they'd never close).

### Build pipeline
- \`plugin/scripts/build-server.mjs\` cross-compiles \`./cmd/obsidian-remote-server\` (\`GOOS=linux GOARCH=amd64 CGO_ENABLED=0\`) and writes the result to \`plugin/server-bin/obsidian-remote-server-linux-amd64\`. Falls back to \`~/tools/go-portable/go\` on the dev box when \`go\` isn't on PATH. \`REMOTE_SSH_SKIP_SERVER_BUILD=1\` short-circuits for hosts without a Go toolchain.
- \`plugin/scripts/dev-install.mjs\` additionally copies \`plugin/server-bin/*\` into \`<vault>/.obsidian/plugins/remote-ssh/server-bin/\` so the plugin finds the binary at runtime.
- New npm scripts: \`build:server\`, \`build:full\` (server + plugin + install in one shot).
- Root \`.gitignore\` now excludes \`plugin/server-bin/\`.

### \`main.ts\`
- \`locateDaemonBinary()\` resolves \`<vault>/.obsidian/plugins/<id>/server-bin/obsidian-remote-server-linux-amd64\`; returns \`null\` when missing.
- \`debugTestRpcTunnel()\` now does the full flow: deploy → tunnel → handshake → smoke list, with a per-step trace in \`console.log\`.

### Tests
\`tests/ServerDeployer.test.ts\` (8 cases): order of \`mkdir → kill → upload → chmod → start → wait-for-token\`, \`killExisting=false\` skips the kill, custom remote paths flow into the start command, paths with spaces are single-quoted, non-zero exit on a non-tolerant command surfaces, token-read retries until present, deadline is enforced, \`stop()\` runs pkill + cleanup.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 123 / 123 pass (8 new)
- [x] \`cd plugin && npm run build:full\` — Go cross-compile (3.75 MiB) + plugin build + dev vault install all green; bundle 382 KB (+3 KB over #33)

## Dogfood (after merge)
1. \`cd plugin && npm run build:full\`
2. Reload the plugin in the dev vault.
3. Run "Connect to remote vault" against the Panza profile.
4. Run "Debug: test RPC tunnel against obsidian-remote-server".

Expect: a Notice with daemon version + entry count, and a per-step trace in \`console.log\`. **No manual \`scp\` / \`nohup\` steps.**

## Follow-ups
- **Phase 5-D.4**: switch \`SftpDataAdapter\`'s client over to \`RpcRemoteFsClient\` automatically when a profile carries an \`rpcSocketPath\`; SFTP path stays as fallback.
- Cross-arch staging (\`linux/arm64\`, \`darwin/*\`) for non-amd64 hosts.
- Wire \`ServerDeployer.stop\` into \`Plugin.disconnect\` so daemons don't outlive the Obsidian session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)