### PR TITLE
feat(plugin): richer ssh_config parser + ProfileForm refresh (Tier 2-A)

### DIFF
--- a/plugin/src/settings/ProfileForm.ts
+++ b/plugin/src/settings/ProfileForm.ts
@@ -25,6 +25,17 @@ export class ProfileForm extends Modal {
   }
 
   onOpen() {
+    this.renderBody();
+  }
+
+  /**
+   * Render the modal contents from scratch. Called on first open
+   * and again whenever an SSH-config import has populated fields,
+   * so the form picks up the new values without close + re-open
+   * (which used to flicker the modal and lose the dropdown's
+   * selection state).
+   */
+  private renderBody() {
     const { contentEl } = this;
     contentEl.empty();
     contentEl.createEl('h2', { text: this.isNew ? 'Add SSH Profile' : 'Edit Profile' });
@@ -33,7 +44,7 @@ export class ProfileForm extends Modal {
     if (sshEntries.length > 0) {
       new Setting(contentEl)
         .setName('Import from SSH config')
-        .setDesc('Pre-fill fields from ~/.ssh/config')
+        .setDesc('Pre-fill fields from ~/.ssh/config (HostName, User, Port, IdentityFile, ProxyJump).')
         .addDropdown(d => {
           d.addOption('', '— select host —');
           for (const e of sshEntries) d.addOption(e.alias, e.alias);
@@ -41,8 +52,7 @@ export class ProfileForm extends Modal {
             if (!alias) return;
             const e = sshEntries.find(x => x.alias === alias)!;
             this.applyConfigEntry(e);
-            this.close();
-            new ProfileForm(this.app, this.profile, this.onSave).open();
+            this.renderBody();
           });
         });
     }
@@ -142,7 +152,18 @@ export class ProfileForm extends Modal {
       this.profile.privateKeyPath = e.identityFile;
     }
     if (e.proxyJump) {
-      this.profile.jumpHost = { host: e.proxyJump, port: 22, username: e.user, authMethod: 'privateKey' };
+      // ProxyJump → JumpHostConfig. Auth defaults to agent when no
+      // identity is known (matches OpenSSH's typical bastion setup),
+      // privateKey when the referenced Host block had an IdentityFile.
+      this.profile.jumpHost = {
+        host:           e.proxyJump.host,
+        port:           e.proxyJump.port,
+        username:       e.proxyJump.user,
+        authMethod:     e.proxyJump.identityFile ? 'privateKey' : 'agent',
+        privateKeyPath: e.proxyJump.identityFile,
+      };
+    } else {
+      this.profile.jumpHost = undefined;
     }
   }
 

--- a/plugin/src/ssh/SshConfigReader.ts
+++ b/plugin/src/ssh/SshConfigReader.ts
@@ -2,15 +2,56 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+/**
+ * One resolved Host entry from `~/.ssh/config`. Returned by
+ * `readSshConfig` after applying `Host *` defaults and resolving
+ * any `ProxyJump` reference back to its own Host block.
+ */
 export interface SshConfigEntry {
   alias: string;
   hostname: string;
   user: string;
   port: number;
   identityFile?: string;
+  proxyJump?: ProxyJumpEntry;
+}
+
+/**
+ * The first hop of a `ProxyJump` directive, with the referenced
+ * Host alias already inlined when one was found. We only surface
+ * the first hop because the SSH layer this plugin uses
+ * (ssh2.openssh_forwardOutStreamLocal) opens at most one bastion
+ * per session.
+ */
+export interface ProxyJumpEntry {
+  host: string;
+  port: number;
+  user: string;
+  identityFile?: string;
+}
+
+interface RawHostBlock {
+  /** Specific (non-wildcard) aliases declared on the `Host` line. */
+  aliases: string[];
+  /** True when this block is the literal `Host *` default block. */
+  isDefaults: boolean;
+  fields: RawFields;
+}
+
+interface RawFields {
+  hostname?: string;
+  user?: string;
+  port?: number;
+  identityFile?: string;
   proxyJump?: string;
 }
 
+/**
+ * Read and resolve the user's `~/.ssh/config` (or a custom path).
+ * Returns one entry per concrete Host alias. Wildcards other than
+ * the literal `*` are skipped — we don't try to evaluate
+ * `Host *.example.com` patterns. Missing or unreadable file → `[]`.
+ */
 export function readSshConfig(configPath?: string): SshConfigEntry[] {
   const filePath = configPath ?? path.join(os.homedir(), '.ssh', 'config');
   let content: string;
@@ -20,59 +61,183 @@ export function readSshConfig(configPath?: string): SshConfigEntry[] {
     return [];
   }
 
-  const entries: SshConfigEntry[] = [];
-  let alias: string | null = null;
-  let current: Partial<SshConfigEntry> = {};
+  const blocks = parseBlocks(content);
+  const defaults = mergeDefaults(blocks);
 
-  const flush = () => {
-    if (alias && current.hostname) {
-      entries.push(finalize(alias, current));
+  const entries: SshConfigEntry[] = [];
+  for (const block of blocks) {
+    if (block.isDefaults) continue;
+    for (const alias of block.aliases) {
+      entries.push(buildEntry(alias, block.fields, defaults));
     }
-  };
+  }
+
+  // Resolve ProxyJump references in a second pass so a forward
+  // reference (the bastion declared after the host that uses it)
+  // still resolves correctly.
+  const aliasMap = new Map(entries.map(e => [e.alias, e]));
+  for (const e of entries) {
+    if (e.proxyJump) {
+      e.proxyJump = resolveProxyJump(e.proxyJump, aliasMap, e.user);
+    }
+  }
+
+  return entries;
+}
+
+// ─── parsing ───────────────────────────────────────────────────────────
+
+function parseBlocks(content: string): RawHostBlock[] {
+  const blocks: RawHostBlock[] = [];
+  let current: RawHostBlock | null = null;
 
   for (const raw of content.split('\n')) {
     const line = raw.trim();
     if (!line || line.startsWith('#')) continue;
 
-    const spaceIdx = line.indexOf(' ');
-    if (spaceIdx === -1) continue;
-    const key = line.slice(0, spaceIdx).toLowerCase();
-    const value = line.slice(spaceIdx + 1).trim();
+    const ws = line.search(/\s/);
+    if (ws === -1) continue;
+    const key = line.slice(0, ws).toLowerCase();
+    const value = line.slice(ws + 1).trim();
 
     if (key === 'host') {
-      flush();
-      if (value.includes('*') || value.includes('?')) {
-        alias = null;
-      } else {
-        alias = value;
-        current = {};
-      }
+      const patterns = value.split(/\s+/).filter(Boolean);
+      const aliases = patterns.filter(p => !p.includes('*') && !p.includes('?'));
+      const isDefaults = patterns.length === 1 && patterns[0] === '*';
+      current = { aliases, isDefaults, fields: {} };
+      blocks.push(current);
       continue;
     }
 
-    if (!alias) continue;
+    if (!current) continue;
 
     switch (key) {
-      case 'hostname':     current.hostname = value; break;
-      case 'user':         current.user = value; break;
-      case 'port':         current.port = parseInt(value) || 22; break;
-      case 'identityfile': current.identityFile = value.replace('~', os.homedir()); break;
-      case 'proxyjump':    current.proxyJump = value; break;
+      case 'hostname':     current.fields.hostname = value; break;
+      case 'user':         current.fields.user = value; break;
+      case 'port':         current.fields.port = parseInt(value, 10) || 22; break;
+      case 'identityfile': current.fields.identityFile = expandTilde(value); break;
+      case 'proxyjump':    current.fields.proxyJump = value; break;
     }
   }
 
-  flush();
-
-  return entries;
+  return blocks;
 }
 
-function finalize(alias: string, e: Partial<SshConfigEntry>): SshConfigEntry {
+/**
+ * Walk the parsed blocks and compose a single defaults bag from
+ * every `Host *` block (later blocks shadow earlier ones, mirroring
+ * OpenSSH's "first match wins" semantics applied in declaration
+ * order).
+ */
+function mergeDefaults(blocks: RawHostBlock[]): RawFields {
+  const defaults: RawFields = {};
+  for (const b of blocks) {
+    if (!b.isDefaults) continue;
+    if (b.fields.hostname     !== undefined) defaults.hostname     = b.fields.hostname;
+    if (b.fields.user         !== undefined) defaults.user         = b.fields.user;
+    if (b.fields.port         !== undefined) defaults.port         = b.fields.port;
+    if (b.fields.identityFile !== undefined) defaults.identityFile = b.fields.identityFile;
+    if (b.fields.proxyJump    !== undefined) defaults.proxyJump    = b.fields.proxyJump;
+  }
+  return defaults;
+}
+
+function buildEntry(
+  alias: string,
+  fields: RawFields,
+  defaults: RawFields,
+): SshConfigEntry {
+  const hostname     = fields.hostname     ?? defaults.hostname     ?? alias;
+  const user         = fields.user         ?? defaults.user         ?? defaultUserName();
+  const port         = fields.port         ?? defaults.port         ?? 22;
+  const identityFile = fields.identityFile ?? defaults.identityFile;
+  const rawJump      = fields.proxyJump    ?? defaults.proxyJump;
+
   return {
     alias,
-    hostname:     e.hostname ?? alias,
-    user:         e.user ?? os.userInfo().username,
-    port:         e.port ?? 22,
-    identityFile: e.identityFile,
-    proxyJump:    e.proxyJump,
+    hostname,
+    user,
+    port,
+    identityFile,
+    // Note: user/identityFile on proxyJump are left blank-or-explicit
+    // here on purpose. The resolution pass in readSshConfig fills them
+    // from the referenced alias when available, falling back to the
+    // parent host's user when no alias matched.
+    proxyJump: rawJump !== undefined ? parseProxyJumpRaw(rawJump) : undefined,
   };
+}
+
+// ─── ProxyJump ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a `ProxyJump` directive value. The grammar is
+ * `[user@]host[:port]` per hop, comma-separated; we keep only the
+ * first hop. The result's `user` may be empty — that gap is filled
+ * by `resolveProxyJump` (which knows whether to use the referenced
+ * alias's user or the parent host's user).
+ */
+function parseProxyJumpRaw(raw: string): ProxyJumpEntry {
+  const first = raw.split(',')[0].trim();
+  let rest = first;
+  let user = '';
+
+  const at = first.indexOf('@');
+  if (at >= 0) {
+    user = first.slice(0, at);
+    rest = first.slice(at + 1);
+  }
+
+  let host = rest;
+  let port = 22;
+  const colon = rest.indexOf(':');
+  if (colon >= 0) {
+    host = rest.slice(0, colon);
+    port = parseInt(rest.slice(colon + 1), 10) || 22;
+  }
+
+  return { host, port, user, identityFile: undefined };
+}
+
+/**
+ * Fill in missing fields on the parsed ProxyJump entry. If the
+ * proxy host matches a declared Host alias, the alias's resolved
+ * fields take precedence (mirrors OpenSSH's "ProxyJump references
+ * the bastion's Host block" behaviour). When the proxy host is a
+ * literal hostname not matching any alias, an empty user falls back
+ * to the parent host's user.
+ *
+ * An explicit `port` or `user` in the ProxyJump line itself always
+ * wins over both the referenced alias and the parent fallback.
+ */
+function resolveProxyJump(
+  pj: ProxyJumpEntry,
+  aliasMap: Map<string, SshConfigEntry>,
+  parentUser: string,
+): ProxyJumpEntry {
+  const referenced = aliasMap.get(pj.host);
+  if (!referenced) {
+    return { ...pj, user: pj.user || parentUser };
+  }
+  return {
+    host: referenced.hostname,
+    port: pj.port !== 22 ? pj.port : referenced.port,
+    user: pj.user || referenced.user,
+    identityFile: referenced.identityFile,
+  };
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+function expandTilde(p: string): string {
+  if (p === '~') return os.homedir();
+  if (p.startsWith('~/')) return path.join(os.homedir(), p.slice(2));
+  return p;
+}
+
+function defaultUserName(): string {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return '';
+  }
 }

--- a/plugin/tests/SshConfigReader.test.ts
+++ b/plugin/tests/SshConfigReader.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { readSshConfig } from '../src/ssh/SshConfigReader';
+
+/**
+ * Each test writes a small ssh_config-like file to a temp dir and
+ * points readSshConfig at it; that's faster and more robust than
+ * mocking `fs`. Files are cleaned up in afterEach.
+ */
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ssh-cfg-test-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function write(content: string): string {
+  const p = path.join(tmpDir, 'config');
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+describe('readSshConfig: missing / empty file', () => {
+  it('returns [] when the file does not exist', () => {
+    expect(readSshConfig(path.join(tmpDir, 'nope'))).toEqual([]);
+  });
+
+  it('returns [] for an empty file', () => {
+    const p = write('');
+    expect(readSshConfig(p)).toEqual([]);
+  });
+
+  it('skips comments and blank lines', () => {
+    const p = write([
+      '# this is a comment',
+      '',
+      'Host foo',
+      '  HostName foo.example.com',
+      '',
+      '# another comment',
+    ].join('\n'));
+    const entries = readSshConfig(p);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].hostname).toBe('foo.example.com');
+  });
+});
+
+describe('readSshConfig: single host', () => {
+  it('reads HostName / User / Port / IdentityFile', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+      '  User alice',
+      '  Port 2222',
+      '  IdentityFile /home/alice/.ssh/id_ed25519',
+    ].join('\n'));
+    expect(readSshConfig(p)).toEqual([
+      {
+        alias: 'srv',
+        hostname: 'srv.example.com',
+        user: 'alice',
+        port: 2222,
+        identityFile: '/home/alice/.ssh/id_ed25519',
+        proxyJump: undefined,
+      },
+    ]);
+  });
+
+  it('expands ~ in IdentityFile', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+      '  IdentityFile ~/.ssh/id_ed25519',
+    ].join('\n'));
+    const entry = readSshConfig(p)[0];
+    expect(entry.identityFile).toBe(path.join(os.homedir(), '.ssh', 'id_ed25519'));
+  });
+
+  it('falls back hostname → alias when HostName is missing', () => {
+    const p = write([
+      'Host srv',
+      '  User alice',
+    ].join('\n'));
+    expect(readSshConfig(p)[0].hostname).toBe('srv');
+  });
+
+  it('falls back port → 22 and user → OS username', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+    ].join('\n'));
+    const entry = readSshConfig(p)[0];
+    expect(entry.port).toBe(22);
+    expect(entry.user).toBeTruthy(); // os.userInfo().username; non-empty everywhere we run
+  });
+});
+
+describe('readSshConfig: multi-pattern Host line', () => {
+  it('expands `Host foo bar` to two entries with shared body', () => {
+    const p = write([
+      'Host foo bar',
+      '  HostName 10.0.0.1',
+      '  User shared',
+    ].join('\n'));
+    const entries = readSshConfig(p);
+    expect(entries.map(e => e.alias).sort()).toEqual(['bar', 'foo']);
+    for (const e of entries) {
+      expect(e.hostname).toBe('10.0.0.1');
+      expect(e.user).toBe('shared');
+    }
+  });
+
+  it('skips wildcard patterns inside a multi-pattern line', () => {
+    const p = write([
+      'Host explicit *.wild',
+      '  User mixed',
+    ].join('\n'));
+    const entries = readSshConfig(p);
+    expect(entries.map(e => e.alias)).toEqual(['explicit']);
+  });
+});
+
+describe('readSshConfig: Host * defaults', () => {
+  it('applies defaults to non-wildcard entries that don\'t override them', () => {
+    const p = write([
+      'Host *',
+      '  User defaultuser',
+      '  IdentityFile /key',
+      '',
+      'Host srv',
+      '  HostName srv.example.com',
+    ].join('\n'));
+    const entry = readSshConfig(p)[0];
+    expect(entry.user).toBe('defaultuser');
+    expect(entry.identityFile).toBe('/key');
+  });
+
+  it('lets specific Host blocks override defaults', () => {
+    const p = write([
+      'Host *',
+      '  User defaultuser',
+      '',
+      'Host srv',
+      '  HostName srv.example.com',
+      '  User specific',
+    ].join('\n'));
+    expect(readSshConfig(p)[0].user).toBe('specific');
+  });
+
+  it('does not include the * block itself in the output', () => {
+    const p = write([
+      'Host *',
+      '  User defaultuser',
+      '',
+      'Host srv',
+      '  HostName srv.example.com',
+    ].join('\n'));
+    expect(readSshConfig(p).map(e => e.alias)).toEqual(['srv']);
+  });
+});
+
+describe('readSshConfig: ProxyJump', () => {
+  it('parses a literal hostname', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+      '  User alice',
+      '  ProxyJump bastion.example.com',
+    ].join('\n'));
+    const entry = readSshConfig(p)[0];
+    expect(entry.proxyJump).toEqual({
+      host: 'bastion.example.com',
+      port: 22,
+      user: 'alice',           // inherits from parent host
+      identityFile: undefined,
+    });
+  });
+
+  it('parses [user@]host[:port]', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+      '  User alice',
+      '  ProxyJump bob@bastion.example.com:2222',
+    ].join('\n'));
+    const entry = readSshConfig(p)[0];
+    expect(entry.proxyJump).toEqual({
+      host: 'bastion.example.com',
+      port: 2222,
+      user: 'bob',
+      identityFile: undefined,
+    });
+  });
+
+  it('takes only the first hop of a chain', () => {
+    const p = write([
+      'Host srv',
+      '  ProxyJump first.example.com,second.example.com',
+    ].join('\n'));
+    expect(readSshConfig(p)[0].proxyJump?.host).toBe('first.example.com');
+  });
+
+  it('resolves a referenced Host alias to its HostName/Port/User/IdentityFile', () => {
+    const p = write([
+      'Host bastion',
+      '  HostName 10.0.0.99',
+      '  User bastionuser',
+      '  Port 2200',
+      '  IdentityFile /bkey',
+      '',
+      'Host srv',
+      '  HostName srv.example.com',
+      '  ProxyJump bastion',
+    ].join('\n'));
+    const srv = readSshConfig(p).find(e => e.alias === 'srv')!;
+    expect(srv.proxyJump).toEqual({
+      host: '10.0.0.99',
+      port: 2200,
+      user: 'bastionuser',
+      identityFile: '/bkey',
+    });
+  });
+
+  it('lets an explicit ProxyJump port override the referenced alias\'s port', () => {
+    const p = write([
+      'Host bastion',
+      '  HostName 10.0.0.99',
+      '  Port 2200',
+      '',
+      'Host srv',
+      '  ProxyJump bastion:9999',
+    ].join('\n'));
+    const srv = readSshConfig(p).find(e => e.alias === 'srv')!;
+    expect(srv.proxyJump?.port).toBe(9999);
+  });
+
+  it('still works when the referenced alias is declared after the host that uses it', () => {
+    const p = write([
+      'Host srv',
+      '  ProxyJump bastion',
+      '',
+      'Host bastion',
+      '  HostName 10.0.0.99',
+    ].join('\n'));
+    const srv = readSshConfig(p).find(e => e.alias === 'srv')!;
+    expect(srv.proxyJump?.host).toBe('10.0.0.99');
+  });
+});


### PR DESCRIPTION
## Summary

The \`Import from SSH config\` dropdown was already wired, but the
parser had three real bugs and the import flow had a UX hack:

- \`Host foo bar\` (multi-pattern Host line) stored \`"foo bar"\` as a
  single alias instead of two
- \`Host *\` default blocks were skipped entirely
- ProxyJump was kept as a raw string; ProfileForm hardcoded
  \`port=22, authMethod=privateKey\` when converting it to
  JumpHostConfig, ignoring \`user@host\` or \`host:port\` suffixes and
  failing to resolve a ProxyJump alias to its own Host block
- After picking an alias the form did \`this.close(); new ProfileForm(...).open()\`

## Changes

### Reader rewrite

- Multi-pattern Host lines → one entry per alias, shared body.
  Mixed wildcards (\`Host explicit *.wild\`) keep only the explicit
  patterns.
- \`Host *\` defaults are merged and applied to every concrete entry;
  specific blocks always win.
- ProxyJump is now a structured \`ProxyJumpEntry\` (\`{host, port,
  user, identityFile?}\`). When the proxy host matches another Host
  alias, the alias's HostName/User/Port/IdentityFile are inlined;
  explicit \`user@\` or \`:port\` in the ProxyJump line still wins.
  Forward references (bastion declared after the host that uses
  it) resolve correctly.
- IdentityFile \`~\` and \`~/\` expand against the OS home dir.

### ProfileForm

- \`onOpen\` extracted into \`renderBody()\`; the import handler calls
  \`renderBody()\` instead of close + reopen.
- \`applyConfigEntry\` consumes the new \`ProxyJumpEntry\`; auth defaults
  to \`agent\` when no IdentityFile is known, \`privateKey\` when the
  referenced bastion block had one. Clearing the dropdown also
  clears \`profile.jumpHost\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 228 passed (19 files), 18 new cases on
      SshConfigReader covering missing/empty/comments, single host
      fields, \`~\` expansion, hostname/port/user fallbacks, multi-
      pattern, wildcard mixing, defaults merge + override, ProxyJump
      literal / \`user@host:port\` / chain (first hop) / alias
      resolution / explicit port wins / forward reference
- [x] \`npm run build:full\` — bundle + linux/amd64 daemon staged
- [ ] manual smoke (in dev vault):
  1. Open Add SSH Profile, pick a host from the dropdown — fields
     should populate without flicker.
  2. Pick a host whose \`~/.ssh/config\` declares ProxyJump pointing
     at another Host alias; verify the JumpHostConfig section shows
     the bastion's HostName, Port, IdentityFile.
  3. Save, reopen — values are persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)