### PR TITLE
feat(plugin): per-client path mapping (PathMapper)

### DIFF
--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -2,6 +2,8 @@ import type { DataWriteOptions, ListedFiles, Stat } from 'obsidian';
 import type { RemoteFsClient } from './RemoteFsClient';
 import type { ReadCache } from '../cache/ReadCache';
 import type { DirCache } from '../cache/DirCache';
+import type { PathMapper } from '../path/PathMapper';
+import type { RemoteEntry } from '../types';
 import { logger } from '../util/logger';
 
 /**
@@ -35,6 +37,14 @@ export class SftpDataAdapter {
     private readCache: ReadCache,
     private dirCache: DirCache,
     private vaultName: string,
+    /**
+     * Optional per-client path remapping. When supplied, paths matching
+     * the mapper's "private" patterns (e.g. `.obsidian/workspace.json`)
+     * are redirected into a per-client subtree on the remote so two
+     * machines on the same vault don't clobber each other's UI state.
+     * Phase 4-J0.
+     */
+    private pathMapper: PathMapper | null = null,
   ) {}
 
   // ─── DataAdapter (read-side) ─────────────────────────────────────────────
@@ -64,21 +74,69 @@ export class SftpDataAdapter {
   }
 
   async list(normalizedPath: string): Promise<ListedFiles> {
-    const remote = this.toRemote(normalizedPath);
-    let entries = this.dirCache.get(remote);
-    if (!entries) {
-      entries = await this.client.list(remote);
-      this.dirCache.put(remote, entries);
+    const plan = this.planList(normalizedPath);
+    const primaryRemote = this.joinRemote(plan.primary);
+
+    let primaryEntries = this.dirCache.get(primaryRemote);
+    if (!primaryEntries) {
+      primaryEntries = await this.client.list(primaryRemote);
+      this.dirCache.put(primaryRemote, primaryEntries);
     }
+    if (plan.hideUserDirName) {
+      primaryEntries = primaryEntries.filter(e => e.name !== plan.hideUserDirName);
+    }
+
+    let userEntries: RemoteEntry[] = [];
+    if (plan.mergeFromUser && plan.userSubtree) {
+      const userRemote = this.joinRemote(plan.userSubtree);
+      let cached = this.dirCache.get(userRemote);
+      if (!cached) {
+        try {
+          cached = await this.client.list(userRemote);
+          this.dirCache.put(userRemote, cached);
+        } catch {
+          // The per-client subtree doesn't exist yet — that's fine on
+          // first connect, no entries to merge.
+          cached = [];
+        }
+      }
+      userEntries = cached;
+    }
+
     const files: string[] = [];
     const folders: string[] = [];
     const prefix = normalizedPath ? normalizedPath + '/' : '';
-    for (const e of entries) {
-      const childPath = prefix + e.name;
-      if (e.isDirectory) folders.push(childPath);
+    const seen = new Set<string>();
+    const emit = (entry: RemoteEntry) => {
+      if (seen.has(entry.name)) return;
+      seen.add(entry.name);
+      const childPath = prefix + entry.name;
+      if (entry.isDirectory) folders.push(childPath);
       else files.push(childPath);
-    }
+    };
+    // The user-subtree entries take precedence — their names always
+    // appear in the merged listing, even if a same-named placeholder
+    // somehow exists in the primary listing.
+    for (const e of userEntries) emit(e);
+    for (const e of primaryEntries) emit(e);
     return { files, folders };
+  }
+
+  /**
+   * Wrapper that lets the test suite see what the path mapper
+   * decided about a given list request without going through a real
+   * RemoteFsClient.
+   */
+  planList(normalizedPath: string): {
+    primary: string;
+    mergeFromUser: boolean;
+    userSubtree?: string;
+    hideUserDirName?: string;
+  } {
+    if (this.pathMapper) {
+      return this.pathMapper.resolveListing(normalizedPath);
+    }
+    return { primary: normalizedPath, mergeFromUser: false };
   }
 
   async read(normalizedPath: string): Promise<string> {
@@ -265,11 +323,28 @@ export class SftpDataAdapter {
     this.dirCache.invalidate(parent);
   }
 
+  /**
+   * Resolve a vault-relative path to the absolute path on the remote.
+   *
+   * If a PathMapper is attached, private vault paths are first
+   * redirected into the per-client subtree (`.obsidian/workspace.json`
+   * → `.obsidian/user/<id>/workspace.json`) so two machines on the
+   * same vault don't trample each other's UI state. The mapped result
+   * is then joined with `remoteBasePath` to form the full path the
+   * `RemoteFsClient` sees.
+   */
   toRemote(normalizedPath: string): string {
-    if (!normalizedPath || normalizedPath === '/') return this.remoteBasePath;
-    if (this.remoteBasePath === '') return normalizedPath;
-    if (this.remoteBasePath === '/') return '/' + normalizedPath;
-    return `${this.remoteBasePath}/${normalizedPath}`;
+    const mapped = this.pathMapper
+      ? this.pathMapper.toRemote(normalizedPath)
+      : normalizedPath;
+    return this.joinRemote(mapped);
+  }
+
+  private joinRemote(vaultRelative: string): string {
+    if (!vaultRelative || vaultRelative === '/') return this.remoteBasePath;
+    if (this.remoteBasePath === '') return vaultRelative;
+    if (this.remoteBasePath === '/') return '/' + vaultRelative;
+    return `${this.remoteBasePath}/${vaultRelative}`;
   }
 }
 

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -14,6 +14,7 @@ import { SftpRemoteFsClient } from './adapter/SftpRemoteFsClient';
 import { RpcRemoteFsClient } from './adapter/RpcRemoteFsClient';
 import { establishRpcConnection } from './transport/RpcConnection';
 import { ServerDeployer } from './transport/ServerDeployer';
+import { PathMapper, defaultClientId } from './path/PathMapper';
 import * as fs from 'fs';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
@@ -326,12 +327,20 @@ export default class RemoteSshPlugin extends Plugin {
       ? new RpcRemoteFsClient(this.rpcConnection.rpc)
       : new SftpRemoteFsClient(this.client);
     const transportLabel = this.rpcConnection ? 'RPC' : 'SFTP';
+    // Per-client path remapping: client-private files like
+    // .obsidian/workspace.json get redirected into a per-client subtree
+    // on the remote so two machines on the same vault don't trample
+    // each other's UI state. Phase 4-J0.
+    const clientId = defaultClientId();
+    const mapper = new PathMapper(clientId);
+    logger.info(`PathMapper: clientId="${clientId}"`);
     this.dataAdapter = new SftpDataAdapter(
       fsClient,
       this.activeRemoteBasePath,
       this.readCache,
       this.dirCache,
       this.app.vault.getName(),
+      mapper,
     );
     this.patcher = new AdapterPatcher(targetAdapter, this.dataAdapter);
     try {

--- a/plugin/src/path/PathMapper.ts
+++ b/plugin/src/path/PathMapper.ts
@@ -1,0 +1,181 @@
+import * as os from 'os';
+
+/**
+ * Vault-relative paths that hold *client-private* state and must not be
+ * shared across machines. They get redirected from `.obsidian/<file>`
+ * to `.obsidian/user/<client-id>/<file>` on the remote so two clients
+ * can sit on the same vault without trampling each other's UI state.
+ *
+ * The list errs on the side of "private" because nothing here costs
+ * the user anything to keep per-machine, and the alternatives
+ * (corrupted layout files, conflicting graph views) are loud failures.
+ *
+ * Patterns are matched as either an exact vault-relative path or a
+ * directory prefix (so `.obsidian/cache` covers everything inside).
+ */
+export const DEFAULT_PRIVATE_PATTERNS: readonly string[] = [
+  '.obsidian/workspace.json',
+  '.obsidian/workspace-mobile.json',
+  '.obsidian/cache',
+  '.obsidian/cache.zlib',
+  '.obsidian/types.json',
+  '.obsidian/file-recovery.json',
+  '.obsidian/graph.json',
+  '.obsidian/canvas.json',
+];
+
+/**
+ * The single directory under `.obsidian/` that we own for per-client
+ * subtrees. Listing `.obsidian/` strips this so other clients' state
+ * never appears in the vault's UI.
+ */
+const PRIVATE_ROOT = '.obsidian/user';
+
+/**
+ * Sanitize a hostname into something safe to use as a directory name.
+ * Keeps ASCII alphanumerics, dots, hyphens, underscores. Replaces
+ * everything else with `-`. Empty input yields `'unknown'`.
+ */
+export function sanitizeClientId(raw: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned || 'unknown';
+}
+
+/**
+ * Returns a stable client id derived from the OS hostname. Designed
+ * for the single-machine common case; multi-instance setups should
+ * pass an explicit override to the PathMapper constructor.
+ */
+export function defaultClientId(): string {
+  try {
+    return sanitizeClientId(os.hostname());
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * PathMapper translates between the vault-relative paths Obsidian uses
+ * and the actual paths we store on the remote. The mapping is the
+ * identity for ordinary vault content; only `.obsidian/*` files
+ * matched by `DEFAULT_PRIVATE_PATTERNS` (or a caller-supplied
+ * extension) are redirected into a per-client subtree.
+ *
+ * The class is stateless apart from its configuration, so a single
+ * instance can serve every adapter call without locking.
+ */
+export class PathMapper {
+  private readonly privateRoot: string;
+  private readonly privatePatterns: readonly string[];
+
+  constructor(
+    public readonly clientId: string,
+    privatePatterns: readonly string[] = DEFAULT_PRIVATE_PATTERNS,
+  ) {
+    this.privateRoot = `${PRIVATE_ROOT}/${clientId}`;
+    this.privatePatterns = privatePatterns;
+  }
+
+  // ─── classification ──────────────────────────────────────────────────────
+
+  /** True when the vault-relative path should live in this client's private subtree. */
+  isPrivate(vaultPath: string): boolean {
+    const normalized = stripLeadingSlash(vaultPath);
+    return this.privatePatterns.some(p => normalized === p || normalized.startsWith(p + '/'));
+  }
+
+  /**
+   * True when the path is the parent of one or more private patterns
+   * but not itself private. Listing such a path needs to be merged
+   * with this client's private subtree so the patterns appear under
+   * their nominal names.
+   *
+   * In practice the only such path today is `.obsidian/` itself.
+   */
+  isCrossingPoint(vaultPath: string): boolean {
+    const normalized = stripLeadingSlash(vaultPath);
+    if (this.isPrivate(normalized)) return false;
+    return this.privatePatterns.some(p => parentDirOf(p) === normalized);
+  }
+
+  // ─── translation ─────────────────────────────────────────────────────────
+
+  /**
+   * Convert a vault-relative path to the path that should be sent to
+   * the remote. Identity for non-private paths; redirects private
+   * paths into the per-client subtree.
+   *
+   * Custom patterns are expected to live under `.obsidian/` so the
+   * redirect lands inside the per-client subtree cleanly; a pattern
+   * outside that prefix is accepted but its full original path is
+   * appended verbatim (so `.foo` becomes `.obsidian/user/<id>/.foo`).
+   */
+  toRemote(vaultPath: string): string {
+    const normalized = stripLeadingSlash(vaultPath);
+    if (!this.isPrivate(normalized)) return vaultPath;
+    const rest = normalized.startsWith('.obsidian/')
+      ? normalized.slice('.obsidian/'.length)
+      : normalized;
+    return `${this.privateRoot}/${rest}`;
+  }
+
+  /**
+   * Inverse: take a path that came back from the remote (e.g. an
+   * entry name during a list merge) and convert it back to the path
+   * Obsidian thinks it's reading. Foreign clients' subtrees are
+   * preserved unchanged so callers can decide whether to filter them.
+   */
+  toVault(remotePath: string): string {
+    const prefix = `${this.privateRoot}/`;
+    if (remotePath.startsWith(prefix)) {
+      return `.obsidian/${remotePath.slice(prefix.length)}`;
+    }
+    return remotePath;
+  }
+
+  // ─── listing helpers ─────────────────────────────────────────────────────
+
+  /**
+   * Plan a `list(vaultPath)` execution.
+   *
+   * The returned `primary` is always queried. When `mergeFromUser` is
+   * true the caller should also list `userSubtree` and concatenate;
+   * `hideUserDirName`, when set, names a directory entry that should
+   * be dropped from the primary listing (the "user" sibling under
+   * `.obsidian/`).
+   */
+  resolveListing(vaultPath: string): {
+    primary: string;
+    mergeFromUser: boolean;
+    userSubtree?: string;
+    hideUserDirName?: string;
+  } {
+    const normalized = stripLeadingSlash(vaultPath);
+    if (this.isPrivate(normalized)) {
+      // The whole subtree lives in user/<id>/...
+      return { primary: this.toRemote(vaultPath), mergeFromUser: false };
+    }
+    if (this.isCrossingPoint(normalized)) {
+      return {
+        primary: vaultPath,
+        mergeFromUser: true,
+        userSubtree: this.privateRoot,
+        // Hide the `user` directory entry from the primary listing so
+        // other clients' subtrees never surface.
+        hideUserDirName: 'user',
+      };
+    }
+    return { primary: vaultPath, mergeFromUser: false };
+  }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+function stripLeadingSlash(p: string): string {
+  return p.startsWith('/') ? p.slice(1) : p;
+}
+
+function parentDirOf(p: string): string {
+  const i = p.lastIndexOf('/');
+  return i < 0 ? '' : p.slice(0, i);
+}

--- a/plugin/tests/PathMapper.test.ts
+++ b/plugin/tests/PathMapper.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import { PathMapper, sanitizeClientId, DEFAULT_PRIVATE_PATTERNS } from '../src/path/PathMapper';
+
+const ID = 'host-a';
+
+describe('sanitizeClientId', () => {
+  it('passes through ASCII alphanumerics + dot/hyphen/underscore', () => {
+    expect(sanitizeClientId('GERMI')).toBe('GERMI');
+    expect(sanitizeClientId('node-1.local_2')).toBe('node-1.local_2');
+  });
+
+  it('replaces unsafe characters with hyphen and trims them at the edges', () => {
+    expect(sanitizeClientId('host with spaces')).toBe('host-with-spaces');
+    expect(sanitizeClientId('!!evil!!')).toBe('evil');
+  });
+
+  it('falls back to "unknown" when the input is empty after sanitisation', () => {
+    expect(sanitizeClientId('')).toBe('unknown');
+    expect(sanitizeClientId('!!!')).toBe('unknown');
+  });
+});
+
+describe('PathMapper.isPrivate', () => {
+  const m = new PathMapper(ID);
+
+  it('matches the canonical private files', () => {
+    expect(m.isPrivate('.obsidian/workspace.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/cache.zlib')).toBe(true);
+    expect(m.isPrivate('.obsidian/types.json')).toBe(true);
+  });
+
+  it('matches inside a private directory pattern', () => {
+    expect(m.isPrivate('.obsidian/cache/index')).toBe(true);
+    expect(m.isPrivate('.obsidian/cache/sub/x.bin')).toBe(true);
+  });
+
+  it('rejects sibling paths that share a prefix', () => {
+    expect(m.isPrivate('.obsidian/cache.zlib2')).toBe(false);
+    expect(m.isPrivate('.obsidian/workspace.json.bak')).toBe(false);
+  });
+
+  it('rejects regular vault content', () => {
+    expect(m.isPrivate('Notes/foo.md')).toBe(false);
+    expect(m.isPrivate('.obsidian/hotkeys.json')).toBe(false);
+    expect(m.isPrivate('.obsidian/plugins/myplugin/data.json')).toBe(false);
+  });
+
+  it('tolerates a leading slash on the input', () => {
+    expect(m.isPrivate('/.obsidian/workspace.json')).toBe(true);
+  });
+});
+
+describe('PathMapper.isCrossingPoint', () => {
+  it('flags `.obsidian/` because every private pattern lives directly under it', () => {
+    const m = new PathMapper(ID);
+    expect(m.isCrossingPoint('.obsidian')).toBe(true);
+  });
+
+  it('does not flag the private dirs themselves (those are private, not crossing)', () => {
+    const m = new PathMapper(ID);
+    expect(m.isCrossingPoint('.obsidian/cache')).toBe(false);
+    expect(m.isCrossingPoint('.obsidian/workspace.json')).toBe(false);
+  });
+
+  it('does not flag unrelated parents', () => {
+    const m = new PathMapper(ID);
+    expect(m.isCrossingPoint('Notes')).toBe(false);
+    expect(m.isCrossingPoint('')).toBe(false);
+  });
+});
+
+describe('PathMapper.toRemote / toVault', () => {
+  const m = new PathMapper(ID);
+
+  it('redirects private files into the per-client subtree', () => {
+    expect(m.toRemote('.obsidian/workspace.json'))
+      .toBe('.obsidian/user/host-a/workspace.json');
+    expect(m.toRemote('.obsidian/cache/foo.bin'))
+      .toBe('.obsidian/user/host-a/cache/foo.bin');
+  });
+
+  it('passes non-private paths through unchanged', () => {
+    expect(m.toRemote('Notes/foo.md')).toBe('Notes/foo.md');
+    expect(m.toRemote('.obsidian/hotkeys.json')).toBe('.obsidian/hotkeys.json');
+    expect(m.toRemote('.obsidian')).toBe('.obsidian');
+  });
+
+  it('toVault inverts a redirected path back to its vault-relative form', () => {
+    expect(m.toVault('.obsidian/user/host-a/workspace.json'))
+      .toBe('.obsidian/workspace.json');
+    expect(m.toVault('.obsidian/user/host-a/cache/foo.bin'))
+      .toBe('.obsidian/cache/foo.bin');
+  });
+
+  it('leaves another client\'s subtree alone (so the caller can filter it out)', () => {
+    expect(m.toVault('.obsidian/user/host-b/workspace.json'))
+      .toBe('.obsidian/user/host-b/workspace.json');
+  });
+
+  it('uses the configured client id for the redirect prefix', () => {
+    const other = new PathMapper('SomeBox');
+    expect(other.toRemote('.obsidian/workspace.json'))
+      .toBe('.obsidian/user/SomeBox/workspace.json');
+  });
+});
+
+describe('PathMapper.resolveListing', () => {
+  const m = new PathMapper(ID);
+
+  it('asks the caller to merge `.obsidian` with the user subtree, hiding the user/ dir', () => {
+    const r = m.resolveListing('.obsidian');
+    expect(r.primary).toBe('.obsidian');
+    expect(r.mergeFromUser).toBe(true);
+    expect(r.userSubtree).toBe('.obsidian/user/host-a');
+    expect(r.hideUserDirName).toBe('user');
+  });
+
+  it('redirects a list of a private directory entirely', () => {
+    const r = m.resolveListing('.obsidian/cache');
+    expect(r.primary).toBe('.obsidian/user/host-a/cache');
+    expect(r.mergeFromUser).toBe(false);
+  });
+
+  it('passes ordinary listings through', () => {
+    const r = m.resolveListing('Notes');
+    expect(r.primary).toBe('Notes');
+    expect(r.mergeFromUser).toBe(false);
+  });
+
+  it('passes `.obsidian/plugins` through unmerged (not a crossing point under default patterns)', () => {
+    const r = m.resolveListing('.obsidian/plugins');
+    expect(r.primary).toBe('.obsidian/plugins');
+    expect(r.mergeFromUser).toBe(false);
+  });
+});
+
+describe('PathMapper with custom patterns', () => {
+  it('respects caller-supplied private patterns instead of the defaults', () => {
+    // Patterns must live under .obsidian/ so they redirect cleanly into the
+    // per-client subtree; this test extends the list with a hypothetical
+    // graph-experimental.json that ships with a future Obsidian version.
+    const m = new PathMapper(ID, ['.obsidian/graph-experimental.json']);
+    expect(m.isPrivate('.obsidian/graph-experimental.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/workspace.json')).toBe(false); // not in custom list
+    expect(m.toRemote('.obsidian/graph-experimental.json'))
+      .toBe('.obsidian/user/host-a/graph-experimental.json');
+  });
+
+  it('exports a stable default pattern list', () => {
+    expect(DEFAULT_PRIVATE_PATTERNS).toContain('.obsidian/workspace.json');
+    expect(DEFAULT_PRIVATE_PATTERNS).toContain('.obsidian/cache');
+  });
+});

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { SftpDataAdapter } from '../src/adapter/SftpDataAdapter';
 import { ReadCache } from '../src/cache/ReadCache';
 import { DirCache } from '../src/cache/DirCache';
+import { PathMapper } from '../src/path/PathMapper';
 import type { RemoteEntry, RemoteStat } from '../src/types';
 
 /** Minimal stand-in for SftpClient covering both read- and write-side calls. */
@@ -491,6 +492,117 @@ describe('SftpDataAdapter (read-side)', () => {
       await adapter.trashLocal('note.md');
       expect('/v/note.md' in fake.files).toBe(false);
       expect(fake.files['/v/.trash/note.md'].data.toString('utf8')).toBe('bye');
+    });
+  });
+
+  // ─── PathMapper integration ───────────────────────────────────────────────
+  //
+  // These tests confirm that when an adapter is constructed with a
+  // PathMapper, vault-relative reads/writes/lists for client-private
+  // paths land in the per-client subtree on the remote, while ordinary
+  // vault content (and shared `.obsidian/*` files) go to their nominal
+  // locations unchanged.
+
+  describe('with PathMapper', () => {
+    it('redirects writes for private vault paths into .obsidian/user/<id>/', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+
+      await adapter.write('.obsidian/workspace.json', '{"open":[]}');
+      // The remote sees the per-client subtree, not the bare path.
+      expect('/v/.obsidian/workspace.json' in fake.files).toBe(false);
+      expect(fake.files['/v/.obsidian/user/host-a/workspace.json'].data.toString('utf8'))
+        .toBe('{"open":[]}');
+    });
+
+    it('reads private paths from the per-client subtree', async () => {
+      const fake = makeFakeClient({
+        files: {
+          '/v/.obsidian/user/host-a/workspace.json': { data: Buffer.from('{"a":1}'), mtime: 1 },
+        },
+        dirs: { '/v': [], '/v/.obsidian': [], '/v/.obsidian/user': [], '/v/.obsidian/user/host-a': [] },
+      });
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+
+      await expect(adapter.read('.obsidian/workspace.json')).resolves.toBe('{"a":1}');
+    });
+
+    it('passes non-private paths through to their nominal remote locations', async () => {
+      const fake = makeFakeClient({ dirs: { '/v': [] } });
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+
+      await adapter.write('Notes/foo.md', '# Hello');
+      expect(fake.files['/v/Notes/foo.md'].data.toString('utf8')).toBe('# Hello');
+      // Definitely not redirected.
+      expect(Object.keys(fake.files).some(k => k.includes('user/host-a/Notes'))).toBe(false);
+    });
+
+    it('list(".obsidian") merges shared and per-client entries, hiding the user/ dir', async () => {
+      const fake = makeFakeClient({
+        files: {
+          '/v/.obsidian/hotkeys.json': { data: Buffer.from('{}'), mtime: 1 },
+          '/v/.obsidian/user/host-a/workspace.json': { data: Buffer.from('{}'), mtime: 1 },
+        },
+        dirs: {
+          '/v': [],
+          // Shared .obsidian (hotkeys.json + a plugins dir + the user-subtree dir)
+          '/v/.obsidian': [
+            { name: 'hotkeys.json', isFile: true, isDirectory: false, isSymbolicLink: false, mtime: 1, size: 2 },
+            { name: 'plugins',      isFile: false, isDirectory: true, isSymbolicLink: false, mtime: 1, size: 0 },
+            { name: 'user',         isFile: false, isDirectory: true, isSymbolicLink: false, mtime: 1, size: 0 },
+          ],
+          '/v/.obsidian/plugins': [],
+          '/v/.obsidian/user': [
+            { name: 'host-a', isFile: false, isDirectory: true, isSymbolicLink: false, mtime: 1, size: 0 },
+          ],
+          '/v/.obsidian/user/host-a': [
+            { name: 'workspace.json', isFile: true, isDirectory: false, isSymbolicLink: false, mtime: 1, size: 2 },
+          ],
+        },
+      });
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+
+      const out = await adapter.list('.obsidian');
+      // The `user/` directory is hidden; both private and shared
+      // children appear under their nominal `.obsidian/...` paths.
+      expect(out.folders.sort()).toEqual(['.obsidian/plugins']);
+      expect(out.files.sort()).toEqual(['.obsidian/hotkeys.json', '.obsidian/workspace.json']);
+    });
+
+    it('list of a fully-private directory walks the per-client subtree', async () => {
+      const fake = makeFakeClient({
+        dirs: {
+          '/v': [],
+          '/v/.obsidian/user/host-a/cache': [
+            { name: 'index.bin', isFile: true, isDirectory: false, isSymbolicLink: false, mtime: 1, size: 0 },
+          ],
+        },
+      });
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+
+      const out = await adapter.list('.obsidian/cache');
+      expect(out.files).toEqual(['.obsidian/cache/index.bin']);
+      expect(out.folders).toEqual([]);
+    });
+
+    it('toRemote on a private path returns the per-client absolute path', () => {
+      const fake = makeFakeClient();
+      const adapter = new SftpDataAdapter(
+        fake.client, '/v', readCache, dirCache, 'v', new PathMapper('host-a'),
+      );
+      expect(adapter.toRemote('.obsidian/workspace.json'))
+        .toBe('/v/.obsidian/user/host-a/workspace.json');
+      expect(adapter.toRemote('Notes/x.md')).toBe('/v/Notes/x.md');
     });
   });
 });


### PR DESCRIPTION
## Summary
Vault-relative paths matching \`.obsidian/workspace.json\`, \`.obsidian/cache\`, \`.obsidian/types.json\`, etc. are redirected into a per-client subtree on the remote (\`.obsidian/user/<client-id>/...\`) so two machines on the same vault don't trample each other's UI state. The client id defaults to a sanitized OS hostname; multi-instance setups can override later via a settings field (TBD).

## What's new

### \`src/path/PathMapper.ts\`
- \`DEFAULT_PRIVATE_PATTERNS\`: \`workspace.json\`, \`workspace-mobile.json\`, \`cache\`, \`cache.zlib\`, \`types.json\`, \`file-recovery.json\`, \`graph.json\`, \`canvas.json\`. Errors on the side of "private" — the cost of an unnecessary per-machine copy is low; the cost of a shared \`workspace.json\` being clobbered is loud.
- \`isPrivate(path)\` — exact match or directory-prefix match against the patterns; tolerates a leading slash on input.
- \`isCrossingPoint(path)\` — true when \`path\` is the parent of one or more private patterns but not itself private. Today this matches exactly \`.obsidian\`; listing it requires merging shared remote \`.obsidian/\` with the per-client subtree.
- \`toRemote\` / \`toVault\` — round-trip translation. Foreign clients' subtrees are preserved unchanged on the way back so the caller can decide whether to filter them out.
- \`resolveListing(path)\` — planning helper for \`list()\` that returns \`{ primary, mergeFromUser, userSubtree?, hideUserDirName? }\`.
- \`defaultClientId()\` / \`sanitizeClientId()\` — hostname-based id with unsafe characters replaced by hyphens; falls back to \`"unknown"\`.

### \`src/adapter/SftpDataAdapter.ts\`
- Optional 6th constructor param \`pathMapper\`. When supplied, \`toRemote()\` first runs the vault path through the mapper, then joins with \`remoteBasePath\` as before. A new private \`joinRemote\` exposes the join-only step for the listing planner.
- \`list()\` consults the mapper's \`resolveListing(...)\` plan: it always lists the primary path (and prunes the \`user/\` directory on a crossing-point listing), then optionally lists the user subtree and merges the entries. User-subtree entries take precedence on name conflicts so private files always show up under their nominal \`.obsidian/...\` name.
- A small \`planList(path)\` shim exists so adapter tests can see what the mapper decided without going through a real \`RemoteFsClient\`.

### \`src/main.ts\`
- \`debugPatchAdapter\` now constructs a \`PathMapper\` with \`defaultClientId\` and passes it to the adapter on every patch. The clientId is logged so diagnostics in \`console.log\` show which subtree the current session writes into.

## Tests
- \`tests/PathMapper.test.ts\` (22 cases): isPrivate matching including prefix/sibling distinction, isCrossingPoint, toRemote/toVault round-trip, foreign-client subtree pass-through, resolveListing for \`.obsidian\` (merge with hidden \`user/\`), private-dir redirection, ordinary path pass-through, custom-pattern override, and \`sanitizeClientId\` for the canonical cases.
- \`tests/SftpDataAdapter.test.ts\` grew a "with PathMapper" describe block (6 cases): writes to private paths land in the per-client subtree, reads come back from there, non-private vault content is not redirected, \`.obsidian\` listing merges shared + per-client while hiding the \`user/\` dir, a private-directory listing walks the per-client subtree, and \`toRemote\` returns the full \`<base>/.obsidian/user/<id>/...\` path.

## Verification
- [x] \`cd plugin && npx tsc --noEmit\` clean
- [x] \`cd plugin && npm test\` — 151 / 151 pass (28 new)
- [x] \`cd plugin && npm run build:full\` — all green; bundle 386 KB (+1 KB over #35)

## Dogfood (after merge)
1. \`cd plugin && npm run build:full\`
2. Reload the plugin in the dev vault.
3. Connect to Panza.
4. \`Debug: patch adapter\` — \`console.log\` should now include \`PathMapper: clientId="<host>"\` ahead of the patch line.
5. Open a note via Obsidian → \`work/VaultDev/<file>\` is read through the daemon.
6. Trigger a workspace save (e.g. open / close a tab) → \`work/VaultDev/.obsidian/user/<host>/workspace.json\` materialises on the remote, while \`.obsidian/hotkeys.json\` (when present) stays at \`.obsidian/hotkeys.json\`.

## Follow-ups
- Settings field for an explicit clientId override.
- Bootstrap: seed the per-client subtree from the local \`.obsidian/\` skeleton so the first \`workspace.json\` read after patch doesn't fail with \`FileNotFound\`.
- Phase 5-E: \`fs.watch\` push events. Phase 5-F: \`getResourcePath\` HTTP bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)