### PR TITLE
feat(plugin): harden + test JumpHostTunnel (Tier 2-B)

### DIFF
--- a/plugin/src/ssh/JumpHostTunnel.ts
+++ b/plugin/src/ssh/JumpHostTunnel.ts
@@ -1,62 +1,116 @@
+import * as fs from 'fs';
 import { Client } from 'ssh2';
 import type { ConnectConfig } from 'ssh2';
+import type { Duplex } from 'stream';
 import type { JumpHostConfig } from '../types';
 import type { AuthResolver } from './AuthResolver';
+import type { HostKeyStore } from './HostKeyStore';
+import { expandHome } from '../util/pathUtils';
 import { logger } from '../util/logger';
 
 /**
- * Opens a direct-tcpip channel through a jump host and returns it as a
- * duplex stream.  The stream is passed as `sock` to the main Client so the
- * primary connection tunnels through without an intermediate local port.
+ * Optional knobs for `createJumpTunnel`. Most callers leave them at
+ * defaults; tests inject a mock `Client` factory so the SSH layer
+ * doesn't need a real bastion to run.
+ */
+export interface CreateJumpTunnelOptions {
+  /** TOFU verifier shared with the main session. Strongly recommended. */
+  hostKeyStore?: HostKeyStore;
+  /** Forwarded to ssh2's keepalive on the jump connection. */
+  keepaliveIntervalMs?: number;
+  /** Forwarded as `readyTimeout` to ssh2's connect. */
+  connectTimeoutMs?: number;
+  /** Test seam: factory for the underlying ssh2.Client. */
+  clientFactory?: () => Pick<
+    Client,
+    'on' | 'connect' | 'forwardOut' | 'end' | 'destroy'
+  > & { destroy?: () => void };
+}
+
+/**
+ * Open a direct-tcpip channel through a jump host and return it as a
+ * Duplex stream. The stream is passed as `sock` to the main `Client`
+ * so the primary connection tunnels through without an intermediate
+ * local port.
+ *
+ * The jump connection is kept alive while the returned stream is in
+ * use; the jump client tears down when the tunnel stream closes.
  */
 export async function createJumpTunnel(
   jump: JumpHostConfig,
   targetHost: string,
   targetPort: number,
   authResolver: AuthResolver,
-): Promise<import('stream').Duplex> {
-  const jumpClient = new Client();
+  options: CreateJumpTunnelOptions = {},
+): Promise<Duplex> {
+  const factory = options.clientFactory ?? (() => new Client());
+  const jumpClient = factory();
 
   const authConfig = buildJumpAuthConfig(jump, authResolver);
-
   const config: ConnectConfig = {
     host: jump.host,
     port: jump.port,
     username: jump.username,
-    readyTimeout: 15000,
+    readyTimeout: options.connectTimeoutMs ?? 15_000,
+    keepaliveInterval: options.keepaliveIntervalMs,
     ...authConfig,
   };
+  if (options.hostKeyStore) {
+    const store = options.hostKeyStore;
+    config.hostVerifier = (key: Buffer | string) => {
+      const buf = Buffer.isBuffer(key) ? key : Buffer.from(key as string, 'base64');
+      return store.verify(jump.host, jump.port, buf);
+    };
+  }
 
+  // Wait for the jump client to handshake. Both 'ready' and 'error'
+  // fire at most once; on error we destroy the client so we don't
+  // leak the underlying socket while the rejection unwinds.
   await new Promise<void>((resolve, reject) => {
-    jumpClient.on('ready', () => {
-      logger.info(`Jump host ${jump.host} ready`);
+    const onReady = () => {
+      logger.info(`Jump host ${jump.host}:${jump.port} ready`);
       resolve();
-    });
-    jumpClient.on('error', reject);
+    };
+    const onError = (err: Error) => {
+      try { jumpClient.destroy?.(); } catch { /* ignore */ }
+      reject(new Error(`Jump host "${jump.host}" connect failed: ${err.message}`));
+    };
+    jumpClient.on('ready', onReady);
+    jumpClient.on('error', onError);
     jumpClient.connect(config);
   });
 
-  return new Promise((resolve, reject) => {
+  return new Promise<Duplex>((resolve, reject) => {
     jumpClient.forwardOut(
       '127.0.0.1', 0,
       targetHost, targetPort,
       (err, stream) => {
         if (err) {
           jumpClient.end();
-          reject(new Error(`Jump tunnel to ${targetHost}:${targetPort} failed: ${err.message}`));
+          reject(new Error(
+            `Jump tunnel to ${targetHost}:${targetPort} via "${jump.host}" failed: ${err.message}`,
+          ));
           return;
         }
-        // Clean up jump client when the tunnel stream closes
+        // The forwarded stream owns the jump client lifetime: when
+        // the tunnel closes we tear the jump session down so the OS
+        // socket isn't left hanging.
         stream.on('close', () => {
-          logger.info(`Jump tunnel closed, ending jump client`);
-          jumpClient.end();
+          logger.info(`Jump tunnel to ${targetHost}:${targetPort} closed; ending jump client`);
+          try { jumpClient.end(); } catch { /* ignore */ }
         });
-        resolve(stream as unknown as import('stream').Duplex);
+        resolve(stream as unknown as Duplex);
       },
     );
   });
 }
 
+/**
+ * Build the auth half of `ConnectConfig` for the jump host. Mirrors
+ * `AuthResolver.buildAuthConfig` but for the slimmer
+ * `JumpHostConfig` data model (no passphrase, no agent override —
+ * extending the model is a separate change).
+ */
 function buildJumpAuthConfig(
   jump: JumpHostConfig,
   authResolver: AuthResolver,
@@ -66,17 +120,32 @@ function buildJumpAuthConfig(
       const password = jump.passwordRef
         ? authResolver.getSecret(jump.passwordRef)
         : undefined;
-      if (!password) throw new Error(`No password in memory for jump host "${jump.host}"`);
+      if (!password) {
+        throw new Error(`No password in memory for jump host "${jump.host}"`);
+      }
       return { password };
     }
     case 'privateKey': {
-      if (!jump.privateKeyPath) throw new Error(`No private key path for jump host "${jump.host}"`);
-      const fs = require('fs') as typeof import('fs');
-      return { privateKey: fs.readFileSync(jump.privateKeyPath) };
+      if (!jump.privateKeyPath) {
+        throw new Error(`No private key path for jump host "${jump.host}"`);
+      }
+      const keyPath = expandHome(jump.privateKeyPath);
+      let privateKey: Buffer;
+      try {
+        privateKey = fs.readFileSync(keyPath);
+      } catch (e) {
+        throw new Error(
+          `Cannot read jump host private key at "${keyPath}": ${(e as Error).message}`,
+        );
+      }
+      logger.info(`Jump host auth: using private key ${keyPath}`);
+      return { privateKey };
     }
     case 'agent': {
       const socket = process.env.SSH_AUTH_SOCK;
-      if (!socket) throw new Error('SSH_AUTH_SOCK not set for jump host agent auth');
+      if (!socket) {
+        throw new Error(`SSH_AUTH_SOCK not set; cannot use agent auth for jump host "${jump.host}"`);
+      }
       return { agent: socket };
     }
     default:

--- a/plugin/src/ssh/SftpClient.ts
+++ b/plugin/src/ssh/SftpClient.ts
@@ -61,7 +61,21 @@ export class SftpClient {
     let sock: Duplex | undefined;
     if (profile.jumpHost) {
       logger.info(`SftpClient: opening jump tunnel via ${profile.jumpHost.host}`);
-      sock = await createJumpTunnel(profile.jumpHost, profile.host, profile.port, this.authResolver);
+      // Share the host-key store + connect timings between the jump
+      // and target so a compromised bastion is caught the same way
+      // as a compromised target, and the jump session tears down
+      // around the same time the target idle-keepalive does.
+      sock = await createJumpTunnel(
+        profile.jumpHost,
+        profile.host,
+        profile.port,
+        this.authResolver,
+        {
+          hostKeyStore:        this.hostKeyStore,
+          connectTimeoutMs:    profile.connectTimeoutMs,
+          keepaliveIntervalMs: profile.keepaliveIntervalMs,
+        },
+      );
     }
 
     const client = new Client();

--- a/plugin/tests/JumpHostTunnel.test.ts
+++ b/plugin/tests/JumpHostTunnel.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createJumpTunnel } from '../src/ssh/JumpHostTunnel';
+import { AuthResolver } from '../src/ssh/AuthResolver';
+import { SecretStore } from '../src/ssh/SecretStore';
+import { HostKeyStore } from '../src/ssh/HostKeyStore';
+import type { JumpHostConfig } from '../src/types';
+
+/**
+ * Minimal fake of ssh2.Client. Exposes the surface
+ * `createJumpTunnel` exercises and lets each test pre-program the
+ * outcome of the connect handshake and the forwardOut callback.
+ */
+class FakeClient extends EventEmitter {
+  connectConfig: unknown = null;
+  forwardOutCalls: Array<{
+    srcHost: string; srcPort: number; dstHost: string; dstPort: number;
+  }> = [];
+  ended = 0;
+  destroyed = 0;
+
+  // Programmable outcomes
+  connectOutcome: 'ready' | 'error' | 'never' = 'ready';
+  connectError: Error = new Error('boom');
+  forwardOutcome: 'success' | 'error' | 'never' = 'success';
+  forwardError: Error = new Error('forward boom');
+  forwardStream: EventEmitter & { destroy?: () => void };
+
+  constructor() {
+    super();
+    this.forwardStream = new EventEmitter() as FakeClient['forwardStream'];
+    this.forwardStream.destroy = () => this.forwardStream.emit('close');
+  }
+
+  connect(config: unknown) {
+    this.connectConfig = config;
+    queueMicrotask(() => {
+      if (this.connectOutcome === 'ready')      this.emit('ready');
+      else if (this.connectOutcome === 'error') this.emit('error', this.connectError);
+      // 'never' just hangs the test — used for timeouts
+    });
+  }
+
+  forwardOut(
+    srcHost: string,
+    srcPort: number,
+    dstHost: string,
+    dstPort: number,
+    cb: (err: Error | undefined, stream: unknown) => void,
+  ) {
+    this.forwardOutCalls.push({ srcHost, srcPort, dstHost, dstPort });
+    queueMicrotask(() => {
+      if (this.forwardOutcome === 'success')    cb(undefined, this.forwardStream);
+      else if (this.forwardOutcome === 'error') cb(this.forwardError, undefined);
+    });
+  }
+
+  end()     { this.ended++; }
+  destroy() { this.destroyed++; }
+}
+
+let fake: FakeClient;
+let authResolver: AuthResolver;
+let secrets: SecretStore;
+
+const baseJump: JumpHostConfig = {
+  host: 'bastion.example.com',
+  port: 22,
+  username: 'alice',
+  authMethod: 'agent',
+};
+
+beforeEach(() => {
+  fake = new FakeClient();
+  secrets = new SecretStore();
+  authResolver = new AuthResolver(secrets);
+  // Tests assume agent auth so we don't have to write a real key file.
+  process.env.SSH_AUTH_SOCK = '/tmp/fake-agent.sock';
+});
+
+describe('createJumpTunnel: success path', () => {
+  it('connects, forwards, and resolves with the stream', async () => {
+    const stream = await createJumpTunnel(
+      baseJump,
+      'target.example.com', 22,
+      authResolver,
+      { clientFactory: () => fake },
+    );
+    expect(stream).toBe(fake.forwardStream);
+    expect(fake.forwardOutCalls).toHaveLength(1);
+    expect(fake.forwardOutCalls[0]).toMatchObject({
+      dstHost: 'target.example.com',
+      dstPort: 22,
+    });
+  });
+
+  it('passes connectTimeoutMs as readyTimeout and keepalive when configured', async () => {
+    await createJumpTunnel(
+      baseJump,
+      'target.example.com', 22,
+      authResolver,
+      {
+        clientFactory:       () => fake,
+        connectTimeoutMs:    9_000,
+        keepaliveIntervalMs: 5_000,
+      },
+    );
+    const cfg = fake.connectConfig as Record<string, unknown>;
+    expect(cfg.readyTimeout).toBe(9_000);
+    expect(cfg.keepaliveInterval).toBe(5_000);
+  });
+
+  it('uses a default readyTimeout when not configured', async () => {
+    await createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    );
+    const cfg = fake.connectConfig as Record<string, unknown>;
+    expect(cfg.readyTimeout).toBe(15_000);
+  });
+
+  it('attaches a hostVerifier when a HostKeyStore is supplied', async () => {
+    const store = new HostKeyStore();
+    const verifySpy = vi.spyOn(store, 'verify').mockReturnValue(true);
+    await createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake, hostKeyStore: store },
+    );
+    const cfg = fake.connectConfig as { hostVerifier?: (k: Buffer) => boolean };
+    expect(typeof cfg.hostVerifier).toBe('function');
+    cfg.hostVerifier!(Buffer.from('fake key'));
+    expect(verifySpy).toHaveBeenCalledWith('bastion.example.com', 22, expect.any(Buffer));
+  });
+
+  it('ends the jump client when the tunnel stream closes', async () => {
+    const stream = await createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    );
+    expect(fake.ended).toBe(0);
+    (stream as unknown as EventEmitter).emit('close');
+    expect(fake.ended).toBe(1);
+  });
+});
+
+describe('createJumpTunnel: failure paths', () => {
+  it('rejects with a wrapped error when the jump connect errors', async () => {
+    fake.connectOutcome = 'error';
+    fake.connectError = new Error('auth refused');
+    await expect(createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/Jump host "bastion.example.com" connect failed: auth refused/);
+    // Failed connect should destroy the client to free the socket.
+    expect(fake.destroyed).toBe(1);
+  });
+
+  it('rejects with a wrapped error when forwardOut fails', async () => {
+    fake.forwardOutcome = 'error';
+    fake.forwardError = new Error('admin prohibited');
+    await expect(createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/Jump tunnel to target.example.com:22 via "bastion.example.com" failed: admin prohibited/);
+    // forwardOut failure should also tear the jump client down.
+    expect(fake.ended).toBe(1);
+  });
+});
+
+describe('createJumpTunnel: auth handling', () => {
+  it('errors clearly when password auth has no stored secret', async () => {
+    const jump: JumpHostConfig = {
+      ...baseJump,
+      authMethod: 'password',
+      passwordRef: 'p:bastion',
+    };
+    await expect(createJumpTunnel(
+      jump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/No password in memory for jump host "bastion.example.com"/);
+  });
+
+  it('supplies a stored password to ssh2.connect', async () => {
+    authResolver.storeSecret('p:bastion', 's3cret');
+    const jump: JumpHostConfig = {
+      ...baseJump,
+      authMethod: 'password',
+      passwordRef: 'p:bastion',
+    };
+    await createJumpTunnel(
+      jump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    );
+    expect((fake.connectConfig as Record<string, unknown>).password).toBe('s3cret');
+  });
+
+  it('errors clearly when privateKey auth has no path set', async () => {
+    const jump: JumpHostConfig = {
+      ...baseJump,
+      authMethod: 'privateKey',
+    };
+    await expect(createJumpTunnel(
+      jump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/No private key path for jump host "bastion.example.com"/);
+  });
+
+  it('reads and forwards the private key when a path is set', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'jump-key-'));
+    const keyPath = path.join(tmp, 'id_test');
+    fs.writeFileSync(keyPath, 'FAKE-KEY-CONTENTS', 'utf8');
+    try {
+      const jump: JumpHostConfig = {
+        ...baseJump,
+        authMethod: 'privateKey',
+        privateKeyPath: keyPath,
+      };
+      await createJumpTunnel(
+        jump, 'target.example.com', 22, authResolver,
+        { clientFactory: () => fake },
+      );
+      const cfg = fake.connectConfig as { privateKey: Buffer };
+      expect(cfg.privateKey.toString('utf8')).toBe('FAKE-KEY-CONTENTS');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('errors when SSH_AUTH_SOCK is missing for agent auth', async () => {
+    const original = process.env.SSH_AUTH_SOCK;
+    delete process.env.SSH_AUTH_SOCK;
+    try {
+      await expect(createJumpTunnel(
+        baseJump, 'target.example.com', 22, authResolver,
+        { clientFactory: () => fake },
+      )).rejects.toThrow(/SSH_AUTH_SOCK not set/);
+    } finally {
+      if (original !== undefined) process.env.SSH_AUTH_SOCK = original;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

JumpHostTunnel was wired into \`SftpClient.connect\` already, but the
implementation skipped a few things that bite in production:

- **No host-key verification on the bastion.** A compromised jump
  host could silently MITM the target session even though the
  target's fingerprint was checked.
- **No keepaliveInterval.** Bastions that drop idle SSH connections
  silently broke the tunnel after a few minutes.
- **readyTimeout hard-coded at 15 s**, ignoring the profile's
  \`connectTimeoutMs\`.
- **No \`expandHome\`** on the jump's \`privateKeyPath\`, so
  \`~/.ssh/id_ed25519\` from the SshConfig importer didn't actually
  open.
- \`require('fs')\` instead of an ESM import.
- **Zero tests.** Three real-world bugs in the SshConfigReader
  changes (PR #49) convinced me we shouldn't ship more SSH code
  blind.

## Changes

- New \`CreateJumpTunnelOptions\` (hostKeyStore, keepaliveIntervalMs,
  connectTimeoutMs, clientFactory) — all optional, defaults
  preserve existing non-test behaviour.
- \`SftpClient.connect\` threads its existing \`HostKeyStore\` + the
  profile's keepalive/timeout settings into the jump call so a
  compromised bastion is rejected the same way as the target.
- \`expandHome\` on \`jump.privateKeyPath\`; clearer "cannot read jump
  key at <path>" error.
- Failed connect → \`destroy\`; failed forwardOut → \`end\`. Both
  messages now include the bastion's host:port plus the target's,
  so console.log makes it obvious which leg failed.
- ESM \`fs\` import. \`Pick<Client, …>\` type on the factory so the
  test mock doesn't need to implement the entire ssh2 surface.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 240 passed (20 files), 12 new JumpHostTunnel
      cases via a small EventEmitter-based fake of \`ssh2.Client\`:
      success path, options propagation (timeout / keepalive /
      hostVerifier delegation / default timeout), \`end()\` on stream
      close, connect-error wrapping + \`destroy\`, forwardOut-error
      wrapping + \`end\`, password / privateKey / agent auth
      success-and-failure modes
- [x] \`npm run build:full\` — bundle + linux/amd64 daemon staged
- [ ] manual smoke (in dev vault): connect a profile whose ssh_config
      Host block has a working \`ProxyJump\` line. Confirm:
  - first-time TOFU prompt (or implicit accept) for the bastion's
    host key fingerprint
  - bastion-side keepalive log lines roughly every
    \`keepaliveIntervalMs\`
  - tunnel survives the target's typical session length
  - kill the bastion connection (\`pkill sshd\` on it); the target
    side notices via the existing reconnect loop and rebuilds

🤖 Generated with [Claude Code](https://claude.com/claude-code)