### PR TITLE
chore(security): scrub remaining maintainer refs from HEAD

### DIFF
--- a/docs/architecture-shadow-vault.md
+++ b/docs/architecture-shadow-vault.md
@@ -495,13 +495,6 @@ captured `view.fileItems` before/after manual `view.onCreate(folder)`
 calls, which is what surfaced the "fire create for folders too"
 fix in PR #68.
 
-### Plan file
-
-Maintainer's local plan file at
-`C:\Users\souta\.claude\plans\self-archive-obsidian-staged-nova.md`
-gets rewritten alongside this PR to reflect the post-pivot reality
-(it was a pre-pivot handoff snapshot).
-
 ## 9. Post-MVP backlog
 
 Captured during the Phase 4 verification session — both items

--- a/plugin/tests/ServerDeployer.test.ts
+++ b/plugin/tests/ServerDeployer.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { ServerDeployer, resolveRemotePath, buildKillPattern, type DeployerSshClient } from '../src/transport/ServerDeployer';
 
 /**
- * Generic remote home used in mocks. Deliberately not the maintainer's
- * actual home (`/home/souta`) — the deployer must never assume any
- * particular shape, and tests should reflect that.
+ * Generic remote home used in mocks. Deliberately a fake path — the
+ * deployer must never assume any particular shape (`/home/...`,
+ * `/Users/...`, container paths) and tests should reflect that.
  */
 const FAKE_HOME = '/home/alice';
 


### PR DESCRIPTION
## Summary

Step 1 of the pre-public security pass. Two leftovers from the 0.3.2 cleanup that addressed only part of the tree:

- [docs/architecture-shadow-vault.md](docs/architecture-shadow-vault.md) — drops the \"Plan file\" subsection that pointed at the maintainer's local Claude plans path. No content lost; the surrounding sections cover the post-pivot reality.
- [plugin/tests/ServerDeployer.test.ts:1-9](plugin/tests/ServerDeployer.test.ts#L1-L9) — reword the leading comment to not name the maintainer's home path. Same point about not assuming any home shape stays.

History still references the same strings (this PR cleans HEAD only). A coordinated `git filter-repo` pass scrubs history before the repo flips to public.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 332 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)