### PR TITLE
feat(plugin): Range request support in ResourceBridge (Phase 6-B)

### DIFF
--- a/plugin/src/adapter/ResourceBridge.ts
+++ b/plugin/src/adapter/ResourceBridge.ts
@@ -155,17 +155,110 @@ export class ResourceBridge {
     }
 
     const contentType = guessMimeType(rawPath);
-    res.writeHead(200, {
+    const total = bytes.byteLength;
+
+    // Range support. We always advertise byte ranges in 200 responses;
+    // when the client asks for a range we respond with 206 and a
+    // sliced body. Note: we still load the *full* bytes through
+    // fetchBinary above — true partial reads would need
+    // `fs.readBinaryRange` in the daemon protocol (Phase 6-B.2).
+    // ReadCache means repeated range requests for the same file
+    // don't re-read across the SSH link as long as it fits.
+    const rangeHeader = req.headers.range;
+    const parsed = rangeHeader ? parseRangeHeader(rangeHeader, total) : 'none';
+
+    if (parsed === 'invalid') {
+      res.writeHead(416, {
+        'Content-Range': `bytes */${total}`,
+        'Cache-Control': 'no-store',
+      }).end();
+      return;
+    }
+
+    if (parsed === 'none') {
+      res.writeHead(200, {
+        'Content-Type': contentType,
+        'Content-Length': total,
+        'Cache-Control': 'no-store',
+        'Accept-Ranges': 'bytes',
+      });
+      if (req.method === 'HEAD') {
+        res.end();
+      } else {
+        res.end(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
+      }
+      return;
+    }
+
+    const { start, end } = parsed;
+    const sliceLen = end - start + 1;
+    res.writeHead(206, {
       'Content-Type': contentType,
-      'Content-Length': bytes.byteLength,
+      'Content-Length': sliceLen,
+      'Content-Range': `bytes ${start}-${end}/${total}`,
       'Cache-Control': 'no-store',
+      'Accept-Ranges': 'bytes',
     });
     if (req.method === 'HEAD') {
       res.end();
     } else {
-      res.end(Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength));
+      const slice = bytes.subarray(start, end + 1);
+      res.end(Buffer.from(slice.buffer, slice.byteOffset, slice.byteLength));
     }
   }
+}
+
+/**
+ * Parse an HTTP `Range:` header against a known total resource size.
+ * Pure function so the rules can be unit-tested without spinning up
+ * a server.
+ *
+ * Returns:
+ *   - `'invalid'` for syntactically broken or out-of-range requests
+ *     (caller should reply 416 with `Content-Range: bytes *\/total`)
+ *   - `{start, end}` for a satisfiable single-range request (caller
+ *     should reply 206 with `Content-Range: bytes start-end/total`)
+ *
+ * Multi-range (`bytes=0-50,100-150`) is intentionally rejected as
+ * invalid — the webview only ever asks for one range at a time, and
+ * supporting multipart/byteranges is a much bigger change.
+ *
+ * Forms understood (mirroring RFC 7233):
+ *   - `bytes=N-M`      — explicit start and end (inclusive)
+ *   - `bytes=N-`       — from N to the end of the resource
+ *   - `bytes=-N`       — last N bytes (a "suffix" range)
+ */
+export function parseRangeHeader(
+  headerValue: string,
+  totalSize: number,
+): { start: number; end: number } | 'invalid' {
+  if (totalSize <= 0) return 'invalid';
+  const m = /^bytes=(\d*)-(\d*)$/.exec(headerValue.trim());
+  if (!m) return 'invalid';
+  const startStr = m[1];
+  const endStr = m[2];
+  let start: number;
+  let end: number;
+  if (startStr === '' && endStr === '') return 'invalid';
+  if (startStr === '') {
+    // Suffix range: last N bytes.
+    const n = parseInt(endStr, 10);
+    if (!Number.isFinite(n) || n <= 0) return 'invalid';
+    start = Math.max(0, totalSize - n);
+    end = totalSize - 1;
+  } else if (endStr === '') {
+    start = parseInt(startStr, 10);
+    end = totalSize - 1;
+  } else {
+    start = parseInt(startStr, 10);
+    end = parseInt(endStr, 10);
+  }
+  if (!Number.isFinite(start) || !Number.isFinite(end)) return 'invalid';
+  if (start < 0 || start >= totalSize) return 'invalid';
+  if (end < start) return 'invalid';
+  // Spec allows clamping a too-large end; do so.
+  if (end >= totalSize) end = totalSize - 1;
+  return { start, end };
 }
 
 /**

--- a/plugin/tests/ResourceBridge.test.ts
+++ b/plugin/tests/ResourceBridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as http from 'http';
-import { ResourceBridge } from '../src/adapter/ResourceBridge';
+import { ResourceBridge, parseRangeHeader } from '../src/adapter/ResourceBridge';
 
 /**
  * End-to-end tests against a real localhost http.Server. The bridge is
@@ -158,7 +158,10 @@ describe('ResourceBridge', () => {
  * pulling in a fetch polyfill — vitest's `node` environment doesn't
  * always have one configured here.
  */
-function fetchUrl(rawUrl: string): Promise<{
+function fetchUrl(
+  rawUrl: string,
+  extraHeaders: http.OutgoingHttpHeaders = {},
+): Promise<{
   statusCode: number;
   headers: http.IncomingHttpHeaders;
   body: Buffer;
@@ -166,7 +169,13 @@ function fetchUrl(rawUrl: string): Promise<{
   return new Promise((resolve, reject) => {
     const u = new URL(rawUrl);
     const req = http.request(
-      { host: u.hostname, port: u.port, path: u.pathname + u.search, method: 'GET' },
+      {
+        host: u.hostname,
+        port: u.port,
+        path: u.pathname + u.search,
+        method: 'GET',
+        headers: extraHeaders,
+      },
       res => {
         const chunks: Buffer[] = [];
         res.on('data', c => chunks.push(c));
@@ -182,3 +191,104 @@ function fetchUrl(rawUrl: string): Promise<{
     req.end();
   });
 }
+
+describe('parseRangeHeader', () => {
+  it('parses an explicit start-end range', () => {
+    expect(parseRangeHeader('bytes=0-99', 1000)).toEqual({ start: 0, end: 99 });
+    expect(parseRangeHeader('bytes=100-199', 1000)).toEqual({ start: 100, end: 199 });
+  });
+
+  it('parses an open-ended range as start..total-1', () => {
+    expect(parseRangeHeader('bytes=500-', 1000)).toEqual({ start: 500, end: 999 });
+  });
+
+  it('parses a suffix range as last N bytes', () => {
+    expect(parseRangeHeader('bytes=-100', 1000)).toEqual({ start: 900, end: 999 });
+  });
+
+  it('clamps an end past total-1', () => {
+    expect(parseRangeHeader('bytes=100-9999', 1000)).toEqual({ start: 100, end: 999 });
+  });
+
+  it('rejects malformed headers as invalid', () => {
+    expect(parseRangeHeader('items=0-100', 1000)).toBe('invalid');
+    expect(parseRangeHeader('bytes=', 1000)).toBe('invalid');
+    expect(parseRangeHeader('bytes=-', 1000)).toBe('invalid');
+    expect(parseRangeHeader('bytes=abc-100', 1000)).toBe('invalid');
+    expect(parseRangeHeader('bytes=0-50,100-150', 1000)).toBe('invalid');
+  });
+
+  it('rejects a start past total', () => {
+    expect(parseRangeHeader('bytes=2000-', 1000)).toBe('invalid');
+  });
+
+  it('rejects start > end', () => {
+    expect(parseRangeHeader('bytes=200-100', 1000)).toBe('invalid');
+  });
+
+  it('rejects a suffix range of 0 bytes', () => {
+    expect(parseRangeHeader('bytes=-0', 1000)).toBe('invalid');
+  });
+
+  it('rejects all ranges on an empty resource', () => {
+    expect(parseRangeHeader('bytes=0-', 0)).toBe('invalid');
+  });
+});
+
+describe('ResourceBridge Range responses', () => {
+  let bridge: ResourceBridge;
+  beforeEach(() => { bridge = new ResourceBridge(); });
+  afterEach(async () => { await bridge.stop(); });
+
+  it('advertises Accept-Ranges: bytes on a regular 200 response', async () => {
+    await bridge.start(async () => new TextEncoder().encode('hello world'));
+    const r = await fetchUrl(bridge.urlFor('a.txt'));
+    expect(r.statusCode).toBe(200);
+    expect(r.headers['accept-ranges']).toBe('bytes');
+  });
+
+  it('serves 206 Partial Content for a valid Range', async () => {
+    const payload = new TextEncoder().encode('hello world'); // 11 bytes
+    await bridge.start(async () => payload);
+    const r = await fetchUrl(bridge.urlFor('a.txt'), { Range: 'bytes=6-10' });
+    expect(r.statusCode).toBe(206);
+    expect(r.headers['content-range']).toBe('bytes 6-10/11');
+    expect(Number(r.headers['content-length'])).toBe(5);
+    expect(r.body.toString('utf8')).toBe('world');
+  });
+
+  it('serves 206 for a suffix range', async () => {
+    const payload = new TextEncoder().encode('hello world');
+    await bridge.start(async () => payload);
+    const r = await fetchUrl(bridge.urlFor('a.txt'), { Range: 'bytes=-5' });
+    expect(r.statusCode).toBe(206);
+    expect(r.headers['content-range']).toBe('bytes 6-10/11');
+    expect(r.body.toString('utf8')).toBe('world');
+  });
+
+  it('serves 206 for an open-ended range', async () => {
+    const payload = new TextEncoder().encode('hello world');
+    await bridge.start(async () => payload);
+    const r = await fetchUrl(bridge.urlFor('a.txt'), { Range: 'bytes=6-' });
+    expect(r.statusCode).toBe(206);
+    expect(r.headers['content-range']).toBe('bytes 6-10/11');
+    expect(r.body.toString('utf8')).toBe('world');
+  });
+
+  it('returns 416 with Content-Range: bytes */N for an invalid range', async () => {
+    const payload = new TextEncoder().encode('hello world');
+    await bridge.start(async () => payload);
+    const r = await fetchUrl(bridge.urlFor('a.txt'), { Range: 'bytes=2000-3000' });
+    expect(r.statusCode).toBe(416);
+    expect(r.headers['content-range']).toBe('bytes */11');
+  });
+
+  it('clamps a too-large end and serves 206', async () => {
+    const payload = new TextEncoder().encode('hello world');
+    await bridge.start(async () => payload);
+    const r = await fetchUrl(bridge.urlFor('a.txt'), { Range: 'bytes=6-9999' });
+    expect(r.statusCode).toBe(206);
+    expect(r.headers['content-range']).toBe('bytes 6-10/11');
+    expect(r.body.toString('utf8')).toBe('world');
+  });
+});


### PR DESCRIPTION
## Summary

Webview can now seek inside large media (PDF, mp4) without
redownloading the whole asset on every scrub. The wire-level
implementation is complete (\`Range:\` / 206 / 416 / \`Accept-Ranges\`);
internally the bridge still loads the full bytes through
\`fetchBinary\` and slices server-side, which means ReadCache hits
make repeated seeks free but the very first read of a 1 GB video
still pulls 1 GB. Real partial reads via a new
\`fs.readBinaryRange\` RPC method land in 6-B.2.

## Wire format

| client                                    | response                                       |
|-------------------------------------------|------------------------------------------------|
| no \`Range\`                              | \`200\` + \`Accept-Ranges: bytes\` + full body  |
| \`Range: bytes=N-M\` (satisfiable)        | \`206\` + \`Content-Range: bytes N-M/total\`    |
| \`Range: bytes=N-\` / \`Range: bytes=-N\` | \`206\`, same as above with computed N..total-1 |
| invalid / out-of-range                    | \`416\` + \`Content-Range: bytes */total\`      |
| HEAD                                      | same headers, no body                           |

\`parseRangeHeader\` is exported as a pure helper and unit-tested
separately so the rules can be verified without a server.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 210 passed (18 files), incl. 15 new:
      \`parseRangeHeader\` (9 cases: explicit, open-ended, suffix,
      clamp, malformed, multi-range rejected, start-past-total,
      zero-suffix, empty-resource), end-to-end (6 cases:
      \`Accept-Ranges\` header, 206 explicit / suffix / open-ended,
      416 unsatisfiable, end clamped)
- [x] \`npm run build:full\` — bundle + linux/amd64 daemon staged
- [ ] manual smoke: with patched adapter, embed a remote-side PDF
      and confirm Obsidian opens it; scrubbing in a few-MB mp4
      should be smooth after the first read warms the cache

## Out of scope (6-B.2)

- True partial reads (\`fs.readBinaryRange\`) so >cache-size assets
  don't load fully on every cache miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)