### PR TITLE
ci(replay): replay previous release tag's tests against current source

### DIFF
--- a/.github/replay-skip.txt
+++ b/.github/replay-skip.txt
@@ -1,0 +1,26 @@
+# Tests from the previous release tag that no longer apply against
+# current main, listed here so the cross-version replay job
+# (`.github/workflows/replay.yml` / `npm run test:replay`) can
+# omit them while still asserting against the rest of the frozen
+# contract.
+#
+# Format (each non-comment line):
+#   <relative-path-under-plugin/tests/>  # <reason / PR ref>
+#
+# - Relative paths use forward slashes (e.g. `subdir/foo.test.ts`).
+# - The `# reason` comment is mandatory on the same line; the
+#   replay script rejects entries without one. Cite the PR that
+#   intentionally retired the invariant so reviewers can audit.
+# - Globs are NOT supported — list one test file per line. This is
+#   on purpose: each retirement is meant to be a deliberate per-file
+#   judgement, not a sweep.
+# - Comment-only lines and blank lines are ignored.
+#
+# Example (do not uncomment unless actually retiring the test):
+#   # AdapterPatcher.test.ts  # PR #175 changed snapshot semantics from data-prop to descriptor — old test no longer applies
+#
+# Keep this file as small as you can. Every entry here is a piece
+# of the previous version's contract that we have stopped enforcing.
+
+# (no entries — replay is expected to pass clean against the
+# current latest tag.)

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -1,0 +1,51 @@
+name: Cross-version test replay
+
+# Run the most recent published release tag's unit tests against the
+# PR's `plugin/src/`. Catches PRs that update tests in lockstep with
+# source so a previously-asserted invariant ships green even though
+# it's actually broken (see `plugin/scripts/replay-prev-tests.mjs`
+# for the rationale).
+#
+# **Trigger:** PRs into `main` only — push-to-main is redundant
+# (already checked at PR time) and would just burn CI cycles. The
+# matching push-to-main run can be added later if signal stays
+# clean over a few weeks of operation.
+#
+# **Status:** advisory (`continue-on-error: true` on the job's
+# `Run replay` step so a regression surfaces in the PR's checks
+# but doesn't block merge). Promote to required-check once the
+# signal-to-noise ratio has been proven over real PR traffic.
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: replay-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  replay:
+    name: Replay previous tag's tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugin
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need full history + tags so `git describe --tags
+          # --abbrev=0 origin/main` resolves the latest release.
+          # Default checkout depth = 1, which omits tag refs.
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: plugin/package-lock.json
+      - run: npm ci
+      # Advisory for now — regressions show up as a failed step in
+      # the PR check list but don't block merge. Flip
+      # `continue-on-error` to `false` to make this required.
+      - name: Run replay
+        continue-on-error: true
+        run: npm run test:replay

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@ plugin/server-bin/
 # baseline to an orphan branch instead of committing it here.
 plugin/perf-results/
 
+# Cross-version test replay scratch dir. Populated by
+# `npm run test:replay` (and the `replay.yml` CI workflow) with the
+# previous release tag's tests; cleaned up at script exit. Should
+# never appear in the working tree of a clean checkout.
+plugin/tests-replay/
+
 # Docker test environment artefacts: keypair generated on first run,
 # bind-mounted vault contents written by integration tests.
 docker/keys/id_test

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -13,6 +13,7 @@
     "cdp:tail": "node scripts/cdp-tail.mjs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
+    "test:replay": "node scripts/replay-prev-tests.mjs",
     "test:integration": "vitest run --config vitest.integration.config.ts --exclude **/perf.sync.bench.test.ts",
     "test:integration:bench": "vitest run --config vitest.integration.config.ts tests/integration/perf.sync.bench.test.ts",
     "sshd:start": "node scripts/start-test-sshd.mjs",

--- a/plugin/scripts/replay-prev-tests.mjs
+++ b/plugin/scripts/replay-prev-tests.mjs
@@ -1,0 +1,214 @@
+// Run the previous release tag's unit tests against the current
+// `plugin/src/` source.
+//
+// **Why:** in a normal PR, source and tests are modified together.
+// If the tests are updated to "fit" a behaviour change, an
+// otherwise-broken-by-the-PR invariant ships green. This replay
+// catches that: the tests as they existed at the previous release
+// tag are taken as a frozen contract; if any of them now fails
+// against current source, either the PR is a regression OR the
+// invariant is being intentionally retired (in which case the test
+// goes onto the skip list with a written reason).
+//
+// **Scope:** `plugin/tests/*.test.ts` only (the unit tier). The
+// integration suite is excluded — it's heavier, has its own opt-in
+// runner (`vitest.integration.config.ts`), and tends to hit
+// transient infra (sshd, workspaces) that's not what we're trying
+// to pin. A future variant can cover integration replay separately.
+//
+// **Usage:**
+//   - CI:    `.github/workflows/replay.yml` (advisory, PR only)
+//   - Local: `npm run test:replay` (from `plugin/`)
+//
+// **Skip list:** `.github/replay-skip.txt` at repo root. One
+// relative path per line (relative to `plugin/tests/`), with a
+// `# reason / PR ref` comment on the same line. Empty / comment-
+// only lines ignored. See the file's header for the full format.
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pluginRoot = path.resolve(here, '..');
+const repoRoot = path.resolve(pluginRoot, '..');
+
+const REPLAY_DIR = path.join(pluginRoot, 'tests-replay');
+const SKIP_LIST = path.join(repoRoot, '.github', 'replay-skip.txt');
+
+/** Run a command, exit on non-zero. Captures stdout for `git` queries. */
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, {
+    encoding: 'utf8',
+    stdio: opts.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+    cwd: opts.cwd ?? repoRoot,
+    shell: false,
+  });
+  if (r.status !== 0) {
+    if (opts.softFail) return null;
+    process.exit(r.status ?? 1);
+  }
+  return opts.capture ? r.stdout.trim() : '';
+}
+
+/** `git describe` against `origin/main` so PR branches replay against
+ *  the most recent **published** tag, not whatever happens to be
+ *  reachable from the PR's HEAD (which on a PR that bumps the
+ *  version would otherwise be the bump itself). */
+function findPreviousTag() {
+  // Prefer origin/main; fall back to local tag list if origin isn't
+  // wired (e.g. shallow clone in some CI configs).
+  const fromOrigin = run('git', ['describe', '--tags', '--abbrev=0', 'origin/main'], {
+    capture: true,
+    softFail: true,
+  });
+  if (fromOrigin) return fromOrigin;
+  return run('git', ['describe', '--tags', '--abbrev=0'], { capture: true });
+}
+
+/** Read `.github/replay-skip.txt` into a Set of relative paths.
+ *  Lines without a `#` reason comment are rejected — the format is
+ *  meant to be self-documenting. */
+function readSkipList() {
+  if (!fs.existsSync(SKIP_LIST)) return new Set();
+  const lines = fs.readFileSync(SKIP_LIST, 'utf8').split(/\r?\n/);
+  const skips = new Set();
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const hash = line.indexOf('#');
+    if (hash < 0) {
+      console.error(
+        `replay-skip.txt: missing '# reason' comment on line: "${line}"\n` +
+        `Each entry must explain why the test is being dropped.`,
+      );
+      process.exit(1);
+    }
+    const pathPart = line.slice(0, hash).trim();
+    if (pathPart) skips.add(pathPart);
+  }
+  return skips;
+}
+
+/** Recursively copy a directory, dropping any paths in the skip
+ *  set. Returns the count of `*.test.ts` files actually copied so
+ *  a misconfigured skip glob (= "skipped everything") is visible
+ *  in the log.
+ *
+ *  We copy the **entire** tests tree — including `integration/` —
+ *  rather than skipping integration at the dir level here, because
+ *  some top-level unit tests import helpers physically located
+ *  under `integration/helpers/` (e.g. `assertSyncReflect`,
+ *  `perfAggregator`). Stripping the directory would break those
+ *  imports at module-resolution time. The integration **tests**
+ *  themselves are excluded from execution by
+ *  `vitest.replay.config.ts`'s `exclude` glob, so they don't run
+ *  even though their helpers are present. */
+function copyTests(src, dest, skips) {
+  fs.mkdirSync(dest, { recursive: true });
+  let copied = 0;
+  const walk = (relDir) => {
+    const absSrc = path.join(src, relDir);
+    const absDest = path.join(dest, relDir);
+    fs.mkdirSync(absDest, { recursive: true });
+    for (const entry of fs.readdirSync(absSrc, { withFileTypes: true })) {
+      const rel = path.posix.join(relDir.replaceAll(path.sep, '/'), entry.name);
+      if (entry.isDirectory()) {
+        walk(rel);
+      } else if (entry.isFile()) {
+        if (skips.has(rel)) {
+          console.log(`replay: skipping ${rel} (in replay-skip.txt)`);
+          continue;
+        }
+        fs.copyFileSync(path.join(absSrc, entry.name), path.join(absDest, entry.name));
+        if (rel.endsWith('.test.ts')) copied += 1;
+      }
+    }
+  };
+  walk('');
+  return copied;
+}
+
+function rmrf(target) {
+  if (!fs.existsSync(target)) return;
+  // `maxRetries` + `retryDelay` smooth over Windows + cloud-sync
+  // (Dropbox / OneDrive) races where a recently-closed file handle
+  // hasn't been released yet, which surfaces as `EPERM` on `rmSync`.
+  // `force: true` already swallows ENOENT; the retries cover EPERM /
+  // EBUSY on slow filesystems.
+  //
+  // We swallow any leftover error: cleanup failure must not mask the
+  // test result. The replay scratch dir is gitignored, so a leftover
+  // tree only inconveniences the next run (which `rmrf`s upfront);
+  // it never escapes into the working tree's tracked state.
+  try {
+    fs.rmSync(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  } catch (e) {
+    console.warn(`replay: cleanup of ${target} failed (${e.code ?? 'unknown'}); leaving in place`);
+  }
+}
+
+function main() {
+  const tag = findPreviousTag();
+  if (!tag) {
+    console.error('replay: could not resolve a previous tag — repo has no tags?');
+    process.exit(1);
+  }
+  console.log(`replay: baseline tag = ${tag}`);
+
+  const worktree = fs.mkdtempSync(path.join(os.tmpdir(), 'replay-'));
+  rmrf(REPLAY_DIR);
+
+  let exitCode = 0;
+  try {
+    run('git', ['worktree', 'add', '--detach', worktree, tag]);
+    const skips = readSkipList();
+    const srcTests = path.join(worktree, 'plugin', 'tests');
+    if (!fs.existsSync(srcTests)) {
+      console.error(`replay: tag ${tag} has no plugin/tests/ — nothing to replay`);
+      return;
+    }
+    const copied = copyTests(srcTests, REPLAY_DIR, skips);
+    console.log(`replay: copied ${copied} unit-test file(s) from ${tag}`);
+    if (copied === 0) {
+      console.error('replay: 0 test files copied — skip list mis-configured?');
+      exitCode = 1;
+      return;
+    }
+
+    // Run vitest with the replay-only config. The default
+    // `vitest.config.ts` pins `include: tests/**/*.test.ts`, which
+    // doesn't match `tests-replay/`; the dedicated replay config
+    // narrows discovery to that directory exclusively. Inherits
+    // stdio so the user sees vitest's normal output.
+    const vitestBin = path.join(pluginRoot, 'node_modules', 'vitest', 'vitest.mjs');
+    const result = spawnSync(process.execPath, [
+      vitestBin, 'run', '--config', 'vitest.replay.config.ts',
+    ], {
+      cwd: pluginRoot,
+      stdio: 'inherit',
+      shell: false,
+    });
+    if (result.status !== 0) {
+      console.error(
+        `\nreplay: tests from ${tag} failed against current plugin/src/.\n` +
+        `Either fix the regression, or — if the invariant is being\n` +
+        `intentionally retired — append the failing test path(s) to\n` +
+        `.github/replay-skip.txt with a "# reason / PR ref" comment.`,
+      );
+      exitCode = result.status ?? 1;
+    } else {
+      console.log(`\nreplay: ${tag}'s tests pass against current source.`);
+    }
+  } finally {
+    // Always clean up so a re-run doesn't trip on a stale worktree.
+    run('git', ['worktree', 'remove', '--force', worktree], { softFail: true });
+    rmrf(worktree);
+    rmrf(REPLAY_DIR);
+  }
+  process.exit(exitCode);
+}
+
+main();

--- a/plugin/vitest.replay.config.ts
+++ b/plugin/vitest.replay.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+// Vitest config used by `npm run test:replay` (and the
+// `replay.yml` CI workflow). Discovers test files under
+// `tests-replay/` — the scratch dir the replay script populates
+// with the previous release tag's tests. Excludes the integration
+// tier the same way `vitest.config.ts` does.
+//
+// Why a separate config: the default config's `include` pin is
+// `tests/**/*.test.ts`, which doesn't match the sibling
+// `tests-replay/` directory. Mounting the previous tag's tests
+// inside `tests/` would let vitest discover them under the default
+// config too, but then `npm run test` would run them as well — we
+// want the replay invocation alone to see them.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['./vitest.setup.ts'],
+    include: ['tests-replay/**/*.test.ts'],
+    exclude: ['tests-replay/integration/**', 'node_modules/**'],
+  },
+});


### PR DESCRIPTION
## Summary

Adds a CI workflow + helper script that runs the **most recent published release tag's unit tests** against the PR's `plugin/src/`. This catches PRs where source and tests are modified in lockstep, hiding regressions of previously-asserted invariants.

The check is **advisory** for now (`continue-on-error: true`) — regressions show up as a failed step in the PR's check list but don't block merge. Promote to required once the signal-to-noise ratio has been validated over real PR traffic.

## Why

In a normal PR, `src/` and `tests/` change together. If a behaviour changes and the matching test is updated to fit, an otherwise-broken-by-the-PR invariant ships green. The replay catches that: the previous release's tests are the frozen contract; if any of them now fails against the current source, either the PR is a regression or the invariant is being intentionally retired (in which case the test goes onto an explicit skip list with a written reason).

This was a `相談` (consult) item from souta — chose **option A (tag replay)** out of three candidates (A: tag replay; B: append-only contract suite; C: snapshot pinning). Reasoning lives in the design discussion that produced this PR; the short version is **A reuses 626 existing tests as the contract for free, and shadow-vault-style major pivots are infrequent enough that the bless-list operational cost is acceptable**.

## What ships

| File | Role |
|---|---|
| `plugin/scripts/replay-prev-tests.mjs` | Orchestrator: resolves previous tag via `git describe --tags --abbrev=0 origin/main`, copies `plugin/tests/` into `plugin/tests-replay/`, applies skip list, runs vitest. Locally invokable via `npm run test:replay`. |
| `plugin/vitest.replay.config.ts` | Replay-only vitest config: discovers `tests-replay/**/*.test.ts`, excludes `tests-replay/integration/**`. Separate from the default config so `npm run test` doesn't double-run. |
| `.github/replay-skip.txt` | Append-only retirement list. Format: `<rel-path>  # <reason / PR ref>` per line; reason mandatory. Empty at landing. |
| `.github/workflows/replay.yml` | PR-only trigger, ubuntu, advisory step. Uses `fetch-depth: 0` so `git describe` sees tags. |
| `plugin/package.json` | New `test:replay` script. |
| `.gitignore` | Excludes the scratch dir. |

## Design notes

- **Why copy the entire tests tree (including `integration/`)**: some top-level unit tests import shared helpers from `integration/helpers/` (e.g. `assertSyncReflect`, `perfAggregator`). Stripping `integration/` at copy time broke those imports at module-resolution. The vitest config's `exclude` glob enforces "no integration tests run" instead.
- **Why a separate vitest config**: the default config pins `include: tests/**/*.test.ts`, which doesn't match the sibling `tests-replay/`. Mounting the previous tag's tests inside `tests/` would let vitest discover them under the default config too — but then `npm run test` would run them as well, defeating the point.
- **Why `git describe origin/main`** rather than `HEAD`: a PR that bumps the version (typical for feat/fix PRs in this repo) creates a tag-reachable bump commit if the tag was merged earlier. Resolving against `origin/main` ensures the baseline is always the most-recent-merged release, not the PR's own bump.
- **`continue-on-error: true` for now**: rolling out as advisory matches souta's "最初は advisory、 1 月運用して安定したら required に昇格" preference. The PR description for the eventual flip should cite which real PRs the check caught.

## Verification

Ran locally against tag `0.4.88` (the current latest): vitest discovered 42 unit-test files, ran 626 tests, all passed. The gitignored scratch dir is correctly cleaned up at script exit (with a Windows + Dropbox EPERM warning that's non-fatal — local-dev only; CI is ubuntu).

## Test plan

- [ ] CI shows the new `Cross-version test replay` check running on this PR
- [ ] The check passes against tag `0.4.88` with current source (= this PR's source modulo the CI files, which `tests-replay/` doesn't see)
- [ ] After merge, open a deliberately-broken follow-up PR (e.g. break one assertion in `plugin/src/adapter/SftpDataAdapter.ts`) to confirm the workflow flags it
- [ ] Once a few real PRs have run cleanly through this, flip `continue-on-error: true` → `false` and add the workflow to the required-check list

🤖 Generated with [Claude Code](https://claude.com/claude-code)