### PR TITLE
feat(server): fs.watch / fs.unwatch + push notifications

### DIFF
--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/handlers"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/watcher"
 )
 
 // Version is replaced at link time via -ldflags "-X main.Version=...".
@@ -103,11 +104,22 @@ func run(args []string) (int, error) {
 		logger.Warn("chmod socket", "err", err.Error())
 	}
 
+	// Vault watcher: a single fsnotify watcher subscribes to the
+	// whole tree and dispatches events to per-session callbacks.
+	// Built before the Server so the SubscriptionCleaner can drop
+	// orphan subscriptions when connections close.
+	vaultWatcher, err := watcher.New(absRoot)
+	if err != nil {
+		return 1, fmt.Errorf("watcher: %w", err)
+	}
+	defer func() { _ = vaultWatcher.Close() }()
+
 	srv := server.New(server.Options{
-		Token:     token,
-		VaultRoot: absRoot,
-		Version:   Version,
-		Logger:    logger,
+		Token:               token,
+		VaultRoot:           absRoot,
+		Version:             Version,
+		Logger:              logger,
+		SubscriptionCleaner: watcherCleaner{vaultWatcher},
 	})
 	disp := srv.Dispatcher()
 	disp.Handle("auth", handlers.Auth(token))
@@ -130,6 +142,9 @@ func run(args []string) (int, error) {
 	disp.Handle("fs.rename", handlers.RequireAuth(handlers.FsRename(absRoot)))
 	disp.Handle("fs.copy", handlers.RequireAuth(handlers.FsCopy(absRoot)))
 	disp.Handle("fs.trashLocal", handlers.RequireAuth(handlers.FsTrashLocal(absRoot)))
+	// Watch side.
+	disp.Handle("fs.watch", handlers.RequireAuth(handlers.FsWatch(vaultWatcher)))
+	disp.Handle("fs.unwatch", handlers.RequireAuth(handlers.FsUnwatch(vaultWatcher)))
 
 	// Wire signal-driven shutdown: closing the listener unwinds Serve.
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -157,4 +172,19 @@ func defaultStateDir() (string, error) {
 		return "", fmt.Errorf("home dir: %w", err)
 	}
 	return filepath.Join(home, ".obsidian-remote"), nil
+}
+
+// watcherCleaner adapts watcher.Watcher to server.SubscriptionCleaner
+// so the server can drop a session's watcher subscriptions when its
+// connection closes. The wrapper is needed because the server module
+// must not import watcher (the dependency direction goes the other
+// way: handlers + main wire watcher into the server's options).
+type watcherCleaner struct {
+	w *watcher.Watcher
+}
+
+func (c watcherCleaner) CleanupSubscriptions(ids []string) {
+	for _, id := range ids {
+		c.w.Unsubscribe(id)
+	}
 }

--- a/server/go.mod
+++ b/server/go.mod
@@ -1,3 +1,7 @@
 module github.com/sotashimozono/obsidian-remote-ssh/server
 
 go 1.22
+
+require github.com/fsnotify/fsnotify v1.9.0
+
+require golang.org/x/sys v0.13.0 // indirect

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,0 +1,4 @@
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/server/internal/handlers/fs_unwatch.go
+++ b/server/internal/handlers/fs_unwatch.go
@@ -1,0 +1,29 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+)
+
+// FsUnwatch returns the handler for `fs.unwatch`. The id is dropped
+// from the watcher and from the session's subscription set.
+//
+// An unknown id is not an error — the client may have raced a
+// connection close, and re-issuing the unwatch is safe. The handler
+// returns an empty success in that case so the client can proceed.
+func FsUnwatch(w WatcherCore) rpc.Handler {
+	return func(ctx context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.UnwatchParams
+		if e := decodeParams("fs.unwatch", params, &p); e != nil {
+			return nil, e
+		}
+		session := server.SessionFromContext(ctx)
+		w.Unsubscribe(p.SubscriptionID)
+		session.RemoveSubscription(p.SubscriptionID)
+		return struct{}{}, nil
+	}
+}

--- a/server/internal/handlers/fs_watch.go
+++ b/server/internal/handlers/fs_watch.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/watcher"
+)
+
+// WatcherCore is the slice of watcher.Watcher this handler relies on.
+// Defining it as an interface keeps the handler isolated from
+// fsnotify in tests — a tiny in-memory fake satisfies it.
+type WatcherCore interface {
+	Subscribe(vaultPath string, recursive bool, cb watcher.Subscriber) (string, error)
+	Unsubscribe(id string) bool
+}
+
+// FsWatch returns the handler for `fs.watch`. Sessions register
+// interest in a vault-relative path; events bubble back via the
+// session's notifier as `fs.changed` push frames.
+//
+// Resolved subscription ids are tracked on the Session so the server
+// can drop them via SubscriptionCleaner when the connection closes
+// — the watcher must not keep firing callbacks against a dead writer.
+func FsWatch(w WatcherCore) rpc.Handler {
+	return func(ctx context.Context, params json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.WatchParams
+		if e := decodeParams("fs.watch", params, &p); e != nil {
+			return nil, e
+		}
+		session := server.SessionFromContext(ctx)
+
+		var subID string
+		var setupErr error
+		subID, setupErr = w.Subscribe(p.Path, p.Recursive, func(ev watcher.Event) {
+			notifyParams := proto.FsChangedParams{
+				SubscriptionID: subID,
+				Path:           ev.Path,
+				Event:          mapEventType(ev.Type),
+			}
+			// We deliberately ignore SendNotification errors: the
+			// connection has likely gone away, in which case the
+			// watcher will be unsubscribed shortly anyway.
+			_ = session.SendNotification("fs.changed", notifyParams)
+		})
+		if setupErr != nil {
+			return nil, rpc.ErrInternal("fs.watch: " + setupErr.Error())
+		}
+		session.AddSubscription(subID)
+		return proto.WatchResult{SubscriptionID: subID}, nil
+	}
+}
+
+func mapEventType(t watcher.EventType) proto.FsChangeEvent {
+	switch t {
+	case watcher.EventCreated:
+		return proto.FsChangeEventCreated
+	case watcher.EventDeleted:
+		return proto.FsChangeEventDeleted
+	case watcher.EventModified:
+		return proto.FsChangeEventModified
+	}
+	return proto.FsChangeEventModified
+}

--- a/server/internal/handlers/fs_watch_test.go
+++ b/server/internal/handlers/fs_watch_test.go
@@ -1,0 +1,138 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/watcher"
+)
+
+type fakeWatcher struct {
+	subs           map[string]watcher.Subscriber
+	subscribeErr   error
+	unsubscribed   []string
+}
+
+func (f *fakeWatcher) Subscribe(_ string, _ bool, cb watcher.Subscriber) (string, error) {
+	if f.subscribeErr != nil {
+		return "", f.subscribeErr
+	}
+	id := "sub-" + jsonNumber(len(f.subs))
+	if f.subs == nil {
+		f.subs = map[string]watcher.Subscriber{}
+	}
+	f.subs[id] = cb
+	return id, nil
+}
+
+func (f *fakeWatcher) Unsubscribe(id string) bool {
+	f.unsubscribed = append(f.unsubscribed, id)
+	if _, ok := f.subs[id]; !ok {
+		return false
+	}
+	delete(f.subs, id)
+	return true
+}
+
+func jsonNumber(n int) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func TestFsWatch_RegistersSubscriptionAndTracksItOnSession(t *testing.T) {
+	fake := &fakeWatcher{}
+	h := FsWatch(fake)
+	sess := server.NewSession()
+
+	// Capture push notifications via the session's notifier.
+	type push struct{ method string; params interface{} }
+	pushes := []push{}
+	sess.SetNotifier(func(method string, params interface{}) error {
+		pushes = append(pushes, push{method, params})
+		return nil
+	})
+	ctx := server.WithSession(context.Background(), sess)
+
+	raw, _ := json.Marshal(proto.WatchParams{Path: "Notes", Recursive: true})
+	result, rerr := h(ctx, raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+
+	got, ok := result.(proto.WatchResult)
+	if !ok {
+		t.Fatalf("result type = %T, want WatchResult", result)
+	}
+	if got.SubscriptionID == "" {
+		t.Error("SubscriptionID should be set")
+	}
+
+	// Session should have tracked the id so the connection-close
+	// cleanup can drop it later.
+	if ids := sess.SubscriptionIDs(); len(ids) != 1 || ids[0] != got.SubscriptionID {
+		t.Errorf("session subscriptions = %v, want [%q]", ids, got.SubscriptionID)
+	}
+
+	// Drive an event through the registered callback and confirm
+	// it surfaces as an fs.changed notification.
+	cb := fake.subs[got.SubscriptionID]
+	cb(watcher.Event{Path: "Notes/a.md", Type: watcher.EventModified})
+	if len(pushes) != 1 || pushes[0].method != "fs.changed" {
+		t.Fatalf("expected one fs.changed push, got %+v", pushes)
+	}
+	pp := pushes[0].params.(proto.FsChangedParams)
+	if pp.SubscriptionID != got.SubscriptionID {
+		t.Errorf("notification subscriptionId = %q, want %q", pp.SubscriptionID, got.SubscriptionID)
+	}
+	if pp.Path != "Notes/a.md" || pp.Event != proto.FsChangeEventModified {
+		t.Errorf("notification params = %+v", pp)
+	}
+}
+
+func TestFsWatch_SurfacesSubscribeError(t *testing.T) {
+	fake := &fakeWatcher{subscribeErr: errors.New("boom")}
+	h := FsWatch(fake)
+	ctx := server.WithSession(context.Background(), server.NewSession())
+	raw, _ := json.Marshal(proto.WatchParams{Path: "x"})
+	_, rerr := h(ctx, raw)
+	if rerr == nil || rerr.Code != proto.ErrorInternalError {
+		t.Fatalf("want InternalError, got %+v", rerr)
+	}
+}
+
+func TestFsUnwatch_DropsSubscription(t *testing.T) {
+	fake := &fakeWatcher{subs: map[string]watcher.Subscriber{
+		"sub-x": func(_ watcher.Event) { /* unused */ },
+	}}
+	sess := server.NewSession()
+	sess.AddSubscription("sub-x")
+	ctx := server.WithSession(context.Background(), sess)
+
+	h := FsUnwatch(fake)
+	raw, _ := json.Marshal(proto.UnwatchParams{SubscriptionID: "sub-x"})
+	_, rerr := h(ctx, raw)
+	if rerr != nil {
+		t.Fatalf("unexpected error: %+v", rerr)
+	}
+	if len(fake.unsubscribed) != 1 || fake.unsubscribed[0] != "sub-x" {
+		t.Errorf("watcher.Unsubscribe was not called: %v", fake.unsubscribed)
+	}
+	if ids := sess.SubscriptionIDs(); len(ids) != 0 {
+		t.Errorf("session should have no subscriptions left, got %v", ids)
+	}
+}
+
+func TestFsUnwatch_UnknownIdSucceeds(t *testing.T) {
+	fake := &fakeWatcher{}
+	sess := server.NewSession()
+	ctx := server.WithSession(context.Background(), sess)
+	h := FsUnwatch(fake)
+	raw, _ := json.Marshal(proto.UnwatchParams{SubscriptionID: "ghost"})
+	if _, rerr := h(ctx, raw); rerr != nil {
+		t.Fatalf("unwatching an unknown id should be a no-op success, got %+v", rerr)
+	}
+}

--- a/server/internal/server/server.go
+++ b/server/internal/server/server.go
@@ -17,8 +17,18 @@ import (
 	"sync/atomic"
 
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/auth"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
 )
+
+// SubscriptionCleaner unhooks any watcher subscriptions a closing
+// session may have left registered. The server calls
+// CleanupSubscriptions on the cleaner once per closed session,
+// passing the ids the session knows about. A nil cleaner is fine —
+// fs.watch hasn't been registered.
+type SubscriptionCleaner interface {
+	CleanupSubscriptions(ids []string)
+}
 
 // Options configure a Server.
 type Options struct {
@@ -38,6 +48,12 @@ type Options struct {
 	// Logger is used for connection-level events. Defaults to a no-op
 	// logger when nil.
 	Logger *slog.Logger
+
+	// SubscriptionCleaner is invoked when a connection closes; its
+	// CleanupSubscriptions method receives the watcher subscription
+	// ids the session collected so the watcher can drop them. Nil is
+	// fine and means "no cleanup needed".
+	SubscriptionCleaner SubscriptionCleaner
 }
 
 // Server accepts one connection at a time on an external listener and
@@ -105,17 +121,45 @@ func (s *Server) handleConn(ctx context.Context, conn net.Conn) {
 	connID := s.connCount.Add(1)
 	log := s.log.With("conn", connID, "peer", conn.RemoteAddr().String())
 	log.Info("connection opened")
+	session := NewSession()
 	defer func() {
+		// Drop any watcher subscriptions the session collected before
+		// the connection actually closes — otherwise the watcher
+		// would keep firing callbacks on a dead writer.
+		if s.opts.SubscriptionCleaner != nil {
+			s.opts.SubscriptionCleaner.CleanupSubscriptions(session.SubscriptionIDs())
+		}
 		_ = conn.Close()
 		log.Info("connection closed")
 	}()
 
-	session := NewSession()
 	reader := bufio.NewReader(conn)
-	// Protect concurrent writes to the connection (currently only the
-	// reply path writes, but fs.watch push events will write from
-	// other goroutines in a later phase).
+	// Protect concurrent writes to the connection: replies and
+	// fs.watch push notifications can race for the wire.
 	var writeMu sync.Mutex
+
+	// Wire the session's notifier so push handlers can write to
+	// `conn` without grabbing private fields. JSON marshalling lives
+	// in this closure so we depend on `proto` here rather than in
+	// every handler that wants to push.
+	session.SetNotifier(func(method string, params interface{}) error {
+		paramsBytes, err := json.Marshal(params)
+		if err != nil {
+			return fmt.Errorf("server: marshal notification params: %w", err)
+		}
+		envelope := proto.Notification{
+			JSONRPC: proto.JSONRPCVersion,
+			Method:  method,
+			Params:  paramsBytes,
+		}
+		body, err := json.Marshal(envelope)
+		if err != nil {
+			return fmt.Errorf("server: marshal notification: %w", err)
+		}
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		return rpc.WriteFrame(conn, body)
+	})
 
 	for {
 		body, err := rpc.ReadFrame(reader, 0)

--- a/server/internal/server/server_test.go
+++ b/server/internal/server/server_test.go
@@ -18,7 +18,19 @@ import (
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/rpc"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/watcher"
 )
+
+// watcherCleaner adapts the package's vault watcher to
+// server.SubscriptionCleaner — see the equivalent type in
+// cmd/obsidian-remote-server/main.go for the production wiring.
+type watcherCleaner struct{ w *watcher.Watcher }
+
+func (c watcherCleaner) CleanupSubscriptions(ids []string) {
+	for _, id := range ids {
+		c.w.Unsubscribe(id)
+	}
+}
 
 // testServer spins up a listening Server on 127.0.0.1:<random>, wires
 // the full handler set (matching main.go), and tears everything down
@@ -43,10 +55,17 @@ func startTestServer(t *testing.T) *testServer {
 	}
 
 	vaultRoot := t.TempDir()
+	w, err := watcher.New(vaultRoot)
+	if err != nil {
+		t.Fatalf("watcher: %v", err)
+	}
+	t.Cleanup(func() { _ = w.Close() })
+
 	srv := server.New(server.Options{
-		Token:     tk,
-		VaultRoot: vaultRoot,
-		Version:   "test",
+		Token:               tk,
+		VaultRoot:           vaultRoot,
+		Version:             "test",
+		SubscriptionCleaner: watcherCleaner{w},
 	})
 	disp := srv.Dispatcher()
 	disp.Handle("auth", handlers.Auth(tk))
@@ -66,6 +85,8 @@ func startTestServer(t *testing.T) *testServer {
 	disp.Handle("fs.rename", handlers.RequireAuth(handlers.FsRename(vaultRoot)))
 	disp.Handle("fs.copy", handlers.RequireAuth(handlers.FsCopy(vaultRoot)))
 	disp.Handle("fs.trashLocal", handlers.RequireAuth(handlers.FsTrashLocal(vaultRoot)))
+	disp.Handle("fs.watch", handlers.RequireAuth(handlers.FsWatch(w)))
+	disp.Handle("fs.unwatch", handlers.RequireAuth(handlers.FsUnwatch(w)))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
@@ -431,6 +452,7 @@ func TestServer_AuthThenServerInfo(t *testing.T) {
 		"fs.readBinary", "fs.readText",
 		"fs.remove", "fs.rename", "fs.rmdir",
 		"fs.stat", "fs.trashLocal",
+		"fs.unwatch", "fs.watch",
 		"fs.write", "fs.writeBinary",
 		"server.info",
 	}
@@ -455,5 +477,99 @@ func TestServer_GracefulEOF(t *testing.T) {
 	_, errObj := c.call(t, "auth", map[string]string{"token": string(ts.token)})
 	if errObj != nil {
 		t.Fatalf("auth after prior close: %+v", errObj)
+	}
+}
+
+// TestServer_WatchPipeline confirms the daemon's fs.watch surface
+// end-to-end: a "watcher" client subscribes to the vault root, a
+// separate "writer" client writes a file through fs.write, and the
+// watcher receives a matching `fs.changed` notification on its
+// socket.
+//
+// Two connections keep the watcher's read loop from racing the
+// fs.write reply.
+func TestServer_WatchPipeline(t *testing.T) {
+	ts := startTestServer(t)
+
+	// Watcher connection.
+	w := ts.dial(t)
+	if _, errObj := w.call(t, "auth", map[string]string{"token": string(ts.token)}); errObj != nil {
+		t.Fatalf("watcher auth: %+v", errObj)
+	}
+	subRaw, errObj := w.call(t, "fs.watch", map[string]any{"path": "", "recursive": true})
+	if errObj != nil {
+		t.Fatalf("fs.watch: %+v", errObj)
+	}
+	var sub proto.WatchResult
+	if err := json.Unmarshal(subRaw, &sub); err != nil {
+		t.Fatalf("unmarshal watch result: %v", err)
+	}
+	if sub.SubscriptionID == "" {
+		t.Fatal("fs.watch returned an empty subscription id")
+	}
+
+	// Writer connection: a separate session does the file write so
+	// the watcher's reader never has to interleave the fs.write reply
+	// with the fs.changed notification.
+	wr := ts.dial(t)
+	if _, errObj := wr.call(t, "auth", map[string]string{"token": string(ts.token)}); errObj != nil {
+		t.Fatalf("writer auth: %+v", errObj)
+	}
+	go func() {
+		// Tiny delay so the watcher reader is blocked on its
+		// next ReadFrame when the notification lands.
+		time.Sleep(50 * time.Millisecond)
+		_, _ = wr.call(t, "fs.write", map[string]any{
+			"path":    "watched.md",
+			"content": "fresh",
+		})
+	}()
+
+	// atomicWriteFile creates a tmp file first and then renames it to
+	// the target, so fsnotify will fire several events in sequence
+	// (create + modify on the tmp, then a rename + create matching
+	// the final path). We just need to find one fs.changed where the
+	// path matches our target.
+	deadline := time.Now().Add(3 * time.Second)
+	gotChange := false
+	for time.Now().Before(deadline) && !gotChange {
+		_ = w.conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		body, err := rpc.ReadFrame(w.reader, 0)
+		if err != nil {
+			continue // read deadline; try again
+		}
+		var env struct {
+			ID     json.RawMessage `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(body, &env); err != nil {
+			continue
+		}
+		if env.Method != "fs.changed" {
+			continue
+		}
+		var p proto.FsChangedParams
+		if err := json.Unmarshal(env.Params, &p); err != nil {
+			t.Fatalf("unmarshal fs.changed params: %v", err)
+		}
+		if p.SubscriptionID != sub.SubscriptionID {
+			t.Errorf("subscriptionId = %q, want %q", p.SubscriptionID, sub.SubscriptionID)
+		}
+		if p.Path == "watched.md" {
+			if p.Event != proto.FsChangeEventCreated && p.Event != proto.FsChangeEventModified {
+				t.Errorf("event = %q, want created or modified", p.Event)
+			}
+			gotChange = true
+		}
+		// Other events (tmp file artefacts) just get drained — keep reading.
+	}
+	_ = w.conn.SetReadDeadline(time.Time{})
+	if !gotChange {
+		t.Fatal("never received an fs.changed notification for watched.md within the deadline")
+	}
+
+	if _, errObj := w.call(t, "fs.unwatch", map[string]string{"subscriptionId": sub.SubscriptionID}); errObj != nil {
+		t.Fatalf("fs.unwatch: %+v", errObj)
 	}
 }

--- a/server/internal/server/session.go
+++ b/server/internal/server/session.go
@@ -1,6 +1,15 @@
 package server
 
-import "sync"
+import (
+	"errors"
+	"sync"
+)
+
+// NotificationSender writes one server-push notification on the
+// session's connection. The implementation is responsible for
+// serialising concurrent writes (a request reply may be in flight
+// at the same time a watcher event tries to push).
+type NotificationSender func(method string, params interface{}) error
 
 // Session is the per-connection state used by method handlers.
 // Every accepted connection gets its own Session, so mutation of
@@ -12,6 +21,7 @@ type Session struct {
 	mu              sync.Mutex
 	authenticated   bool
 	subscriptionIDs map[string]struct{}
+	sender          NotificationSender
 }
 
 // NewSession returns a fresh, unauthenticated session.
@@ -60,4 +70,27 @@ func (s *Session) SubscriptionIDs() []string {
 		out = append(out, id)
 	}
 	return out
+}
+
+// SetNotifier installs the function the session uses to write a
+// server-push frame. Called once at connection setup; later calls
+// replace the previous sender atomically.
+func (s *Session) SetNotifier(send NotificationSender) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sender = send
+}
+
+// SendNotification writes one notification frame on the session's
+// connection. Returns an error when no notifier has been set (the
+// session was constructed in test code without one) or the underlying
+// write fails.
+func (s *Session) SendNotification(method string, params interface{}) error {
+	s.mu.Lock()
+	send := s.sender
+	s.mu.Unlock()
+	if send == nil {
+		return errors.New("Session: SendNotification called before SetNotifier")
+	}
+	return send(method, params)
 }

--- a/server/internal/watcher/watcher.go
+++ b/server/internal/watcher/watcher.go
@@ -1,0 +1,301 @@
+// Package watcher reports filesystem changes inside a vault root.
+//
+// One Watcher is created per daemon. Sessions register interest in
+// vault-relative paths via Subscribe(...) and supply a callback; when
+// fsnotify reports a change inside a subscribed range the callback is
+// invoked synchronously on the watcher's dispatch goroutine.
+//
+// fsnotify itself is not recursive on Linux/Windows, so the Watcher
+// walks the vault tree once at start to add every existing directory
+// and adds new directories on the fly when it sees a Create event for
+// one. Subscriptions can still be recursive — the matching is done
+// lexically on event paths.
+package watcher
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// EventType describes the change observed on disk. Maps directly to
+// the wire-level proto.FsChangeEvent values.
+type EventType string
+
+const (
+	EventCreated  EventType = "created"
+	EventModified EventType = "modified"
+	EventDeleted  EventType = "deleted"
+)
+
+// Event is the high-level observation reported to subscribers. Paths
+// are vault-relative with forward slashes — matching the rest of the
+// proto.
+type Event struct {
+	Path string
+	Type EventType
+}
+
+// Subscriber is the callback fired when an event matches a
+// subscription. It runs on the watcher's dispatch goroutine, so it
+// must not block — typical implementations enqueue and return.
+type Subscriber func(event Event)
+
+type subscription struct {
+	id        string
+	path      string // vault-relative; "" means the vault root
+	recursive bool
+	callback  Subscriber
+}
+
+// Watcher wraps an fsnotify watcher with a vault-relative subscription
+// model. Construct one per daemon via New.
+type Watcher struct {
+	root    string
+	notify  *fsnotify.Watcher
+	stop    chan struct{}
+	stopped chan struct{}
+
+	mu   sync.Mutex
+	subs map[string]*subscription
+}
+
+// New creates a Watcher rooted at vaultRoot (an absolute path). It
+// walks the existing tree, adds every directory to the underlying
+// fsnotify watcher, then starts dispatching events on its own
+// goroutine. Close() must be called to release OS resources.
+func New(vaultRoot string) (*Watcher, error) {
+	abs, err := filepath.Abs(vaultRoot)
+	if err != nil {
+		return nil, err
+	}
+	notify, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Watcher{
+		root:    abs,
+		notify:  notify,
+		stop:    make(chan struct{}),
+		stopped: make(chan struct{}),
+		subs:    map[string]*subscription{},
+	}
+
+	if err := w.addTree(abs); err != nil {
+		_ = notify.Close()
+		return nil, err
+	}
+
+	go w.run()
+	return w, nil
+}
+
+// addTree adds `root` and every existing subdirectory to the
+// fsnotify watcher. fsnotify is not recursive on Linux/Windows; this
+// walk closes that gap up front. New subdirectories are picked up
+// lazily in the event loop when their parent fires a Create event.
+func (w *Watcher) addTree(root string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Best-effort: dropped directories or permission errors don't
+			// stop the rest of the walk.
+			return nil
+		}
+		if d.IsDir() {
+			_ = w.notify.Add(path)
+		}
+		return nil
+	})
+}
+
+// Subscribe registers an interest in `vaultPath` (recursive controls
+// whether descendants are included). Returns a subscription id used
+// later to Unsubscribe. The callback runs synchronously on the
+// dispatch goroutine.
+func (w *Watcher) Subscribe(vaultPath string, recursive bool, cb Subscriber) (string, error) {
+	if cb == nil {
+		return "", errors.New("watcher: callback is nil")
+	}
+	id, err := newSubID()
+	if err != nil {
+		return "", err
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.subs[id] = &subscription{
+		id:        id,
+		path:      cleanVaultPath(vaultPath),
+		recursive: recursive,
+		callback:  cb,
+	}
+	return id, nil
+}
+
+// Unsubscribe drops the subscription created by Subscribe. Returns
+// true if the id was known, false otherwise (callers can ignore the
+// result for a "best-effort" cancel).
+func (w *Watcher) Unsubscribe(id string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.subs[id]; !ok {
+		return false
+	}
+	delete(w.subs, id)
+	return true
+}
+
+// Close stops the dispatch goroutine and releases the underlying
+// fsnotify watcher. Idempotent.
+func (w *Watcher) Close() error {
+	select {
+	case <-w.stop:
+		// Already stopped.
+		return nil
+	default:
+		close(w.stop)
+	}
+	err := w.notify.Close()
+	<-w.stopped
+	return err
+}
+
+// run is the dispatch goroutine. It exits when Close is called.
+func (w *Watcher) run() {
+	defer close(w.stopped)
+	for {
+		select {
+		case <-w.stop:
+			return
+		case ev, ok := <-w.notify.Events:
+			if !ok {
+				return
+			}
+			w.handleFsEvent(ev)
+		case _, ok := <-w.notify.Errors:
+			if !ok {
+				return
+			}
+			// Errors from fsnotify are typically transient (a temporarily
+			// unreadable directory). Drop them; the next event will still
+			// arrive correctly.
+		}
+	}
+}
+
+func (w *Watcher) handleFsEvent(ev fsnotify.Event) {
+	relative, err := filepath.Rel(w.root, ev.Name)
+	if err != nil {
+		return
+	}
+	relative = filepath.ToSlash(relative)
+	// Walking up out of the root would produce a leading "..". Skip
+	// such events — they shouldn't happen in practice but a
+	// misbehaving fsnotify backend shouldn't crash the daemon.
+	if strings.HasPrefix(relative, "..") {
+		return
+	}
+
+	// Auto-watch directories created inside the tree so we keep
+	// receiving events for files born inside them. Best-effort:
+	// failures are ignored (we just won't see grandchild events).
+	if ev.Has(fsnotify.Create) {
+		if info, err := lstat(ev.Name); err == nil && info.IsDir() {
+			_ = w.notify.Add(ev.Name)
+		}
+	}
+
+	out, ok := classify(ev.Op)
+	if !ok {
+		return // chmod and friends — not interesting
+	}
+	event := Event{Path: relative, Type: out}
+
+	// Dispatch under a snapshot of the subscription map. Callbacks
+	// run synchronously, but they hold no locks; an unsubscribe
+	// during dispatch is safe (we're operating on the snapshot).
+	w.mu.Lock()
+	subs := make([]*subscription, 0, len(w.subs))
+	for _, s := range w.subs {
+		if matches(s, relative) {
+			subs = append(subs, s)
+		}
+	}
+	w.mu.Unlock()
+
+	for _, s := range subs {
+		s.callback(event)
+	}
+}
+
+// classify maps an fsnotify op flag set to one of our high-level
+// event types. Returns false when the op is one we ignore (chmod).
+func classify(op fsnotify.Op) (EventType, bool) {
+	switch {
+	case op.Has(fsnotify.Remove), op.Has(fsnotify.Rename):
+		return EventDeleted, true
+	case op.Has(fsnotify.Create):
+		return EventCreated, true
+	case op.Has(fsnotify.Write):
+		return EventModified, true
+	}
+	return "", false
+}
+
+// matches reports whether `relativePath` falls under subscription `s`.
+//
+// - empty path is the vault root; recursive subs match everything.
+// - non-recursive subs match exactly the path itself, and immediate
+//   children when the subscription path is a directory.
+// - recursive subs match the path itself and any descendant.
+func matches(s *subscription, relativePath string) bool {
+	if s.path == "" || s.path == "." {
+		return true // root-recursive (or root non-recursive) sees everything
+	}
+	if relativePath == s.path {
+		return true
+	}
+	if s.recursive {
+		return strings.HasPrefix(relativePath, s.path+"/")
+	}
+	// Non-recursive: an event is "in this dir" when relativePath has
+	// the subscription path as its parent.
+	parent := relativePath
+	if i := strings.LastIndex(relativePath, "/"); i >= 0 {
+		parent = relativePath[:i]
+	} else {
+		parent = ""
+	}
+	return parent == s.path
+}
+
+// cleanVaultPath normalises a vault-relative input. Strips a leading
+// slash, collapses `.` and `./`, leaves paths empty for root.
+func cleanVaultPath(p string) string {
+	p = strings.TrimPrefix(p, "/")
+	if p == "" || p == "." {
+		return ""
+	}
+	return p
+}
+
+func newSubID() (string, error) {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+// lstat is split out so tests can pretend a created path is a dir
+// without touching disk.
+var lstat = func(path string) (fs.FileInfo, error) {
+	return os.Lstat(path)
+}

--- a/server/internal/watcher/watcher_test.go
+++ b/server/internal/watcher/watcher_test.go
@@ -1,0 +1,260 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitForEvent polls a "received" slot for up to 2 s. fsnotify
+// usually fires within a few ms but can take longer on Windows.
+func waitForEvent(t *testing.T, get func() (Event, bool)) Event {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if e, ok := get(); ok {
+			return e
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for filesystem event")
+	return Event{}
+}
+
+func TestWatcher_NotifiesOnFileWrite(t *testing.T) {
+	root := t.TempDir()
+	w, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	var (
+		mu    sync.Mutex
+		seen  []Event
+	)
+	if _, err := w.Subscribe("", true, func(ev Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, ev)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "a.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := waitForEvent(t, func() (Event, bool) {
+		mu.Lock()
+		defer mu.Unlock()
+		// We tolerate either Created or Modified for the first arrival
+		// since some platforms emit both back-to-back.
+		for _, e := range seen {
+			if e.Path == "a.md" && (e.Type == EventCreated || e.Type == EventModified) {
+				return e, true
+			}
+		}
+		return Event{}, false
+	})
+	_ = got // assertion is implicit in waitForEvent's success
+}
+
+func TestWatcher_NonRecursiveOnlySeesOwnDir(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "outer", "inner"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	var (
+		mu     sync.Mutex
+		seen   []Event
+	)
+	// Subscribe to "outer" only, non-recursive.
+	if _, err := w.Subscribe("outer", false, func(ev Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		seen = append(seen, ev)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Touch a file in outer/ — should fire.
+	if err := os.WriteFile(filepath.Join(root, "outer", "x.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Touch a file in outer/inner/ — should NOT fire.
+	if err := os.WriteFile(filepath.Join(root, "outer", "inner", "y.md"), []byte("y"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait a bit, then check what we got.
+	time.Sleep(300 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	sawX := false
+	for _, e := range seen {
+		if e.Path == "outer/x.md" {
+			sawX = true
+		}
+		if e.Path == "outer/inner/y.md" {
+			t.Errorf("non-recursive sub should not see deep file, got %+v", e)
+		}
+	}
+	if !sawX {
+		t.Errorf("expected event for outer/x.md, got %v", seen)
+	}
+}
+
+func TestWatcher_RecursiveSeesNestedFiles(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "a", "b", "c"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	w, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	got := make(chan Event, 8)
+	if _, err := w.Subscribe("a", true, func(ev Event) { got <- ev }); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "a", "b", "c", "leaf.md"), []byte("leaf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-got:
+			if ev.Path == "a/b/c/leaf.md" {
+				return // pass
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for a/b/c/leaf.md event")
+		}
+	}
+}
+
+func TestWatcher_UnsubscribeStopsCallbacks(t *testing.T) {
+	root := t.TempDir()
+	w, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	var fired bool
+	id, err := w.Subscribe("", true, func(_ Event) { fired = true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !w.Unsubscribe(id) {
+		t.Fatal("Unsubscribe returned false on a known id")
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "x.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if fired {
+		t.Error("callback ran after Unsubscribe")
+	}
+}
+
+func TestWatcher_PicksUpNewSubdirs(t *testing.T) {
+	root := t.TempDir()
+	w, err := New(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	got := make(chan Event, 8)
+	if _, err := w.Subscribe("", true, func(ev Event) { got <- ev }); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a brand-new subdir, then a file in it.
+	if err := os.MkdirAll(filepath.Join(root, "fresh"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Wait for the dir event to flush so the auto-add logic runs.
+	time.Sleep(200 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(root, "fresh", "new.md"), []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-got:
+			if ev.Path == "fresh/new.md" {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for fresh/new.md event (auto-watch of new dir failed?)")
+		}
+	}
+}
+
+func TestWatcher_UnsubscribeUnknownIdReturnsFalse(t *testing.T) {
+	w, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if w.Unsubscribe("nope") {
+		t.Error("Unsubscribe should return false for an unknown id")
+	}
+}
+
+func TestWatcher_CloseIsIdempotent(t *testing.T) {
+	w, err := New(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Errorf("second close should be a no-op, got %v", err)
+	}
+}
+
+// matches() unit tests run without filesystem to keep them fast.
+func TestMatches(t *testing.T) {
+	cases := []struct {
+		name      string
+		sub       *subscription
+		path      string
+		want      bool
+	}{
+		{"root-recursive sees everything",      &subscription{path: "", recursive: true},   "a/b/c.md", true},
+		{"root-recursive sees a top-level file", &subscription{path: "", recursive: true},   "a.md",     true},
+		{"recursive matches descendant",         &subscription{path: "docs", recursive: true}, "docs/a.md", true},
+		{"recursive matches deep descendant",    &subscription{path: "docs", recursive: true}, "docs/sub/b.md", true},
+		{"recursive does not match sibling prefix", &subscription{path: "docs", recursive: true}, "docs2/a.md", false},
+		{"non-recursive matches direct child",   &subscription{path: "docs", recursive: false}, "docs/a.md", true},
+		{"non-recursive misses grandchild",      &subscription{path: "docs", recursive: false}, "docs/sub/a.md", false},
+		{"matches the subscription path itself", &subscription{path: "note.md", recursive: false}, "note.md", true},
+		{"unrelated path",                       &subscription{path: "docs", recursive: true}, "Notes/a.md", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := matches(tc.sub, tc.path); got != tc.want {
+				t.Errorf("matches(%+v, %q) = %v, want %v", tc.sub, tc.path, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The daemon now reports filesystem changes back to subscribed clients as \`fs.changed\` push frames, riding the same JSON-RPC channel that carries request/reply traffic. Plugin-side subscription + cache invalidation lands in the next PR.

## What's new

### \`server/internal/watcher\`
Wraps \`github.com/fsnotify/fsnotify\` (v1.9.0) with a vault-relative subscription model. One \`Watcher\` per daemon; the whole tree is walked at start so existing dirs are added up front, and new subdirs are auto-added the moment fsnotify reports their Create event so events from grandchildren flow without manual fiddling.

\`Subscribe(path, recursive, cb) → id\`; \`Unsubscribe(id) → bool\`. Recursive subs match descendants; non-recursive subs see only direct children of the path. \`handleFsEvent\` maps \`fsnotify.Op\` to one of \`created\` / \`modified\` / \`deleted\` (chmod dropped, rename folded into \`deleted\`).

### \`server/internal/server\`
- \`Session.SetNotifier\` / \`Session.SendNotification\` form the push side. The dispatcher's reply path and the notifier path share \`writeMu\` inside \`handleConn\`, so a watcher event firing while a reply is mid-flight serialises cleanly onto the wire.
- \`handleConn\` registers the notifier on the freshly-created session, marshalling \`proto.Notification\` envelopes inline so handlers don't pull \`proto\` themselves.
- New \`Options.SubscriptionCleaner\` — \`handleConn\` invokes \`CleanupSubscriptions(ids)\` before closing the conn so the watcher's callbacks don't keep firing against a dead writer.

### \`server/internal/handlers\`
- \`FsWatch(WatcherCore)\` registers a callback that turns watcher events into \`proto.FsChangedParams\` and pushes them via \`Session.SendNotification\`. The new subscription id is tracked on the session so the cleaner can drop it on disconnect.
- \`FsUnwatch(WatcherCore)\` drops the id from both the watcher and the session. An unknown id is treated as a no-op success — a client racing a connection close should not see an error here.

### \`cmd/obsidian-remote-server/main.go\`
Constructs a vault-wide watcher next to the listener, registers \`fs.watch\` / \`fs.unwatch\` behind \`RequireAuth\`, and passes a \`watcherCleaner\` adapter to the Server so dropped sessions drop their watcher subscriptions.

## Tests
- \`watcher_test.go\` (8 cases): write-triggered notifications, non-recursive vs recursive subscription scope, unsubscribe stops callbacks, dynamically-created subdirs are auto-watched, idempotent Close, unknown id, and a table-driven \`matches()\` suite.
- \`handlers/fs_watch_test.go\` (4 cases) with a \`fakeWatcher\`: subscription registration, notification dispatch via a captured \`SetNotifier\`, surfacing of Subscribe errors, unsubscribe + unknown-id flow.
- \`server/server_test.go\` \`TestServer_WatchPipeline\`: a "watcher" client subscribes to the vault root recursively; a separate "writer" client triggers an \`fs.write\`; the watcher's connection receives an \`fs.changed\` notification matching the write. Two connections to keep the watcher's read loop from interleaving the \`fs.write\` reply with the notification. Tolerates the tmp-file events that \`atomicWriteFile\` fires on its way to renaming the final target.

## Verification
- [x] \`cd server && go vet ./...\` clean
- [x] \`cd server && go test ./...\` — 7 packages pass (8 + 4 + 1 new tests on top of the existing suite)
- [x] \`go build\` — \`bin/obsidian-remote-server.exe\` (4.24 MB), \`bin/obsidian-remote-server-linux-amd64\` (3.95 MB)

## Dogfood (after merge)
The push half is invisible until the plugin subscribes. After this PR is merged you can validate the daemon side end-to-end with \`netcat\` + a manual JSON-RPC handshake, but the user-facing improvement comes with the next PR (plugin-side subscribe + cache invalidation + Obsidian event firing).

## Follow-ups
- Plugin-side subscription on connect when \`transport === 'rpc'\`, ReadCache + DirCache invalidation on \`fs.changed\`, \`app.vault.trigger('modify' | …)\` calls so Obsidian re-renders when the remote file moves under it.
- Rename event handling: fsnotify gives only the source path; the subsequent Create event already covers the destination, so we emit \`deleted\` + \`created\` instead of synthesising a \`renamed\` event. Revisit if a downstream consumer needs the linkage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)