### PR TITLE
feat(plugin): ResourceBridge for serving remote binaries (Phase 5-F)

### DIFF
--- a/plugin/src/adapter/ResourceBridge.ts
+++ b/plugin/src/adapter/ResourceBridge.ts
@@ -1,0 +1,241 @@
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { randomBytes, timingSafeEqual } from 'crypto';
+import { logger } from '../util/logger';
+
+/**
+ * Async fetcher for vault binary content. The bridge calls this with a
+ * vault-relative path; the implementation goes through whatever adapter
+ * + cache + transport stack the plugin is using.
+ */
+export type FetchBinaryFn = (vaultPath: string) => Promise<Uint8Array>;
+
+export interface StartResult {
+  port: number;
+  /** Hex token embedded in every URL the bridge hands out. */
+  token: string;
+}
+
+/**
+ * Localhost HTTP server that serves binary vault assets to Obsidian's
+ * webview so `<img>`, `<iframe>`, `<audio>`, etc. can render content
+ * that lives on a remote host.
+ *
+ * The server binds to 127.0.0.1 on an OS-assigned random port. Every
+ * URL embeds a token that's regenerated on each `start()` so a leaked
+ * URL from a prior session can't replay against a new one.
+ *
+ * The server is intentionally minimal: GET requests only, no Range,
+ * full body in memory (the underlying readBinary already loads the
+ * whole file). Phase 6-B can add streaming + Range when large PDFs
+ * become a real pain point.
+ */
+export class ResourceBridge {
+  private server: http.Server | null = null;
+  private token: string | null = null;
+  private port: number | null = null;
+  private fetchBinary: FetchBinaryFn | null = null;
+
+  /**
+   * Start the HTTP server and return the chosen port + token. Calling
+   * `start` while already running is an error; `stop` first.
+   */
+  async start(fetchBinary: FetchBinaryFn): Promise<StartResult> {
+    if (this.server) {
+      throw new Error('ResourceBridge already started');
+    }
+    this.token = randomBytes(32).toString('hex');
+    this.fetchBinary = fetchBinary;
+
+    const server = http.createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+    this.server = server;
+
+    return new Promise<StartResult>((resolve, reject) => {
+      const onError = (err: Error) => {
+        this.server = null;
+        this.token = null;
+        this.fetchBinary = null;
+        reject(err);
+      };
+      server.once('error', onError);
+      server.listen(0, '127.0.0.1', () => {
+        server.removeListener('error', onError);
+        const addr = server.address() as AddressInfo;
+        this.port = addr.port;
+        logger.info(`ResourceBridge: listening on 127.0.0.1:${addr.port}`);
+        resolve({ port: addr.port, token: this.token! });
+      });
+    });
+  }
+
+  /** Stop the HTTP server. Safe to call when not running. */
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    const server = this.server;
+    this.server = null;
+    this.token = null;
+    this.port = null;
+    this.fetchBinary = null;
+
+    return new Promise<void>(resolve => {
+      // Force-close any in-flight responses so we don't hang on a slow
+      // remote read while the user is reloading the plugin.
+      try {
+        (server as { closeAllConnections?: () => void }).closeAllConnections?.();
+      } catch { /* older Node: best-effort */ }
+      server.close(() => resolve());
+    });
+  }
+
+  isRunning(): boolean {
+    return this.server !== null;
+  }
+
+  /**
+   * URL Obsidian's webview should hit to retrieve `vaultPath`. The
+   * bridge must already be started; the path is the vault-canonical
+   * form (post `PathMapper.toVault`) — translation back to the
+   * per-client subtree is handled by the `fetchBinary` callback when
+   * it goes through `SftpDataAdapter.readBinary`.
+   */
+  urlFor(vaultPath: string): string {
+    if (!this.server || !this.token || this.port === null) {
+      throw new Error('ResourceBridge not started');
+    }
+    const encoded = encodeURIComponent(vaultPath);
+    return `http://127.0.0.1:${this.port}/r/${this.token}?p=${encoded}`;
+  }
+
+  // ─── internals ───────────────────────────────────────────────────────────
+
+  private async handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+  ): Promise<void> {
+    if (req.method !== 'GET' && req.method !== 'HEAD') {
+      res.writeHead(405, { 'Allow': 'GET, HEAD' }).end();
+      return;
+    }
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    const m = /^\/r\/([0-9a-f]+)$/.exec(url.pathname);
+    if (!m) {
+      res.writeHead(404).end();
+      return;
+    }
+    const tokenInUrl = m[1];
+    if (!this.token || !constantTimeEqualHex(tokenInUrl, this.token)) {
+      res.writeHead(401).end();
+      return;
+    }
+    const rawPath = url.searchParams.get('p');
+    if (rawPath === null || rawPath === '') {
+      res.writeHead(400).end('missing p');
+      return;
+    }
+    if (!isSafeVaultPath(rawPath)) {
+      res.writeHead(400).end('bad path');
+      return;
+    }
+
+    const fetchBinary = this.fetchBinary;
+    if (!fetchBinary) {
+      res.writeHead(503).end();
+      return;
+    }
+
+    let bytes: Uint8Array;
+    try {
+      bytes = await fetchBinary(rawPath);
+    } catch (e) {
+      logger.warn(`ResourceBridge: read failed for "${rawPath}": ${(e as Error).message}`);
+      res.writeHead(404).end();
+      return;
+    }
+
+    const contentType = guessMimeType(rawPath);
+    res.writeHead(200, {
+      'Content-Type': contentType,
+      'Content-Length': bytes.byteLength,
+      'Cache-Control': 'no-store',
+    });
+    if (req.method === 'HEAD') {
+      res.end();
+    } else {
+      res.end(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
+    }
+  }
+}
+
+/**
+ * Constant-time hex comparison. timingSafeEqual itself requires equal
+ * lengths and Buffer inputs; we guard the length first since a length
+ * mismatch on tokens of different sizes would throw.
+ */
+function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, 'hex'), Buffer.from(b, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reject anything that could escape the vault root. Vault-relative
+ * paths shouldn't begin with `/` and shouldn't contain `..` segments;
+ * NULs are filesystem traps regardless of platform.
+ */
+function isSafeVaultPath(p: string): boolean {
+  if (p.includes('\0')) return false;
+  if (p.startsWith('/') || p.startsWith('\\')) return false;
+  for (const part of p.split(/[\\/]+/)) {
+    if (part === '..') return false;
+  }
+  return true;
+}
+
+const MIME_TYPES: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  svg: 'image/svg+xml',
+  ico: 'image/x-icon',
+  avif: 'image/avif',
+
+  pdf: 'application/pdf',
+
+  mp3: 'audio/mpeg',
+  ogg: 'audio/ogg',
+  oga: 'audio/ogg',
+  wav: 'audio/wav',
+  flac: 'audio/flac',
+  m4a: 'audio/mp4',
+  opus: 'audio/opus',
+
+  mp4: 'video/mp4',
+  m4v: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  ogv: 'video/ogg',
+
+  json: 'application/json',
+  txt: 'text/plain; charset=utf-8',
+  md:  'text/markdown; charset=utf-8',
+  html: 'text/html; charset=utf-8',
+  htm:  'text/html; charset=utf-8',
+  css:  'text/css; charset=utf-8',
+  js:   'application/javascript; charset=utf-8',
+  xml:  'application/xml; charset=utf-8',
+};
+
+function guessMimeType(path: string): string {
+  const dot = path.lastIndexOf('.');
+  if (dot < 0) return 'application/octet-stream';
+  const ext = path.slice(dot + 1).toLowerCase();
+  return MIME_TYPES[ext] ?? 'application/octet-stream';
+}

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -3,6 +3,7 @@ import type { RemoteFsClient } from './RemoteFsClient';
 import type { ReadCache } from '../cache/ReadCache';
 import type { DirCache } from '../cache/DirCache';
 import type { PathMapper } from '../path/PathMapper';
+import type { ResourceBridge } from './ResourceBridge';
 import type { RemoteEntry } from '../types';
 import { logger } from '../util/logger';
 
@@ -21,8 +22,12 @@ import { logger } from '../util/logger';
  * dependency from the concrete `SftpClient` to the narrow
  * `RemoteFsClient` interface.
  *
- * `getResourcePath` is intentionally not implemented yet; Phase 4-I
- * will add a localhost HTTP bridge for binary serving.
+ * `getResourcePath` returns a `http://127.0.0.1:<port>/r/<token>?p=…`
+ * URL served by an optional `ResourceBridge` (Phase 5-F). When no
+ * bridge is wired the method falls back to a `data:` URL with no
+ * payload, which Obsidian will fail to render — that's acceptable
+ * because resource serving is a feature of the patched adapter, not
+ * a hard requirement of the interface.
  *
  * Path translation is currently a straight join of `remoteBasePath`
  * and the vault-relative `normalizedPath`. The per-client user-cache
@@ -45,6 +50,13 @@ export class SftpDataAdapter {
      * Phase 4-J0.
      */
     private pathMapper: PathMapper | null = null,
+    /**
+     * Optional localhost HTTP bridge that serves binary content to the
+     * Obsidian webview. When supplied, `getResourcePath` returns a
+     * bridge URL so `<img>`, `<iframe>`, `<audio>` etc. can render
+     * remote-vault assets.
+     */
+    private resourceBridge: ResourceBridge | null = null,
   ) {}
 
   // ─── DataAdapter (read-side) ─────────────────────────────────────────────
@@ -151,6 +163,31 @@ export class SftpDataAdapter {
     const ab = new ArrayBuffer(buf.byteLength);
     new Uint8Array(ab).set(buf);
     return ab;
+  }
+
+  /**
+   * URL the Obsidian webview should fetch to render this asset. If
+   * the ResourceBridge is wired, the URL hits its localhost server
+   * (which calls back into this adapter's `readBinary` for the bytes,
+   * with all the cache + path-mapping logic intact). Without a bridge
+   * we hand back an empty `data:` URL — the asset won't render, but
+   * the read path is the only one that actually needs the bridge.
+   */
+  getResourcePath(normalizedPath: string): string {
+    if (this.resourceBridge && this.resourceBridge.isRunning()) {
+      return this.resourceBridge.urlFor(normalizedPath);
+    }
+    return 'data:application/octet-stream;base64,';
+  }
+
+  /**
+   * Read a vault-relative binary asset and hand back a `Uint8Array`.
+   * Wraps `readBinary` for the bridge's GET handler — ArrayBuffer ↔
+   * Uint8Array is just a view, not a copy.
+   */
+  async fetchBinaryForBridge(normalizedPath: string): Promise<Uint8Array> {
+    const ab = await this.readBinary(normalizedPath);
+    return new Uint8Array(ab);
   }
 
   // ─── DataAdapter (write-side) ────────────────────────────────────────────

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -10,6 +10,7 @@ import { ReadCache } from './cache/ReadCache';
 import { DirCache } from './cache/DirCache';
 import { SftpDataAdapter } from './adapter/SftpDataAdapter';
 import { AdapterPatcher } from './adapter/AdapterPatcher';
+import { ResourceBridge } from './adapter/ResourceBridge';
 import { SftpRemoteFsClient } from './adapter/SftpRemoteFsClient';
 import { RpcRemoteFsClient } from './adapter/RpcRemoteFsClient';
 import { establishRpcConnection } from './transport/RpcConnection';
@@ -35,6 +36,8 @@ const PATCHED_METHODS = [
   'mkdir', 'remove', 'rmdir', 'rename', 'copy',
   // trash
   'trashSystem', 'trashLocal',
+  // resources (binary URL for <img> / <iframe> / <audio>)
+  'getResourcePath',
 ] as const;
 
 export default class RemoteSshPlugin extends Plugin {
@@ -61,6 +64,8 @@ export default class RemoteSshPlugin extends Plugin {
   private rpcWatchHandlerDisposer: (() => void) | null = null;
   /** PathMapper used by the active patched adapter; needed to interpret fs.changed paths. */
   private activePathMapper: PathMapper | null = null;
+  /** Localhost HTTP bridge serving binary vault assets to the webview. */
+  private resourceBridge: ResourceBridge | null = null;
 
   async onload() {
     await this.loadSettings();
@@ -315,7 +320,7 @@ export default class RemoteSshPlugin extends Plugin {
     if (wasActive) new Notice('Remote SSH: Disconnected');
   }
 
-  private debugPatchAdapter(): void {
+  private async debugPatchAdapter(): Promise<void> {
     if (this.state !== SyncState.CONNECTED || !this.activeRemoteBasePath) {
       new Notice('Remote SSH: connect first');
       return;
@@ -342,6 +347,19 @@ export default class RemoteSshPlugin extends Plugin {
     const clientId = defaultClientId();
     const mapper = new PathMapper(clientId);
     logger.info(`PathMapper: clientId="${clientId}"`);
+
+    // Spin up the localhost binary bridge so getResourcePath has
+    // somewhere to send Obsidian. The bridge is best-effort: if it
+    // fails to bind we still patch and just lose image rendering.
+    const bridge = new ResourceBridge();
+    try {
+      await bridge.start(p => this.fetchBinaryForBridge(p));
+      this.resourceBridge = bridge;
+    } catch (e) {
+      logger.warn(`ResourceBridge: start failed: ${(e as Error).message}`);
+      this.resourceBridge = null;
+    }
+
     this.dataAdapter = new SftpDataAdapter(
       fsClient,
       this.activeRemoteBasePath,
@@ -349,6 +367,7 @@ export default class RemoteSshPlugin extends Plugin {
       this.dirCache,
       this.app.vault.getName(),
       mapper,
+      this.resourceBridge,
     );
     this.patcher = new AdapterPatcher(targetAdapter, this.dataAdapter);
     try {
@@ -362,6 +381,9 @@ export default class RemoteSshPlugin extends Plugin {
       this.dataAdapter = null;
       this.readCache = null;
       this.dirCache = null;
+      // Patch failed before we ever served a URL, so no point keeping
+      // the bridge alive for nobody.
+      void this.stopResourceBridge();
       new Notice(`Adapter patch failed: ${(e as Error).message}`);
       return;
     }
@@ -554,6 +576,33 @@ export default class RemoteSshPlugin extends Plugin {
     this.dataAdapter = null;
     this.readCache = null;
     this.dirCache = null;
+    // Bridge tears down asynchronously; we don't await here because
+    // restoreAdapter must remain sync for the connection-close hook.
+    void this.stopResourceBridge();
+  }
+
+  /**
+   * Bridge → adapter glue: fetch a binary asset through the patched
+   * adapter so the bridge benefits from caching and PathMapper
+   * translation. Returns `Uint8Array` as the bridge expects.
+   */
+  private async fetchBinaryForBridge(vaultPath: string): Promise<Uint8Array> {
+    if (!this.dataAdapter) {
+      throw new Error('adapter is not patched');
+    }
+    return this.dataAdapter.fetchBinaryForBridge(vaultPath);
+  }
+
+  /** Stop the resource bridge if running. Idempotent. */
+  private async stopResourceBridge(): Promise<void> {
+    const bridge = this.resourceBridge;
+    if (!bridge) return;
+    this.resourceBridge = null;
+    try {
+      await bridge.stop();
+    } catch (e) {
+      logger.warn(`ResourceBridge: stop failed: ${(e as Error).message}`);
+    }
   }
 
   private async debugListRoot(): Promise<void> {

--- a/plugin/tests/ResourceBridge.test.ts
+++ b/plugin/tests/ResourceBridge.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as http from 'http';
+import { ResourceBridge } from '../src/adapter/ResourceBridge';
+
+/**
+ * End-to-end tests against a real localhost http.Server. The bridge is
+ * small enough that mocking would just hide behaviour; spinning up a
+ * real server on 127.0.0.1:0 each test is fast (<10ms each) and
+ * covers the wire format we actually care about.
+ */
+describe('ResourceBridge', () => {
+  let bridge: ResourceBridge;
+  beforeEach(() => { bridge = new ResourceBridge(); });
+  afterEach(async () => { await bridge.stop(); });
+
+  it('start picks a random port and returns a hex token', async () => {
+    const { port, token } = await bridge.start(async () => new Uint8Array());
+    expect(port).toBeGreaterThan(0);
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(bridge.isRunning()).toBe(true);
+  });
+
+  it('serves a 200 + content for valid token + path', async () => {
+    const payload = new TextEncoder().encode('# hello world\n');
+    const fetchBinary = async (path: string) => {
+      expect(path).toBe('Notes/hi.md');
+      return payload;
+    };
+    await bridge.start(fetchBinary);
+    const url = bridge.urlFor('Notes/hi.md');
+    const r = await fetchUrl(url);
+    expect(r.statusCode).toBe(200);
+    expect(r.headers['content-type']).toBe('text/markdown; charset=utf-8');
+    expect(r.headers['cache-control']).toBe('no-store');
+    expect(Number(r.headers['content-length'])).toBe(payload.byteLength);
+    expect(r.body.toString('utf8')).toBe('# hello world\n');
+  });
+
+  it('returns 401 for a wrong token', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const real = new URL(bridge.urlFor('foo.png'));
+    const bad = `http://127.0.0.1:${real.port}/r/${'0'.repeat(64)}?p=foo.png`;
+    const r = await fetchUrl(bad);
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns 404 for a path that doesn\'t match /r/<hex>', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const real = new URL(bridge.urlFor('foo.png'));
+    const r = await fetchUrl(`http://127.0.0.1:${real.port}/wrong`);
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('rejects path traversal attempts with 400', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const real = new URL(bridge.urlFor('foo.png'));
+    const evil = `http://127.0.0.1:${real.port}/r/${real.pathname.split('/').pop()}?p=${encodeURIComponent('../etc/passwd')}`;
+    const r = await fetchUrl(evil);
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects absolute paths with 400', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const real = new URL(bridge.urlFor('foo.png'));
+    const evil = `http://127.0.0.1:${real.port}/r/${real.pathname.split('/').pop()}?p=${encodeURIComponent('/etc/passwd')}`;
+    const r = await fetchUrl(evil);
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects empty p parameter with 400', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const real = new URL(bridge.urlFor('foo.png'));
+    const r = await fetchUrl(`http://127.0.0.1:${real.port}/r/${real.pathname.split('/').pop()}`);
+    expect(r.statusCode).toBe(400);
+  });
+
+  it('rejects non-GET methods with 405', async () => {
+    await bridge.start(async () => new Uint8Array());
+    const url = new URL(bridge.urlFor('foo.png'));
+    const r = await new Promise<{ status: number }>((resolve, reject) => {
+      const req = http.request(
+        { host: url.hostname, port: url.port, path: url.pathname + url.search, method: 'POST' },
+        res => { res.resume(); resolve({ status: res.statusCode! }); },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(r.status).toBe(405);
+  });
+
+  it('returns 404 when the fetcher throws', async () => {
+    await bridge.start(async () => { throw new Error('not found'); });
+    const r = await fetchUrl(bridge.urlFor('missing.png'));
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('HEAD returns headers but no body', async () => {
+    const payload = new TextEncoder().encode('xyzzy');
+    await bridge.start(async () => payload);
+    const url = new URL(bridge.urlFor('a.txt'));
+    const r = await new Promise<http.IncomingMessage>((resolve, reject) => {
+      const req = http.request(
+        { host: url.hostname, port: url.port, path: url.pathname + url.search, method: 'HEAD' },
+        res => { res.resume(); resolve(res); },
+      );
+      req.on('error', reject);
+      req.end();
+    });
+    expect(r.statusCode).toBe(200);
+    expect(Number(r.headers['content-length'])).toBe(payload.byteLength);
+  });
+
+  it('guesses content-type for common extensions', async () => {
+    const payload = new Uint8Array([0]);
+    await bridge.start(async () => payload);
+    const cases = [
+      ['x.png',  'image/png'],
+      ['x.jpg',  'image/jpeg'],
+      ['x.svg',  'image/svg+xml'],
+      ['x.pdf',  'application/pdf'],
+      ['x.mp3',  'audio/mpeg'],
+      ['x.mp4',  'video/mp4'],
+      ['x.json', 'application/json'],
+      ['x.weird','application/octet-stream'],
+      ['noext',  'application/octet-stream'],
+    ] as const;
+    for (const [path, expected] of cases) {
+      const r = await fetchUrl(bridge.urlFor(path));
+      expect(r.statusCode).toBe(200);
+      expect(r.headers['content-type']).toBe(expected);
+    }
+  });
+
+  it('urlFor throws when not started', () => {
+    expect(() => bridge.urlFor('a.png')).toThrow();
+  });
+
+  it('start twice is rejected; stop allows restart with a fresh token', async () => {
+    const a = await bridge.start(async () => new Uint8Array());
+    await expect(bridge.start(async () => new Uint8Array())).rejects.toThrow();
+    await bridge.stop();
+    const b = await bridge.start(async () => new Uint8Array());
+    expect(b.token).not.toBe(a.token);
+  });
+
+  it('encoded slashes in the path round-trip correctly', async () => {
+    const payload = new TextEncoder().encode('nested');
+    let observed = '';
+    await bridge.start(async (p) => { observed = p; return payload; });
+    const r = await fetchUrl(bridge.urlFor('a/b/c.md'));
+    expect(r.statusCode).toBe(200);
+    expect(observed).toBe('a/b/c.md');
+  });
+});
+
+/**
+ * Tiny GET helper that resolves with status + headers + body. Avoids
+ * pulling in a fetch polyfill — vitest's `node` environment doesn't
+ * always have one configured here.
+ */
+function fetchUrl(rawUrl: string): Promise<{
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body: Buffer;
+}> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(rawUrl);
+    const req = http.request(
+      { host: u.hostname, port: u.port, path: u.pathname + u.search, method: 'GET' },
+      res => {
+        const chunks: Buffer[] = [];
+        res.on('data', c => chunks.push(c));
+        res.on('end', () => resolve({
+          statusCode: res.statusCode!,
+          headers: res.headers,
+          body: Buffer.concat(chunks),
+        }));
+        res.on('error', reject);
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}


### PR DESCRIPTION
## Summary

Phase 5-F. Without this, every image / PDF / audio attachment in a
remote vault rendered as a broken icon — the patched adapter had
no `getResourcePath` so Obsidian was asking the original
FileSystemAdapter for a local file that doesn't exist.

`ResourceBridge` is a localhost HTTP server (127.0.0.1, OS-assigned
port) that the patched `getResourcePath` hands URLs out for. The
server's GET handler calls back into the same patched
`SftpDataAdapter.readBinary`, so `PathMapper`, the `ReadCache`, and
the active transport (RPC daemon or SFTP fallback) are all reused
unchanged. Lifecycle is tied to the patched adapter: started in
`debugPatchAdapter`, stopped in `restoreAdapter`.

## Wire format

`http://127.0.0.1:<port>/r/<token>?p=<url-encoded vault path>`

- token is 32 random bytes hex, regenerated on every start; compared
  in constant time
- vault path is sanitized: rejects `..`, absolute paths, NUL
- Cache-Control: `no-store` (fs.watch invalidates the cache for us)
- Content-Type from a small inline mime map (image / pdf / audio /
  video / common text). Unknown → `application/octet-stream`
- HEAD supported; non-GET / non-HEAD → 405
- Range / streaming deferred to Phase 6-B; v1 sends the full body

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 173 passed (16 files), incl. 14 new ResourceBridge cases:
      port + token shape, 200 + body + headers, 401 wrong token, 404
      wrong route, 400 traversal/absolute/empty p, 405 wrong method,
      404 fetcher throw, HEAD has no body, mime guessing across 9
      extensions, urlFor before start throws, restart token rotation,
      slash round-trip
- [x] `npm run build:full` — bundle + linux/amd64 daemon staged
- [ ] manual smoke: with patched adapter, drag a PNG into a note on
      the remote shell, confirm it renders in Obsidian; same for a
      PDF embed and a small mp3

🤖 Generated with [Claude Code](https://claude.com/claude-code)