### PR TITLE
feat(plugin): per-profile RPC transport, auto-deployed on connect

### DIFF
--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -11,6 +11,7 @@ export const DEFAULT_PROFILE: Omit<SshProfile, 'id' | 'name'> = {
   connectTimeoutMs: 15000,
   keepaliveIntervalMs: 10000,
   keepaliveCountMax: 3,
+  transport: 'sftp',
 };
 
 export const DEFAULT_SETTINGS: PluginSettings = {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -48,6 +48,10 @@ export default class RemoteSshPlugin extends Plugin {
   private readCache: ReadCache | null = null;
   private dirCache: DirCache | null = null;
   private activeRemoteBasePath: string | null = null;
+  /** Authenticated daemon session, populated when the active profile uses transport='rpc'. */
+  private rpcConnection: Awaited<ReturnType<typeof establishRpcConnection>> | null = null;
+  /** ServerDeployer that owns the daemon process; invoked on disconnect to tear it down. */
+  private daemonDeployer: ServerDeployer | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -187,6 +191,26 @@ export default class RemoteSshPlugin extends Plugin {
       return;
     }
 
+    const transport = profile.transport ?? 'sftp';
+    let rpcSummary = '';
+    if (transport === 'rpc') {
+      try {
+        await this.startRpcSession(profile, effectivePath);
+        const caps = this.rpcConnection?.info.capabilities.length ?? 0;
+        const ver  = this.rpcConnection?.info.version ?? '?';
+        rpcSummary = ` — daemon ${ver}, ${caps} capabilities`;
+      } catch (e) {
+        // RPC startup failed; tear the SFTP session back down so the user
+        // can retry from a clean state instead of half-connected.
+        this.setState(SyncState.ERROR);
+        const msg = (e as Error).message;
+        logger.error(`RPC startup failed: ${msg}`);
+        new Notice(`Remote SSH: RPC startup failed — ${msg}`);
+        try { await this.client.disconnect(); } catch { /* ignore */ }
+        return;
+      }
+    }
+
     // Adapter is NOT patched on connect: Obsidian still has paths it expects
     // to read locally (`.obsidian/workspace.json`, plugin data, etc.) until
     // PathMapper (Phase 4-J0) can redirect those to a per-client subtree.
@@ -195,7 +219,50 @@ export default class RemoteSshPlugin extends Plugin {
     this.setState(SyncState.CONNECTED);
     this.settings.activeProfileId = profile.id;
     await this.saveSettings();
-    new Notice(`Remote SSH: Connected to ${profile.name} (adapter NOT patched — use "Debug: patch adapter" to opt in)`);
+    new Notice(
+      `Remote SSH: Connected to ${profile.name} via ${transport.toUpperCase()}${rpcSummary} ` +
+      `(adapter NOT patched — use "Debug: patch adapter" to opt in)`,
+    );
+  }
+
+  /**
+   * Auto-deploy the daemon binary, open a unix-socket Duplex, and run
+   * the framed `auth` + `server.info` handshake. On success
+   * `this.rpcConnection` and `this.daemonDeployer` are populated and
+   * the adapter patch flow can switch to the RPC transport.
+   *
+   * Throws on any step so callers can roll the SFTP session back.
+   */
+  private async startRpcSession(profile: SshProfile, effectivePath: string): Promise<void> {
+    const localBinaryPath = this.locateDaemonBinary();
+    if (!localBinaryPath) {
+      throw new Error(
+        'daemon binary not staged. Run `npm run build:server` (or `build:full`) and reload the plugin.',
+      );
+    }
+
+    const remoteBinaryPath = '.obsidian-remote/server';
+    const remoteSocketPath = profile.rpcSocketPath?.trim() || '.obsidian-remote/server.sock';
+    const remoteTokenPath  = profile.rpcTokenPath?.trim()  || '.obsidian-remote/token';
+
+    logger.info(`startRpcSession: deploying daemon to serve ${effectivePath}`);
+    const deployer = new ServerDeployer(this.client);
+    const deploy = await deployer.deploy({
+      localBinaryPath,
+      remoteBinaryPath,
+      remoteVaultRoot: effectivePath,
+      remoteSocketPath,
+      remoteTokenPath,
+    });
+    this.daemonDeployer = deployer;
+    logger.info(`startRpcSession: daemon up; token len=${deploy.token.length}`);
+
+    const stream = await this.client.openUnixStream(deploy.remoteSocketPath);
+    this.rpcConnection = await establishRpcConnection({ stream, token: deploy.token });
+    logger.info(
+      `startRpcSession: handshake complete; daemon ${this.rpcConnection.info.version} ` +
+      `(protocol v${this.rpcConnection.info.protocolVersion})`,
+    );
   }
 
   /**
@@ -210,6 +277,20 @@ export default class RemoteSshPlugin extends Plugin {
       || this.settings.activeProfileId !== null;
     this.restoreAdapter();
     this.activeRemoteBasePath = null;
+
+    // Close the RPC tunnel before stopping the daemon so the daemon
+    // sees a clean disconnect rather than a half-open socket.
+    if (this.rpcConnection) {
+      try { this.rpcConnection.close(); }
+      catch (e) { logger.warn(`rpcConnection.close: ${(e as Error).message}`); }
+      this.rpcConnection = null;
+    }
+    if (this.daemonDeployer && this.client?.isAlive()) {
+      try { await this.daemonDeployer.stop(); }
+      catch (e) { logger.warn(`daemon stop: ${(e as Error).message}`); }
+    }
+    this.daemonDeployer = null;
+
     if (this.client?.isAlive()) {
       try {
         await this.client.disconnect();
@@ -237,11 +318,14 @@ export default class RemoteSshPlugin extends Plugin {
     const targetAdapter = this.app.vault.adapter as unknown as object;
     this.readCache = new ReadCache();
     this.dirCache = new DirCache();
-    // Wrap the raw SftpClient in the RemoteFsClient adapter so the
-    // adapter itself stays transport-agnostic (Phase 5-D.2). The α
-    // path (RpcRemoteFsClient) will be plugged in here once
-    // SshTunnel lands.
-    const fsClient = new SftpRemoteFsClient(this.client);
+    // Pick the transport that matches the active session: when an
+    // RPC tunnel is up, route everything through the daemon; otherwise
+    // fall back to the direct-SFTP wrapper. The adapter itself is
+    // unaware of the choice — both clients implement RemoteFsClient.
+    const fsClient = this.rpcConnection
+      ? new RpcRemoteFsClient(this.rpcConnection.rpc)
+      : new SftpRemoteFsClient(this.client);
+    const transportLabel = this.rpcConnection ? 'RPC' : 'SFTP';
     this.dataAdapter = new SftpDataAdapter(
       fsClient,
       this.activeRemoteBasePath,
@@ -252,8 +336,8 @@ export default class RemoteSshPlugin extends Plugin {
     this.patcher = new AdapterPatcher(targetAdapter, this.dataAdapter);
     try {
       this.patcher.patch(PATCHED_METHODS as unknown as ReadonlyArray<keyof object & string>);
-      logger.info(`Adapter patched: [${PATCHED_METHODS.join(', ')}]`);
-      new Notice(`Remote SSH: adapter patched (${PATCHED_METHODS.join(', ')})`);
+      logger.info(`Adapter patched via ${transportLabel}: [${PATCHED_METHODS.join(', ')}]`);
+      new Notice(`Remote SSH: adapter patched via ${transportLabel} (${PATCHED_METHODS.length} methods)`);
     } catch (e) {
       logger.error(`Adapter patch failed: ${(e as Error).message}`);
       this.patcher = null;

--- a/plugin/src/settings/ProfileForm.ts
+++ b/plugin/src/settings/ProfileForm.ts
@@ -1,5 +1,5 @@
 import { Modal, App, Setting, Notice } from 'obsidian';
-import type { SshProfile, AuthMethod } from '../types';
+import type { SshProfile, AuthMethod, RemoteTransport } from '../types';
 import { DEFAULT_PROFILE } from '../constants';
 import { readSshConfig, type SshConfigEntry } from '../ssh/SshConfigReader';
 import * as crypto from 'crypto';
@@ -92,24 +92,33 @@ export class ProfileForm extends Modal {
       .addText(t => t.setPlaceholder('/home/user/vault').setValue(this.profile.remotePath)
         .onChange(v => { this.profile.remotePath = v; }));
 
-    contentEl.createEl('h3', { text: 'Remote daemon (experimental)' });
+    contentEl.createEl('h3', { text: 'Transport' });
     contentEl.createEl('p', {
       cls: 'setting-item-description',
       text:
-        'Optional: when obsidian-remote-server is running on the remote, fill these in to enable ' +
-        'the "Debug: test RPC tunnel" command. Auto-deploy of the binary lands in a later phase.',
+        'SFTP (default) talks SFTP directly. RPC auto-deploys obsidian-remote-server on connect ' +
+        'and routes filesystem operations through it — requires the server binary to have been ' +
+        'staged via `npm run build:server`.',
     });
 
     new Setting(contentEl)
+      .setName('Mode')
+      .addDropdown(d => d
+        .addOption('sftp', 'SFTP (direct)')
+        .addOption('rpc', 'RPC (obsidian-remote-server, α)')
+        .setValue(this.profile.transport ?? 'sftp')
+        .onChange(v => { this.profile.transport = v as RemoteTransport; }));
+
+    new Setting(contentEl)
       .setName('Daemon socket path')
-      .setDesc('e.g. .obsidian-remote/server.sock (home-relative is fine)')
+      .setDesc('Default: .obsidian-remote/server.sock (home-relative is fine). RPC mode only.')
       .addText(t => t.setPlaceholder('.obsidian-remote/server.sock')
         .setValue(this.profile.rpcSocketPath ?? '')
         .onChange(v => { this.profile.rpcSocketPath = v.trim() || undefined; }));
 
     new Setting(contentEl)
       .setName('Daemon token path')
-      .setDesc('Default: .obsidian-remote/token (home-relative)')
+      .setDesc('Default: .obsidian-remote/token (home-relative). RPC mode only.')
       .addText(t => t.setPlaceholder('.obsidian-remote/token')
         .setValue(this.profile.rpcTokenPath ?? '')
         .onChange(v => { this.profile.rpcTokenPath = v.trim() || undefined; }));

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -47,9 +47,13 @@ export class SettingsTab extends PluginSettingTab {
     const isActive = this.plugin.isConnected()
       && this.plugin.settings.activeProfileId === profile.id;
 
+    const transport = (profile.transport ?? 'sftp').toUpperCase();
     new Setting(containerEl)
       .setName(`${profile.name}`)
-      .setDesc(`${profile.username}@${profile.host}:${profile.port}  →  ${profile.remotePath}`)
+      .setDesc(
+        `${profile.username}@${profile.host}:${profile.port}  →  ${profile.remotePath}  ` +
+        `[${transport}]`,
+      )
       .addButton(btn => btn
         .setButtonText(isActive ? 'Disconnect' : 'Connect')
         .setCta()

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -1,5 +1,14 @@
 export type AuthMethod = 'password' | 'privateKey' | 'agent';
 
+/**
+ * Wire choice between the legacy direct-SFTP path and the α path
+ * (`obsidian-remote-server` daemon over a JSON-RPC tunnel). Default
+ * `'sftp'` matches what every existing profile already does; users
+ * opt in to `'rpc'` per profile when they want auto-deploy of the
+ * daemon at connect time.
+ */
+export type RemoteTransport = 'sftp' | 'rpc';
+
 export enum SyncState {
   IDLE       = 'idle',
   CONNECTING = 'connecting',
@@ -35,17 +44,20 @@ export interface SshProfile {
   jumpHost?: JumpHostConfig;
 
   /**
-   * α-path daemon socket on the remote host
-   * (e.g. `~/.obsidian-remote/server.sock`). When unset, the plugin's
-   * RPC debug command cannot run and the adapter stays on the direct
-   * SFTP path. Auto-populated by the upcoming server auto-deploy
-   * phase; for now the user fills it in by hand after starting
-   * `obsidian-remote-server` on the remote.
+   * Picks between the legacy direct-SFTP transport and the α path
+   * where the plugin auto-deploys `obsidian-remote-server` on
+   * connect and routes filesystem operations through it. Default
+   * `'sftp'` for backwards compatibility with existing profiles.
+   */
+  transport?: RemoteTransport;
+  /**
+   * α-path daemon socket on the remote host. Default
+   * `.obsidian-remote/server.sock` (home-relative).
    */
   rpcSocketPath?: string;
   /**
-   * Path on the remote host holding the session token the daemon
-   * writes at startup (default `~/.obsidian-remote/token`).
+   * α-path token file written by the daemon at startup. Default
+   * `.obsidian-remote/token`.
    */
   rpcTokenPath?: string;
 }


### PR DESCRIPTION
## Summary
Profiles gain a \`transport\` field (default \`'sftp'\`, new \`'rpc'\`). When \`'rpc'\` is picked, \`Connect\` now stages \`obsidian-remote-server\`, opens a unix-socket tunnel, runs the JSON-RPC handshake, and routes \`debugPatchAdapter\` through \`RpcRemoteFsClient\` automatically. No more "Debug: test RPC tunnel" required to exercise the α path.

## Connect flow when \`transport === 'rpc'\`
1. Open the SFTP session as before — same SSH session also carries the RPC tunnel and the daemon upload.
2. \`ServerDeployer.deploy(...)\` ships the binary, kills any prior daemon, starts the new one, waits for the token.
3. \`openssh_forwardOutStreamLocal\` to the daemon's unix socket.
4. \`establishRpcConnection\` runs \`auth → server.info\` and pins the protocol version.
5. \`RpcConnection\` + \`ServerDeployer\` are stored on the plugin instance for later use.

\`debugPatchAdapter\` picks \`RpcRemoteFsClient\` when an RPC tunnel is up and \`SftpRemoteFsClient\` otherwise. The Notice + console log line both name the active transport so it's obvious which backend is in play after a reload.

\`disconnect\` tears down in the right order:
\`\`\`
RpcConnection.close → ServerDeployer.stop → SftpClient.disconnect
\`\`\`
The framed channel closes cleanly before the daemon is killed; \`stop()\` then removes the socket + token files so the next deploy starts from scratch.

Connect-time RPC failures (binary missing, deploy error, handshake fail) immediately roll the SFTP session back so the user retries from a clean state, never half-connected.

## UI
- **ProfileForm**: \`Transport\` section with a dropdown (\`SFTP (direct)\` / \`RPC (obsidian-remote-server, α)\`) ahead of the daemon-path inputs (now flagged as "RPC mode only").
- **SettingsTab**: every profile row's description ends with \`[SFTP]\` or \`[RPC]\` so the active mode is visible at a glance.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 123 / 123 still pass
- [x] \`cd plugin && npm run build:full\` — all green; bundle 385 KB (+2 KB)

## Dogfood (after merge)
1. \`cd plugin && npm run build:full\`
2. Reload the plugin in the dev vault.
3. Edit the Panza profile → set **Transport = "RPC (obsidian-remote-server, α)"**.
4. \`Connect to remote vault\`. Expect Notice: \`Connected ... via RPC — daemon 0.0.0-dev, N capabilities\`.
5. \`Debug: patch adapter\`. Expect Notice: \`adapter patched via RPC\`.
6. \`Debug: list vault root via current adapter\` — should show entries from \`work/VaultDev\` via the daemon (the label still reads "PATCHED (SFTP)"; that just means the patcher is live, not that the SFTP path is in use — see follow-ups).
7. \`Disconnect\` — the daemon process on Panza is gone and the socket / token files are removed.

## Follow-ups
- Phase 5-D.6: align the debug label and state enum so the transport in use is reflected end-to-end (the "PATCHED (SFTP)" string is now misleading when the RPC path is active).
- \`ServerDeployer.stop\` should also be called from \`onunload\` when the plugin is hot-reloaded mid-session.
- Cross-arch staging (\`linux/arm64\`, \`darwin/*\`) for non-amd64 hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)