### PR TITLE
feat(plugin): reconnect-aware adapter gate + cancel + settings (Phase 4-K.2)

### DIFF
--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -74,6 +74,28 @@ export class SftpDataAdapter {
     this.client = newClient;
   }
 
+  /** True between the start of a reconnect loop and its terminal state. */
+  private reconnecting = false;
+
+  /**
+   * Toggle the "reconnecting" gate. While set:
+   *  - read / readBinary serve cached values only and throw on miss
+   *  - list / stat / exists throw immediately (no cache fallback)
+   *  - any write-side method throws with a clear "reconnecting" notice
+   *
+   * The reconnect manager flips this on at loop start and off at
+   * recovered / failed / cancelled. Existing in-flight calls hit
+   * the dead transport and reject naturally — only *new* calls are
+   * affected by the gate.
+   */
+  setReconnecting(on: boolean): void {
+    this.reconnecting = on;
+  }
+
+  isReconnecting(): boolean {
+    return this.reconnecting;
+  }
+
   // ─── DataAdapter (read-side) ─────────────────────────────────────────────
 
   getName(): string {
@@ -81,10 +103,12 @@ export class SftpDataAdapter {
   }
 
   async exists(normalizedPath: string, _sensitive?: boolean): Promise<boolean> {
+    if (this.reconnecting) throw reconnectingError();
     return this.client.exists(this.toRemote(normalizedPath));
   }
 
   async stat(normalizedPath: string): Promise<Stat | null> {
+    if (this.reconnecting) throw reconnectingError();
     try {
       const s = await this.client.stat(this.toRemote(normalizedPath));
       return {
@@ -101,6 +125,7 @@ export class SftpDataAdapter {
   }
 
   async list(normalizedPath: string): Promise<ListedFiles> {
+    if (this.reconnecting) throw reconnectingError();
     const plan = this.planList(normalizedPath);
     const primaryRemote = this.joinRemote(plan.primary);
 
@@ -208,14 +233,17 @@ export class SftpDataAdapter {
   // ─── DataAdapter (write-side) ────────────────────────────────────────────
 
   async write(normalizedPath: string, data: string, _options?: DataWriteOptions): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     await this.writeBuffer(normalizedPath, Buffer.from(data, 'utf8'));
   }
 
   async writeBinary(normalizedPath: string, data: ArrayBuffer, _options?: DataWriteOptions): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     await this.writeBuffer(normalizedPath, Buffer.from(data));
   }
 
   async append(normalizedPath: string, data: string, options?: DataWriteOptions): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     let existing = '';
     try { existing = await this.read(normalizedPath); }
     catch { /* file did not exist; start empty so append acts like create */ }
@@ -223,6 +251,7 @@ export class SftpDataAdapter {
   }
 
   async appendBinary(normalizedPath: string, data: ArrayBuffer, options?: DataWriteOptions): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     let existing: Buffer;
     try { existing = await this.readBuffer(normalizedPath); }
     catch { existing = Buffer.alloc(0); }
@@ -241,6 +270,7 @@ export class SftpDataAdapter {
     fn: (data: string) => string,
     options?: DataWriteOptions,
   ): Promise<string> {
+    if (this.reconnecting) throw reconnectingError();
     const current = await this.read(normalizedPath);
     const next = fn(current);
     await this.write(normalizedPath, next, options);
@@ -248,12 +278,14 @@ export class SftpDataAdapter {
   }
 
   async mkdir(normalizedPath: string): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const remote = this.toRemote(normalizedPath);
     await this.client.mkdirp(remote);
     this.dirCache.invalidate(parentDirRemote(remote));
   }
 
   async remove(normalizedPath: string): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const remote = this.toRemote(normalizedPath);
     await this.client.remove(remote);
     this.readCache.invalidate(remote);
@@ -261,6 +293,7 @@ export class SftpDataAdapter {
   }
 
   async rmdir(normalizedPath: string, recursive: boolean): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const remote = this.toRemote(normalizedPath);
     await this.client.rmdir(remote, recursive);
     this.readCache.invalidatePrefix(remote);
@@ -269,6 +302,7 @@ export class SftpDataAdapter {
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const oldRemote = this.toRemote(oldPath);
     const newRemote = this.toRemote(newPath);
     await this.client.mkdirp(parentDirRemote(newRemote));
@@ -281,6 +315,7 @@ export class SftpDataAdapter {
   }
 
   async copy(oldPath: string, newPath: string): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const oldRemote = this.toRemote(oldPath);
     const newRemote = this.toRemote(newPath);
     await this.client.mkdirp(parentDirRemote(newRemote));
@@ -305,6 +340,7 @@ export class SftpDataAdapter {
    * matches the desktop behaviour).
    */
   async trashLocal(normalizedPath: string): Promise<void> {
+    if (this.reconnecting) throw reconnectingError();
     const trashedPath = '.trash/' + normalizedPath;
     await this.rename(normalizedPath, trashedPath);
   }
@@ -323,6 +359,17 @@ export class SftpDataAdapter {
   private async readBuffer(normalizedPath: string): Promise<Buffer> {
     const remote = this.toRemote(normalizedPath);
     const cached = this.readCache.peek(remote);
+
+    // While reconnecting we can't talk to the remote at all. Serve
+    // whatever is already in the cache so already-open editors keep
+    // working; throw on a miss rather than block forever.
+    if (this.reconnecting) {
+      if (cached) {
+        this.readCache.get(remote); // bump LRU on hit
+        return cached.data;
+      }
+      throw reconnectingError();
+    }
 
     if (cached) {
       try {
@@ -425,4 +472,15 @@ function parentDirRemote(p: string): string {
   if (i < 0) return '';
   if (i === 0) return '/';
   return p.slice(0, i);
+}
+
+/**
+ * Stable error thrown by every adapter method while a reconnect is
+ * in flight. Distinguishes the "remote is temporarily unavailable"
+ * case from "file not found" / "permission denied" so callers (and
+ * the Obsidian editor in particular) can surface a friendly notice
+ * rather than a generic IO failure.
+ */
+function reconnectingError(): Error {
+  return new Error('Remote SSH: reconnecting — try again once the connection is restored');
 }

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   activeProfileId: null,
   enableDebugLog: false,
   maxLogLines: 500,
+  reconnectMaxRetries: 5,
 };
 
 export const MAX_RETRY = 4;

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -17,6 +17,7 @@ import { establishRpcConnection } from './transport/RpcConnection';
 import { ServerDeployer } from './transport/ServerDeployer';
 import { ReconnectManager } from './transport/ReconnectManager';
 import type { ReconnectState } from './transport/ReconnectManager';
+import { DEFAULT_BACKOFF } from './transport/Backoff';
 import { PathMapper, defaultClientId } from './path/PathMapper';
 import { interpretWatchEvent } from './path/WatchEventFilter';
 import type { FsChangedParams } from './proto/types';
@@ -116,6 +117,17 @@ export default class RemoteSshPlugin extends Plugin {
       id: 'disconnect',
       name: 'Disconnect from remote vault',
       callback: () => this.disconnect(),
+    });
+
+    this.addCommand({
+      id: 'cancel-reconnect',
+      name: 'Cancel ongoing reconnect',
+      checkCallback: (checking) => {
+        const active = this.reconnectManager?.isActive() ?? false;
+        if (checking) return active;
+        if (active) void this.cancelReconnect();
+        return true;
+      },
     });
 
     this.addCommand({
@@ -308,6 +320,25 @@ export default class RemoteSshPlugin extends Plugin {
   }
 
   /**
+   * User-driven cancel of the in-flight reconnect loop. Differs from
+   * `disconnect()` in that it doesn't try to stop a daemon (the SSH
+   * session is already dead) and it leaves `activeProfileId` alone so
+   * the user can hit "connect" again from the StatusBar without
+   * picking the profile again.
+   */
+  private async cancelReconnect(): Promise<void> {
+    if (!this.reconnectManager?.isActive()) return;
+    this.reconnectManager.cancel();
+    this.reconnectManager = null;
+    // Drop the patched adapter so Obsidian stops fielding "reconnecting"
+    // errors and falls back to the original FileSystemAdapter; the
+    // user is on their own to reconnect.
+    this.restoreAdapter();
+    this.setState(SyncState.ERROR);
+    new Notice('Remote SSH: Reconnect cancelled');
+  }
+
+  /**
    * Drive the reconnect loop after an unexpected SSH drop.
    *
    * Idempotent: a second unexpected close while a loop is already
@@ -321,10 +352,27 @@ export default class RemoteSshPlugin extends Plugin {
       this.setState(SyncState.ERROR);
       return;
     }
+    const maxRetries = this.settings.reconnectMaxRetries ?? DEFAULT_SETTINGS.reconnectMaxRetries;
+    if (maxRetries <= 0) {
+      // Auto-reconnect disabled — fall back to the pre-Phase-4-K
+      // behaviour: tear the patched adapter down and park on ERROR.
+      logger.info('startReconnect: auto-reconnect disabled (reconnectMaxRetries <= 0)');
+      this.restoreAdapter();
+      this.setState(SyncState.ERROR);
+      return;
+    }
     this.setState(SyncState.RECONNECTING);
+    // Park every adapter call on a deterministic "reconnecting" error
+    // (read-from-cache where possible) so write attempts during the
+    // outage don't silently corrupt remote state.
+    this.dataAdapter?.setReconnecting(true);
     const manager = new ReconnectManager({
       attempt: () => this.reconnectAttempt(),
       onState: (s) => this.onReconnectStateChange(s),
+      backoff: {
+        ...DEFAULT_BACKOFF,
+        maxRetries,
+      },
     });
     this.reconnectManager = manager;
     await manager.run();
@@ -405,18 +453,21 @@ export default class RemoteSshPlugin extends Plugin {
         `Remote SSH: Reconnecting (attempt ${s.attempt}/${s.totalAttempts})…`,
       );
     } else if (s.kind === 'recovered') {
+      this.dataAdapter?.setReconnecting(false);
       this.setState(SyncState.CONNECTED);
       new Notice('Remote SSH: Reconnected');
       this.reconnectManager = null;
     } else if (s.kind === 'failed') {
       // Give up: tear the patched adapter down so Obsidian falls
       // back to local file:// reads instead of blocking forever on a
-      // dead transport.
+      // dead transport. restoreAdapter clears dataAdapter so the
+      // setReconnecting flag goes with it.
       this.restoreAdapter();
       this.setState(SyncState.ERROR);
       new Notice(`Remote SSH: Reconnect failed — ${s.reason}`);
       this.reconnectManager = null;
     } else if (s.kind === 'cancelled') {
+      this.dataAdapter?.setReconnecting(false);
       this.reconnectManager = null;
     }
   }

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -41,6 +41,20 @@ export class SettingsTab extends PluginSettingTab {
           const { logger } = await import('../util/logger');
           logger.setDebug(v);
         }));
+
+    new Setting(containerEl)
+      .setName('Reconnect attempts after unexpected disconnect')
+      .setDesc('Number of times to retry the connection with exponential backoff before giving up. Set to 0 to disable auto-reconnect.')
+      .addText(t => t
+        .setPlaceholder('5')
+        .setValue(String(this.plugin.settings.reconnectMaxRetries))
+        .onChange(async v => {
+          const n = parseInt(v, 10);
+          if (Number.isFinite(n) && n >= 0 && n <= 100) {
+            this.plugin.settings.reconnectMaxRetries = n;
+            await this.plugin.saveSettings();
+          }
+        }));
   }
 
   private renderProfileRow(containerEl: HTMLElement, profile: SshProfile) {

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -68,6 +68,12 @@ export interface PluginSettings {
   activeProfileId: string | null;
   enableDebugLog: boolean;
   maxLogLines: number;
+  /**
+   * Maximum number of reconnect attempts after an unexpected SSH
+   * drop. Default 5 (Backoff's DEFAULT_BACKOFF.maxRetries). Set to 0
+   * to disable auto-reconnect entirely.
+   */
+  reconnectMaxRetries: number;
 }
 
 export interface LogLine {

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -640,4 +640,66 @@ describe('SftpDataAdapter (read-side)', () => {
       expect(newClient.client.stat).toHaveBeenCalled();
     });
   });
+
+  describe('setReconnecting (gate)', () => {
+    it('serves reads from the cache while reconnecting', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/note.md': { data: Buffer.from('CACHED'), mtime: 1 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      await adapter.read('note.md'); // prime cache
+      fake.client.stat.mockClear();
+      fake.client.readBinary.mockClear();
+      adapter.setReconnecting(true);
+      // Cached read is served without touching the (dead) client.
+      expect(await adapter.read('note.md')).toBe('CACHED');
+      expect(fake.client.stat).not.toHaveBeenCalled();
+      expect(fake.client.readBinary).not.toHaveBeenCalled();
+    });
+
+    it('throws on a cache miss while reconnecting', async () => {
+      const fake = makeFakeClient({});
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      adapter.setReconnecting(true);
+      await expect(adapter.read('absent.md')).rejects.toThrow(/reconnecting/i);
+    });
+
+    it('throws on every write-side method while reconnecting', async () => {
+      const fake = makeFakeClient({});
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      adapter.setReconnecting(true);
+      const ab = new ArrayBuffer(0);
+      await expect(adapter.write('a', 'x')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.writeBinary('a', ab)).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.append('a', 'x')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.appendBinary('a', ab)).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.process('a', x => x)).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.mkdir('d')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.remove('a')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.rmdir('d', false)).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.rename('a', 'b')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.copy('a', 'b')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.trashLocal('a')).rejects.toThrow(/reconnecting/i);
+    });
+
+    it('throws on stat / list / exists while reconnecting', async () => {
+      const fake = makeFakeClient({});
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      adapter.setReconnecting(true);
+      await expect(adapter.exists('x')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.stat('x')).rejects.toThrow(/reconnecting/i);
+      await expect(adapter.list('')).rejects.toThrow(/reconnecting/i);
+    });
+
+    it('returns to normal once the gate is cleared', async () => {
+      const fake = makeFakeClient({
+        files: { '/v/note.md': { data: Buffer.from('hi'), mtime: 9 } },
+      });
+      const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+      adapter.setReconnecting(true);
+      await expect(adapter.write('note.md', 'data')).rejects.toThrow(/reconnecting/i);
+      adapter.setReconnecting(false);
+      await expect(adapter.read('note.md')).resolves.toBe('hi');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Builds on 4-K.1's reconnect loop with the UX guards we deferred:

### Adapter gate

`SftpDataAdapter.setReconnecting(true)` parks every method on a
deterministic "reconnecting" error. Behaviour by method:

| method                                                      | behaviour while gated                       |
|-------------------------------------------------------------|---------------------------------------------|
| `read`, `readBinary`                                        | cache hit returned; cache miss throws       |
| `write`, `writeBinary`, `append`, `appendBinary`, `process` | throws — never silently buffer write data   |
| `mkdir`, `remove`, `rmdir`, `rename`, `copy`, `trashLocal`  | throws — same reason                        |
| `stat`, `list`, `exists`                                    | throws — no useful cache fallback           |
| `getResourcePath`                                           | unchanged (URL pointing at the bridge)      |

The error string is stable so Obsidian's editor can surface a
friendly notice instead of a generic IO failure. In-flight calls
that landed on the dead transport reject naturally; only new
calls are gated.

main.ts flips the gate on at `startReconnect` and off at the
terminal states (`recovered` / `cancelled`); `failed` ends up
calling `restoreAdapter` which drops the dataAdapter entirely.

### Cancel reconnect command

Available only while the manager is active (\`checkCallback\`):
cancels the loop, restores the patched adapter, parks on ERROR.
Distinct from `disconnect`, which also clears `activeProfile`.

### Configurable retry count

`settings.reconnectMaxRetries` (default 5). 0 disables auto-reconnect
entirely (falls back to the pre-4-K behaviour: notice + ERROR).
SettingsTab exposes it as a text input that validates 0..100.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 193 passed (18 files), incl. 5 new SftpDataAdapter
      cases: cache-hit during reconnect, cache-miss throws, every
      write-side method throws (11 methods), stat/list/exists throw,
      gate clears cleanly
- [x] `npm run build:full` — bundle + linux/amd64 daemon staged
- [ ] manual smoke: with adapter patched, kill remote sshd; confirm
      open editors keep showing their content (cache hit), Ctrl+S on
      a dirty file fires "Remote SSH: reconnecting" notice, "Cancel
      ongoing reconnect" command appears in palette only during the
      retry loop, and changing reconnectMaxRetries to 0 makes the
      next drop go straight to ERROR

🤖 Generated with [Claude Code](https://claude.com/claude-code)