### PR TITLE
feat(plugin): subscribe to daemon fs.watch on adapter patch

### DIFF
--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -324,6 +324,20 @@ export class SftpDataAdapter {
   }
 
   /**
+   * Drop cache entries for a path the daemon just reported as
+   * changed via an `fs.changed` push. The argument is the daemon's
+   * vault-relative path (already past PathMapper for private files);
+   * the adapter joins it with `remoteBasePath` to recover the cache
+   * key it actually stored under.
+   */
+  invalidateRemotePath(remoteVaultPath: string): void {
+    const abs = this.joinRemote(remoteVaultPath);
+    this.readCache.invalidate(abs);
+    const parent = parentDirRemote(abs);
+    if (parent) this.dirCache.invalidate(parent);
+  }
+
+  /**
    * Resolve a vault-relative path to the absolute path on the remote.
    *
    * If a PathMapper is attached, private vault paths are first

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -15,6 +15,8 @@ import { RpcRemoteFsClient } from './adapter/RpcRemoteFsClient';
 import { establishRpcConnection } from './transport/RpcConnection';
 import { ServerDeployer } from './transport/ServerDeployer';
 import { PathMapper, defaultClientId } from './path/PathMapper';
+import { interpretWatchEvent } from './path/WatchEventFilter';
+import type { FsChangedParams } from './proto/types';
 import * as fs from 'fs';
 import { StatusBar } from './ui/StatusBar';
 import { ConnectModal } from './ui/ConnectModal';
@@ -53,6 +55,12 @@ export default class RemoteSshPlugin extends Plugin {
   private rpcConnection: Awaited<ReturnType<typeof establishRpcConnection>> | null = null;
   /** ServerDeployer that owns the daemon process; invoked on disconnect to tear it down. */
   private daemonDeployer: ServerDeployer | null = null;
+  /** Active daemon-side fs.watch subscription id (set after debugPatchAdapter). */
+  private rpcWatchSubscriptionId: string | null = null;
+  /** Disposer returned by RpcClient.onNotification('fs.changed', ...). */
+  private rpcWatchHandlerDisposer: (() => void) | null = null;
+  /** PathMapper used by the active patched adapter; needed to interpret fs.changed paths. */
+  private activePathMapper: PathMapper | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -345,6 +353,7 @@ export default class RemoteSshPlugin extends Plugin {
     this.patcher = new AdapterPatcher(targetAdapter, this.dataAdapter);
     try {
       this.patcher.patch(PATCHED_METHODS as unknown as ReadonlyArray<keyof object & string>);
+      this.activePathMapper = mapper;
       logger.info(`Adapter patched via ${transportLabel}: [${PATCHED_METHODS.join(', ')}]`);
       new Notice(`Remote SSH: adapter patched via ${transportLabel} (${PATCHED_METHODS.length} methods)`);
     } catch (e) {
@@ -354,6 +363,91 @@ export default class RemoteSshPlugin extends Plugin {
       this.readCache = null;
       this.dirCache = null;
       new Notice(`Adapter patch failed: ${(e as Error).message}`);
+      return;
+    }
+
+    // Live-update subscription is only meaningful on the RPC transport;
+    // the SFTP fallback has no notification channel.
+    if (this.rpcConnection) {
+      void this.subscribeToFsChanged();
+    }
+  }
+
+  /**
+   * Register an `fs.changed` notification handler and ask the daemon to
+   * watch the entire vault. Failure here is non-fatal: the adapter
+   * still works, the only loss is auto-refresh on remote-side edits.
+   */
+  private async subscribeToFsChanged(): Promise<void> {
+    if (!this.rpcConnection) return;
+    if (this.rpcWatchSubscriptionId) return;
+
+    const rpc = this.rpcConnection.rpc;
+    // Register the notification handler *before* sending fs.watch so we
+    // can't miss the very first event the daemon emits.
+    const handler = (params: FsChangedParams) => this.handleFsChanged(params);
+    this.rpcWatchHandlerDisposer = rpc.onNotification('fs.changed', handler);
+
+    try {
+      const result = await rpc.call('fs.watch', { path: '', recursive: true });
+      this.rpcWatchSubscriptionId = result.subscriptionId;
+      logger.info(`fs.watch subscribed: ${this.rpcWatchSubscriptionId}`);
+    } catch (e) {
+      logger.error(`fs.watch failed: ${(e as Error).message}`);
+      this.rpcWatchHandlerDisposer?.();
+      this.rpcWatchHandlerDisposer = null;
+    }
+  }
+
+  /**
+   * Translate a daemon-pushed `fs.changed` notification into a cache
+   * invalidation + (when the file is already known to the vault) a
+   * vault-level event so open editors and plugins re-read.
+   */
+  private handleFsChanged(params: FsChangedParams): void {
+    if (!this.dataAdapter) return;
+    if (this.rpcWatchSubscriptionId && params.subscriptionId !== this.rpcWatchSubscriptionId) {
+      return;
+    }
+
+    const action = interpretWatchEvent(params.path, this.activePathMapper);
+    if (!action) return;
+
+    this.dataAdapter.invalidateRemotePath(action.remotePath);
+
+    const eventName = mapFsChangeToVaultEvent(params.event);
+    if (!eventName) return;
+
+    const file = this.app.vault.getAbstractFileByPath(action.vaultPath);
+    if (!file) return;
+    // Vault.trigger is inherited from Events; dispatching the same
+    // events Obsidian's own scanner would dispatch lets editors and
+    // plugins react to remote-side edits without us having to reach
+    // into private internals.
+    (this.app.vault as unknown as { trigger: (name: string, ...args: unknown[]) => void })
+      .trigger(eventName, file);
+  }
+
+  /**
+   * Drop the daemon-side subscription and the local notification
+   * handler. Safe to call when nothing was subscribed (the patch
+   * never ran, the RPC tunnel was never established, etc.).
+   */
+  private unsubscribeFromFsChanged(): void {
+    const id = this.rpcWatchSubscriptionId;
+    this.rpcWatchSubscriptionId = null;
+    this.activePathMapper = null;
+
+    if (id && this.rpcConnection) {
+      // Best-effort: if the daemon-side subscription is already gone
+      // (process restart, connection drop) the call will reject and
+      // we just log it.
+      this.rpcConnection.rpc.call('fs.unwatch', { subscriptionId: id })
+        .catch(e => logger.warn(`fs.unwatch failed: ${(e as Error).message}`));
+    }
+    if (this.rpcWatchHandlerDisposer) {
+      this.rpcWatchHandlerDisposer();
+      this.rpcWatchHandlerDisposer = null;
     }
   }
 
@@ -367,6 +461,10 @@ export default class RemoteSshPlugin extends Plugin {
   }
 
   private restoreAdapter(): void {
+    // Drop the watch subscription before tearing the adapter down so
+    // any in-flight fs.changed callbacks find a still-valid adapter
+    // (or, if the handler races, a null `dataAdapter` which it tolerates).
+    this.unsubscribeFromFsChanged();
     if (this.patcher?.isPatched()) {
       try {
         this.patcher.restore();
@@ -521,5 +619,23 @@ export default class RemoteSshPlugin extends Plugin {
     } else if (this.state === SyncState.CONNECTED) {
       this.disconnect();
     }
+  }
+}
+
+/**
+ * Map the daemon's `fs.changed` event names onto Obsidian's vault
+ * event names. Returns `null` for events we don't surface — `renamed`
+ * needs both old and new paths and the cache invalidation already
+ * happened, so dispatching a partial event would just confuse plugins.
+ */
+function mapFsChangeToVaultEvent(
+  e: FsChangedParams['event'],
+): 'create' | 'modify' | 'delete' | null {
+  switch (e) {
+    case 'created':  return 'create';
+    case 'modified': return 'modify';
+    case 'deleted':  return 'delete';
+    case 'renamed':  return null;
+    default:         return null;
   }
 }

--- a/plugin/src/path/WatchEventFilter.ts
+++ b/plugin/src/path/WatchEventFilter.ts
@@ -1,0 +1,73 @@
+import type { PathMapper } from './PathMapper';
+
+/**
+ * Decision returned by `interpretWatchEvent`. Either:
+ *  - `null`     — the event should be silently dropped (atomic-write
+ *                 artefact, foreign client's private subtree, etc.)
+ *  - an object  — the event should be acted on, with `vaultPath`
+ *                 already translated back into the form Obsidian
+ *                 understands and `remotePath` retained so the
+ *                 caller can ask the adapter to invalidate caches.
+ */
+export interface WatchEventAction {
+  /** Path as Obsidian sees it (post `pathMapper.toVault` for our own subtree). */
+  vaultPath: string;
+  /** Path as the daemon reported it; cache keys are derived from this. */
+  remotePath: string;
+}
+
+/**
+ * Classifies one daemon-emitted `fs.changed` path against the active
+ * PathMapper.
+ *
+ * The function is pure so the rules can be unit-tested without a
+ * real RpcClient or vault: callers in `main.ts` just feed in the
+ * raw `params.path` and the configured PathMapper.
+ */
+export function interpretWatchEvent(
+  remotePath: string,
+  pathMapper: PathMapper | null,
+): WatchEventAction | null {
+  // Atomic-write tmp files (created by ServerDeployer's atomicWriteFile
+  // in tmp+rename) generate their own create/write events. They never
+  // belong to vault content, just drop them.
+  if (looksLikeAtomicWriteTmp(remotePath)) {
+    return null;
+  }
+
+  if (!pathMapper) {
+    return { vaultPath: remotePath, remotePath };
+  }
+
+  const userPrefix = `.obsidian/user/${pathMapper.clientId}/`;
+  const anyUserPrefix = '.obsidian/user/';
+
+  if (remotePath.startsWith(userPrefix)) {
+    // Our own per-client subtree — translate back so Obsidian sees
+    // the vault-canonical path (e.g. .obsidian/workspace.json).
+    const vaultPath = pathMapper.toVault(remotePath);
+    return { vaultPath, remotePath };
+  }
+
+  if (remotePath === '.obsidian/user' || remotePath.startsWith(anyUserPrefix)) {
+    // Either the user/ directory itself or another client's subtree.
+    // Both are private to other machines; we don't want their state
+    // racing through Obsidian's event loop on this side.
+    return null;
+  }
+
+  // Ordinary vault content: same path on both sides.
+  return { vaultPath: remotePath, remotePath };
+}
+
+/**
+ * Heuristic for the atomic-write tmp files atomicWriteFile drops next
+ * to its target during a write. Names follow `.rsh-write-<rand>.tmp`.
+ * We match conservatively: the pattern must appear as a basename
+ * component, not somewhere mid-string.
+ */
+function looksLikeAtomicWriteTmp(path: string): boolean {
+  const i = path.lastIndexOf('/');
+  const name = i < 0 ? path : path.slice(i + 1);
+  return name.startsWith('.rsh-write-') && name.endsWith('.tmp');
+}

--- a/plugin/tests/WatchEventFilter.test.ts
+++ b/plugin/tests/WatchEventFilter.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { interpretWatchEvent } from '../src/path/WatchEventFilter';
+import { PathMapper } from '../src/path/PathMapper';
+
+describe('interpretWatchEvent', () => {
+  it('passes ordinary vault paths through unchanged', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('Notes/foo.md', m)).toEqual({
+      vaultPath: 'Notes/foo.md', remotePath: 'Notes/foo.md',
+    });
+  });
+
+  it('translates our own per-client subtree back to the vault path', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('.obsidian/user/host-a/workspace.json', m)).toEqual({
+      vaultPath: '.obsidian/workspace.json',
+      remotePath: '.obsidian/user/host-a/workspace.json',
+    });
+  });
+
+  it('drops events from another client\'s subtree', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('.obsidian/user/host-b/workspace.json', m)).toBeNull();
+  });
+
+  it('drops events on the bare user/ directory', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('.obsidian/user', m)).toBeNull();
+  });
+
+  it('drops atomic-write tmp file artefacts at any depth', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('.rsh-write-abcd.tmp', m)).toBeNull();
+    expect(interpretWatchEvent('Notes/.rsh-write-9999.tmp', m)).toBeNull();
+    expect(interpretWatchEvent('docs/sub/.rsh-write-xyz.tmp', m)).toBeNull();
+  });
+
+  it('does NOT drop a file that just happens to mention the tmp pattern mid-path', () => {
+    // Suspiciously named user content shouldn't be filtered.
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('Notes/.rsh-write-real.md', m)).not.toBeNull();
+    expect(interpretWatchEvent('rsh-write-template.md', m)).not.toBeNull();
+  });
+
+  it('passes events through unchanged when no PathMapper is attached', () => {
+    expect(interpretWatchEvent('.obsidian/user/host-z/workspace.json', null))
+      .toEqual({
+        vaultPath: '.obsidian/user/host-z/workspace.json',
+        remotePath: '.obsidian/user/host-z/workspace.json',
+      });
+  });
+
+  it('passes shared .obsidian content (hotkeys, plugins, …) through unchanged', () => {
+    const m = new PathMapper('host-a');
+    expect(interpretWatchEvent('.obsidian/hotkeys.json', m)).toEqual({
+      vaultPath: '.obsidian/hotkeys.json',
+      remotePath: '.obsidian/hotkeys.json',
+    });
+    expect(interpretWatchEvent('.obsidian/plugins/myplugin/data.json', m)).toEqual({
+      vaultPath: '.obsidian/plugins/myplugin/data.json',
+      remotePath: '.obsidian/plugins/myplugin/data.json',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Plugin-side counterpart to PR #37 (server `fs.watch`/`fs.unwatch`).
Now when the patched adapter is brought up over the RPC transport,
the plugin subscribes to the daemon's vault-wide watcher and reacts
to incoming `fs.changed` pushes by:

- invalidating the matching `ReadCache` / `DirCache` entries
- dispatching the corresponding vault event (`create` / `modify` /
  `delete`) on already-known files so open editors re-read

A new pure helper `WatchEventFilter.interpretWatchEvent` keeps the
classification logic out of `main.ts`:

- atomic-write tmp files (`.rsh-write-*.tmp`) are dropped
- foreign clients' `.obsidian/user/<other-id>/` subtrees are dropped
- our own `.obsidian/user/<self-id>/...` paths are translated back to
  the vault-canonical form (`.obsidian/workspace.json`, etc.)

`restoreAdapter` now drops the daemon-side subscription before
restoring the adapter so we never leak watchers.

## Test plan

- [x] `npx tsc --noEmit` — no errors
- [x] `npm test` — 159 passed (15 files), incl. 7 new
      `WatchEventFilter` cases
- [x] `npm run build:full` — bundle + linux/amd64 daemon stage clean
- [x] `go test ./...` (server) — still green
- [ ] manual smoke: connect → patch adapter → edit a file on the
      remote, confirm console.log shows `fs.changed` invalidations
      and that the open Obsidian editor refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)