### PR TITLE
feat(plugin): auto-patch adapter on connect (Tier 1-A)

### DIFF
--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -22,6 +22,7 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   reconnectMaxRetries: 5,
   clientId: '',
   userName: '',
+  autoPatchAdapter: true,
 };
 
 export const MAX_RETRY = 4;

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -18,7 +18,7 @@ import { ServerDeployer } from './transport/ServerDeployer';
 import { ReconnectManager } from './transport/ReconnectManager';
 import type { ReconnectState } from './transport/ReconnectManager';
 import { DEFAULT_BACKOFF } from './transport/Backoff';
-import { PathMapper, defaultClientId, sanitizeClientId } from './path/PathMapper';
+import { PathMapper, defaultClientId, defaultUserName, sanitizeClientId } from './path/PathMapper';
 import { interpretWatchEvent } from './path/WatchEventFilter';
 import type { FsChangedParams } from './proto/types';
 import * as fs from 'fs';
@@ -254,19 +254,43 @@ export default class RemoteSshPlugin extends Plugin {
       }
     }
 
-    // Adapter is NOT patched on connect: Obsidian still has paths it expects
-    // to read locally (`.obsidian/workspace.json`, plugin data, etc.) until
-    // PathMapper (Phase 4-J0) can redirect those to a per-client subtree.
-    // Use the "Debug: patch adapter" command to opt in for now.
     this.activeRemoteBasePath = effectivePath;
     this.activeProfile = profile;
     this.setState(SyncState.CONNECTED);
     this.settings.activeProfileId = profile.id;
     await this.saveSettings();
+
+    // Auto-patch is the VSCode Remote-SSH equivalent of "open folder
+    // on host" — without it the user sees a connected status bar but
+    // their vault is still local-only. We default to ON; debug
+    // workflows opt out via settings.
+    if (this.settings.autoPatchAdapter) {
+      const patched = await this.patchAdapter();
+      if (!patched) {
+        new Notice('Remote SSH: adapter patch failed — disconnecting');
+        await this.disconnect().catch(() => { /* already errored */ });
+        return;
+      }
+    }
+
+    const userLabel = this.formatUserLabel();
+    const patchSuffix = this.settings.autoPatchAdapter
+      ? ''
+      : ' (adapter NOT patched — autoPatchAdapter is off)';
     new Notice(
-      `Remote SSH: Connected to ${profile.name} via ${transport.toUpperCase()}${rpcSummary} ` +
-      `(adapter NOT patched — use "Debug: patch adapter" to opt in)`,
+      `Remote SSH: Connected to ${profile.name} as ${userLabel} via ${transport.toUpperCase()}${rpcSummary}${patchSuffix}`,
     );
+  }
+
+  /**
+   * Build a `userName@clientId` label using the active settings,
+   * with sensible fallbacks. Used for the connect notice and (later)
+   * for any presence info written alongside the per-client subtree.
+   */
+  private formatUserLabel(): string {
+    const userName = (this.settings.userName?.trim() || defaultUserName());
+    const clientId = this.resolveClientId();
+    return `${userName}@${clientId}`;
   }
 
   /**
@@ -532,14 +556,24 @@ export default class RemoteSshPlugin extends Plugin {
     if (wasActive) new Notice('Remote SSH: Disconnected');
   }
 
-  private async debugPatchAdapter(): Promise<void> {
+  /**
+   * Build the SftpDataAdapter, start the ResourceBridge, monkey-patch
+   * `app.vault.adapter`, and subscribe to fs.watch when the active
+   * transport is RPC.
+   *
+   * Returns true on success, false on failure. Silent — the caller
+   * decides what notice (if any) to surface; both
+   * `connectProfile`'s auto-patch and the manual debug command have
+   * different opinions on phrasing.
+   */
+  private async patchAdapter(): Promise<boolean> {
     if (this.state !== SyncState.CONNECTED || !this.activeRemoteBasePath) {
-      new Notice('Remote SSH: connect first');
-      return;
+      logger.warn('patchAdapter: state is not CONNECTED');
+      return false;
     }
     if (this.patcher?.isPatched()) {
-      new Notice('Remote SSH: adapter already patched');
-      return;
+      logger.info('patchAdapter: adapter already patched');
+      return true;
     }
     const targetAdapter = this.app.vault.adapter as unknown as object;
     this.readCache = new ReadCache();
@@ -586,7 +620,6 @@ export default class RemoteSshPlugin extends Plugin {
       this.patcher.patch(PATCHED_METHODS as unknown as ReadonlyArray<keyof object & string>);
       this.activePathMapper = mapper;
       logger.info(`Adapter patched via ${transportLabel}: [${PATCHED_METHODS.join(', ')}]`);
-      new Notice(`Remote SSH: adapter patched via ${transportLabel} (${PATCHED_METHODS.length} methods)`);
     } catch (e) {
       logger.error(`Adapter patch failed: ${(e as Error).message}`);
       this.patcher = null;
@@ -596,14 +629,38 @@ export default class RemoteSshPlugin extends Plugin {
       // Patch failed before we ever served a URL, so no point keeping
       // the bridge alive for nobody.
       void this.stopResourceBridge();
-      new Notice(`Adapter patch failed: ${(e as Error).message}`);
-      return;
+      return false;
     }
 
     // Live-update subscription is only meaningful on the RPC transport;
     // the SFTP fallback has no notification channel.
     if (this.rpcConnection) {
       void this.subscribeToFsChanged();
+    }
+    return true;
+  }
+
+  /**
+   * Manual command-palette entry point for adapter patching. Used
+   * during development to inspect pre-patch behaviour or to re-patch
+   * after a manual restore — `connectProfile` runs the same flow
+   * automatically when `settings.autoPatchAdapter` is true.
+   */
+  private async debugPatchAdapter(): Promise<void> {
+    if (this.state !== SyncState.CONNECTED || !this.activeRemoteBasePath) {
+      new Notice('Remote SSH: connect first');
+      return;
+    }
+    if (this.patcher?.isPatched()) {
+      new Notice('Remote SSH: adapter already patched');
+      return;
+    }
+    const transportLabel = this.rpcConnection ? 'RPC' : 'SFTP';
+    const ok = await this.patchAdapter();
+    if (ok) {
+      new Notice(`Remote SSH: adapter patched via ${transportLabel} (${PATCHED_METHODS.length} methods)`);
+    } else {
+      new Notice('Remote SSH: adapter patch failed (see console.log)');
     }
   }
 

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -73,6 +73,21 @@ export class SettingsTab extends PluginSettingTab {
         }));
 
     containerEl.createEl('h3', { text: 'Advanced' });
+
+    new Setting(containerEl)
+      .setName('Auto-patch adapter on connect')
+      .setDesc(
+        'When on, connecting to a profile immediately routes vault reads/writes '
+        + 'through the remote — the equivalent of "open folder on host" in VSCode '
+        + 'Remote-SSH. Turn off only for plugin development, when you want to '
+        + 'inspect the pre-patch state and use the Debug commands manually.',
+      )
+      .addToggle(t => t.setValue(this.plugin.settings.autoPatchAdapter)
+        .onChange(async v => {
+          this.plugin.settings.autoPatchAdapter = v;
+          await this.plugin.saveSettings();
+        }));
+
     new Setting(containerEl)
       .setName('Debug logging')
       .addToggle(t => t.setValue(this.plugin.settings.enableDebugLog)

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -89,6 +89,15 @@ export interface PluginSettings {
    * string falls back to the OS username.
    */
   userName: string;
+  /**
+   * When true (default), `connectProfile` automatically patches
+   * `app.vault.adapter` after a successful handshake so the user
+   * lands on the remote vault without running a separate command —
+   * the VSCode Remote-SSH equivalent of "open folder on host". Set
+   * to false during plugin development when you want to inspect the
+   * pre-patch state or use the Debug commands manually.
+   */
+  autoPatchAdapter: boolean;
 }
 
 export interface LogLine {


### PR DESCRIPTION
## Summary

The patched adapter is what makes the plugin actually feel like
VSCode Remote-SSH — without it, \`connect\` only opens an SSH session
while Obsidian keeps reading from the local FileSystemAdapter. Until
now the user had to run a separate \`Debug: patch adapter\` command to
flip into the remote view; this PR makes that automatic.

## Changes

- \`settings.autoPatchAdapter\` (default \`true\`). Off only for plugin
  development.
- \`connectProfile()\` calls a new silent \`patchAdapter()\` after the
  SSH/RPC handshake when the setting is on. On failure → notice +
  \`disconnect()\` so we never leave a half-connected state.
- \`debugPatchAdapter\` is now a thin wrapper that adds the
  success/failure notice; the underlying logic moved to
  \`patchAdapter()\` which returns \`Promise<boolean>\`.
- Connect notice: \`Connected to <profile> as <userName>@<clientId> via <transport>\`
  (reuses identity settings from #44).
- SettingsTab Advanced section gains the toggle, with a desc that
  explains the VSCode parallel.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 210 passed (no new tests; refactor preserves
      behaviour, the notice/setting changes are exercised by manual
      smoke)
- [x] \`npm run build:full\` — bundle + linux/amd64 daemon staged
- [ ] manual smoke (Tier 1 e2e from the plan):
  1. Fresh reload, connect via SSH profile → notice should read
     \`Connected to <name> as <user>@<host> via RPC\`
  2. File Explorer should immediately reflect the remote vault — no
     debug command needed
  3. Toggle \`autoPatchAdapter\` off, reconnect — notice mentions
     "adapter NOT patched", debug command works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)