### PR TITLE
feat(mobile): implement WsRpcClient / WsRpcConnection / WsRemoteFsClient

### DIFF
--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -1,0 +1,1379 @@
+{
+  "name": "obsidian-remote-ssh-mobile",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obsidian-remote-ssh-mobile",
+      "version": "0.1.0",
+      "devDependencies": {
+        "obsidian": "latest",
+        "typescript": "^6.0.0",
+        "vitest": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obsidian": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/mobile/src/adapter/WsRemoteFsClient.ts
+++ b/mobile/src/adapter/WsRemoteFsClient.ts
@@ -1,0 +1,169 @@
+import { WsRpcClient } from '../transport/WsRpcClient.js';
+
+// ─── DTO shapes (mirror next/proto/types.ts) ─────────────────────────────────
+
+interface Stat {
+  type: 'file' | 'folder';
+  mtime: number;
+  size: number;
+  mode: number;
+}
+
+interface Entry {
+  name: string;
+  type: 'file' | 'folder' | 'symlink';
+  mtime: number;
+  size: number;
+}
+
+// ─── Public shapes ────────────────────────────────────────────────────────────
+
+export interface RemoteStat {
+  isDirectory: boolean;
+  isFile: boolean;
+  isSymbolicLink: boolean;
+  mtime: number;
+  size: number;
+  mode: number;
+}
+
+export interface RemoteEntry {
+  name: string;
+  isDirectory: boolean;
+  isFile: boolean;
+  isSymbolicLink: boolean;
+  mtime: number;
+  size: number;
+}
+
+export type CloseListener = (event: { unexpected: boolean }) => void;
+
+/**
+ * WsRemoteFsClient speaks to the Go daemon via WsRpcClient over a
+ * browser WebSocket + relay. It mirrors RpcRemoteFsClient (desktop)
+ * but uses Uint8Array / base64 instead of Node.js Buffer.
+ */
+export class WsRemoteFsClient {
+  constructor(private readonly rpc: WsRpcClient) {}
+
+  // ─── lifecycle ─────────────────────────────────────────────────────────
+
+  isAlive(): boolean {
+    return !this.rpc.isClosed();
+  }
+
+  onClose(cb: CloseListener): () => void {
+    return this.rpc.onClose((err) => cb({ unexpected: err !== undefined }));
+  }
+
+  // ─── read side ─────────────────────────────────────────────────────────
+
+  async stat(path: string): Promise<RemoteStat> {
+    const s = await this.rpc.call('fs.stat', { path }) as Stat | null;
+    if (s === null) {
+      throw Object.assign(new Error(`no such file: ${path}`), { code: -32020 });
+    }
+    return toRemoteStat(s);
+  }
+
+  async exists(path: string): Promise<boolean> {
+    const r = await this.rpc.call('fs.exists', { path }) as { exists: boolean };
+    return r.exists;
+  }
+
+  async list(path: string): Promise<RemoteEntry[]> {
+    const r = await this.rpc.call('fs.list', { path }) as { entries: Entry[] };
+    return r.entries.map(toRemoteEntry);
+  }
+
+  async readBinary(path: string): Promise<Uint8Array> {
+    const r = await this.rpc.call('fs.readBinary', { path }) as { contentBase64: string };
+    return b64ToUint8Array(r.contentBase64);
+  }
+
+  async readBinaryRange(
+    path: string,
+    offset: number,
+    length: number,
+    expectedMtime?: number,
+  ): Promise<{ data: Uint8Array; mtime: number; size: number }> {
+    const r = await this.rpc.call('fs.readBinaryRange', {
+      path, offset, length,
+      ...(expectedMtime !== undefined ? { expectedMtime } : {}),
+    }) as { contentBase64: string; mtime: number; size: number };
+    return { data: b64ToUint8Array(r.contentBase64), mtime: r.mtime, size: r.size };
+  }
+
+  // ─── write side ────────────────────────────────────────────────────────
+
+  async writeBinary(path: string, data: Uint8Array, expectedMtime?: number): Promise<void> {
+    await this.rpc.call('fs.writeBinary', {
+      path,
+      contentBase64: uint8ArrayToB64(data),
+      ...(expectedMtime !== undefined ? { expectedMtime } : {}),
+    });
+  }
+
+  async mkdirp(path: string): Promise<void> {
+    await this.rpc.call('fs.mkdir', { path, recursive: true });
+  }
+
+  async remove(path: string): Promise<void> {
+    await this.rpc.call('fs.remove', { path });
+  }
+
+  async rmdir(path: string, recursive = false): Promise<void> {
+    await this.rpc.call('fs.rmdir', { path, recursive });
+  }
+
+  async rename(oldPath: string, newPath: string): Promise<void> {
+    await this.rpc.call('fs.rename', { oldPath, newPath });
+  }
+
+  async copy(srcPath: string, destPath: string): Promise<void> {
+    await this.rpc.call('fs.copy', { srcPath, destPath });
+  }
+}
+
+// ─── DTO converters ──────────────────────────────────────────────────────────
+
+function toRemoteStat(s: Stat): RemoteStat {
+  return {
+    isDirectory:    s.type === 'folder',
+    isFile:         s.type === 'file',
+    isSymbolicLink: false,
+    mtime:          s.mtime,
+    size:           s.size,
+    mode:           s.mode,
+  };
+}
+
+function toRemoteEntry(e: Entry): RemoteEntry {
+  return {
+    name:           e.name,
+    isDirectory:    e.type === 'folder',
+    isFile:         e.type === 'file',
+    isSymbolicLink: e.type === 'symlink',
+    mtime:          e.mtime,
+    size:           e.size,
+  };
+}
+
+// ─── base64 helpers ──────────────────────────────────────────────────────────
+
+function uint8ArrayToB64(data: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]);
+  }
+  return btoa(binary);
+}
+
+function b64ToUint8Array(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+}

--- a/mobile/src/index.ts
+++ b/mobile/src/index.ts
@@ -6,4 +6,11 @@ export { RpcError } from './transport/RpcError.js';
 export { createMobileSecretStore } from './platform/MobileSecretStore.js';
 export type { SecretStore } from './platform/MobileSecretStore.js';
 
-// WsRpcClient, WsRpcConnection, WsRemoteFsClient — coming in follow-up PR
+export { WsRpcClient } from './transport/WsRpcClient.js';
+export type { WsRpcClientOptions, MethodName } from './transport/WsRpcClient.js';
+
+export { WsRpcConnection } from './transport/WsRpcConnection.js';
+export type { ServerInfo, WsRpcConnectionOptions } from './transport/WsRpcConnection.js';
+
+export { WsRemoteFsClient } from './adapter/WsRemoteFsClient.js';
+export type { RemoteStat, RemoteEntry, CloseListener } from './adapter/WsRemoteFsClient.js';

--- a/mobile/src/transport/WsRpcClient.ts
+++ b/mobile/src/transport/WsRpcClient.ts
@@ -1,0 +1,157 @@
+import { WsChannel } from './WsChannel.js';
+import { RpcError } from './RpcError.js';
+
+// MethodName duplicated from next/proto/types to avoid cross-package import.
+export type MethodName =
+  | 'auth' | 'server.info'
+  | 'fs.stat' | 'fs.exists' | 'fs.list' | 'fs.walk'
+  | 'fs.readText' | 'fs.readBinary' | 'fs.readBinaryRange' | 'fs.thumbnail'
+  | 'fs.write' | 'fs.writeBinary' | 'fs.append' | 'fs.appendBinary'
+  | 'fs.mkdir' | 'fs.remove' | 'fs.rmdir' | 'fs.rename' | 'fs.copy'
+  | 'fs.watch' | 'fs.unwatch';
+
+export interface WsRpcClientOptions {
+  /** Call timeout in milliseconds. Default 30 000. */
+  timeoutMs?: number;
+}
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject:  (reason: unknown) => void;
+  timer:   ReturnType<typeof setTimeout>;
+}
+
+/**
+ * Correlates JSON-RPC 2.0 calls over a WsChannel.
+ *
+ * Each call() writes a Request with a fresh numeric id and returns a
+ * Promise that resolves with the decoded `result` when the matching
+ * reply arrives, or rejects with RpcError when the daemon returns an
+ * error envelope or the call times out.
+ *
+ * Server-push notifications are delivered to handlers registered via
+ * onNotification(). When the channel closes, every pending call is
+ * rejected so callers do not hang forever.
+ */
+export class WsRpcClient {
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingCall>();
+  private readonly notificationHandlers = new Map<string, Array<(p: unknown) => void>>();
+  private readonly closeHandlers: Array<(err?: Error) => void> = [];
+  private closed = false;
+  private readonly timeoutMs: number;
+
+  constructor(private readonly channel: WsChannel, opts: WsRpcClientOptions = {}) {
+    this.timeoutMs = opts.timeoutMs ?? 30_000;
+    channel.onMessage((body) => this.handleMessage(body));
+    channel.onClose(() => this.handleClose());
+  }
+
+  /** Send a request and await its reply. Rejects with RpcError on daemon error or timeout. */
+  async call(method: MethodName, params: Record<string, unknown>): Promise<unknown> {
+    if (this.closed) throw new RpcError(-32603, 'WsRpcClient: closed');
+    const id = this.nextId++;
+    const body = new TextEncoder().encode(
+      JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+    );
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new RpcError(-32603, `RPC timeout: ${method}`));
+      }, this.timeoutMs);
+
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.channel.send(body);
+      } catch (e) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    });
+  }
+
+  /** Register a handler for server-push notifications. Returns a disposer. */
+  onNotification(method: string, handler: (params: unknown) => void): () => void {
+    const list = this.notificationHandlers.get(method) ?? [];
+    list.push(handler);
+    this.notificationHandlers.set(method, list);
+    return () => {
+      const l = this.notificationHandlers.get(method);
+      if (!l) return;
+      const i = l.indexOf(handler);
+      if (i >= 0) l.splice(i, 1);
+    };
+  }
+
+  /** Called once when the channel closes (cleanly or with error). Returns a disposer. */
+  onClose(handler: (err?: Error) => void): () => void {
+    this.closeHandlers.push(handler);
+    return () => {
+      const i = this.closeHandlers.indexOf(handler);
+      if (i >= 0) this.closeHandlers.splice(i, 1);
+    };
+  }
+
+  isClosed(): boolean { return this.closed; }
+
+  /** Close the underlying channel; pending calls reject. */
+  close(): void {
+    if (this.closed) return;
+    this.channel.close();
+  }
+
+  // ─── internals ────────────────────────────────────────────────────────────
+
+  private handleMessage(body: Uint8Array): void {
+    let msg: unknown;
+    try {
+      msg = JSON.parse(new TextDecoder().decode(body));
+    } catch {
+      return; // ignore malformed frames
+    }
+    if (typeof msg !== 'object' || msg === null) return;
+    const m = msg as Record<string, unknown>;
+
+    // Response — matches a pending call by numeric id.
+    if (typeof m['id'] === 'number') {
+      const p = this.pending.get(m['id']);
+      if (!p) return;
+      clearTimeout(p.timer);
+      this.pending.delete(m['id']);
+      const err = m['error'];
+      if (err && typeof err === 'object') {
+        const e = err as { code: number; message: string; data?: unknown };
+        p.reject(new RpcError(e.code, e.message, e.data));
+        return;
+      }
+      p.resolve('result' in m ? m['result'] : null);
+      return;
+    }
+
+    // Notification — no id.
+    if (typeof m['method'] === 'string') {
+      const list = this.notificationHandlers.get(m['method']);
+      if (!list || list.length === 0) return;
+      const params = m['params'];
+      for (const h of [...list]) {
+        try { h(params); } catch { /* per-handler isolation */ }
+      }
+    }
+  }
+
+  private handleClose(err?: Error): void {
+    if (this.closed) return;
+    this.closed = true;
+    const reason = err ?? new RpcError(-32603, 'WsRpcClient: stream closed before reply');
+    for (const p of this.pending.values()) {
+      clearTimeout(p.timer);
+      p.reject(reason);
+    }
+    this.pending.clear();
+    for (const cb of [...this.closeHandlers]) {
+      try { cb(err); } catch { /* ignore */ }
+    }
+  }
+}

--- a/mobile/src/transport/WsRpcConnection.ts
+++ b/mobile/src/transport/WsRpcConnection.ts
@@ -1,0 +1,89 @@
+import { WsChannel } from './WsChannel.js';
+import { WsRpcClient } from './WsRpcClient.js';
+import { RpcError } from './RpcError.js';
+
+/** Minimal ServerInfo shape (mirrors next/proto/types.ts). */
+export interface ServerInfo {
+  version: string;
+  protocolVersion: number;
+  capabilities: string[];
+  vaultRoot: string;
+}
+
+export interface WsRpcConnectionOptions {
+  /** Auth token issued by the relay / plugin on the other end. */
+  token: string;
+  /** Call timeout forwarded to WsRpcClient. Default 30 000 ms. */
+  timeoutMs?: number;
+}
+
+/**
+ * A successfully authenticated JSON-RPC connection to the remote
+ * daemon (or relay). Exposes the underlying RPC client + the
+ * server info gathered during the handshake.
+ *
+ * Typical lifecycle:
+ *
+ *   const conn = await WsRpcConnection.connect(ws, { token });
+ *   const client = conn.rpc;
+ *   conn.close(); // tears down the WsChannel
+ */
+export class WsRpcConnection {
+  /** The authenticated RPC client. Use this for all subsequent calls. */
+  readonly rpc: WsRpcClient;
+  /** Info returned by the server.info RPC during the handshake. */
+  readonly serverInfo: ServerInfo;
+
+  private constructor(rpc: WsRpcClient, serverInfo: ServerInfo) {
+    this.rpc = rpc;
+    this.serverInfo = serverInfo;
+  }
+
+  /** Tear down the underlying WebSocket channel. */
+  close(): void {
+    this.rpc.close();
+  }
+
+  /**
+   * Open a WsChannel over `ws`, authenticate with `token`, and fetch
+   * server info. Resolves once the handshake completes; rejects with
+   * RpcError if auth is refused or the connection drops.
+   *
+   * The WsChannel is created internally so callers pass a raw
+   * WebSocket — they do not need to construct WsChannel themselves.
+   */
+  static async connect(ws: WebSocket, opts: WsRpcConnectionOptions): Promise<WsRpcConnection> {
+    const channel = new WsChannel(ws, { queueBeforeOpen: true });
+    const rpc = new WsRpcClient(channel, { timeoutMs: opts.timeoutMs });
+
+    // Wait for the WebSocket to open before sending any frames.
+    await waitForOpen(ws);
+
+    // 1. Authenticate.
+    await rpc.call('auth', { token: opts.token });
+
+    // 2. Fetch server capabilities and vault root.
+    const info = await rpc.call('server.info', {}) as ServerInfo;
+
+    return new WsRpcConnection(rpc, info);
+  }
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise<void>((resolve, reject) => {
+    const onOpen = () => { cleanup(); resolve(); };
+    const onError = () => { cleanup(); reject(new RpcError(-32603, 'WebSocket failed to open')); };
+    const onClose = () => { cleanup(); reject(new RpcError(-32603, 'WebSocket closed before open')); };
+    function cleanup() {
+      ws.removeEventListener('open', onOpen);
+      ws.removeEventListener('error', onError);
+      ws.removeEventListener('close', onClose);
+    }
+    ws.addEventListener('open', onOpen);
+    ws.addEventListener('error', onError);
+    ws.addEventListener('close', onClose);
+  });
+}

--- a/mobile/tests/WsRemoteFsClient.test.ts
+++ b/mobile/tests/WsRemoteFsClient.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WsRemoteFsClient } from '../src/adapter/WsRemoteFsClient';
+
+// ── WsRpcClient stub ──────────────────────────────────────────────────────────
+
+function makeRpcClient(results: Record<string, unknown> = {}) {
+  const closeHandlers: Array<(err?: Error) => void> = [];
+  let closed = false;
+  return {
+    call: vi.fn(async (method: string, _params: unknown) => {
+      if (!(method in results)) throw new Error(`No stub for ${method}`);
+      return results[method];
+    }),
+    onClose(cb: (err?: Error) => void) {
+      closeHandlers.push(cb);
+      return () => {};
+    },
+    isClosed() { return closed; },
+    close() { closed = true; for (const h of closeHandlers) h(); },
+    _closeHandlers: closeHandlers,
+  };
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function toB64(text: string): string {
+  return btoa(text);
+}
+
+// ── WsRemoteFsClient tests ────────────────────────────────────────────────────
+
+describe('WsRemoteFsClient — read side', () => {
+  it('stat() converts Stat DTO to RemoteStat', async () => {
+    const rpc = makeRpcClient({ 'fs.stat': { type: 'file', mtime: 1000, size: 42, mode: 0o644 } });
+    const client = new WsRemoteFsClient(rpc as any);
+
+    const s = await client.stat('/vault/note.md');
+    expect(s.isFile).toBe(true);
+    expect(s.isDirectory).toBe(false);
+    expect(s.mtime).toBe(1000);
+    expect(s.size).toBe(42);
+    expect(rpc.call).toHaveBeenCalledWith('fs.stat', { path: '/vault/note.md' });
+  });
+
+  it('stat() throws when server returns null', async () => {
+    const rpc = makeRpcClient({ 'fs.stat': null });
+    const client = new WsRemoteFsClient(rpc as any);
+    await expect(client.stat('/missing')).rejects.toThrow(/no such file/i);
+  });
+
+  it('exists() returns boolean', async () => {
+    const rpc = makeRpcClient({ 'fs.exists': { exists: true } });
+    const client = new WsRemoteFsClient(rpc as any);
+    expect(await client.exists('/vault/note.md')).toBe(true);
+  });
+
+  it('list() maps entry DTOs to RemoteEntry[]', async () => {
+    const rpc = makeRpcClient({
+      'fs.list': {
+        entries: [
+          { name: 'note.md', type: 'file', mtime: 2000, size: 100 },
+          { name: 'images', type: 'folder', mtime: 1500, size: 0 },
+          { name: 'link.md', type: 'symlink', mtime: 1000, size: 0 },
+        ],
+      },
+    });
+    const client = new WsRemoteFsClient(rpc as any);
+    const entries = await client.list('/vault');
+
+    expect(entries[0]).toMatchObject({ name: 'note.md', isFile: true, isDirectory: false });
+    expect(entries[1]).toMatchObject({ name: 'images', isDirectory: true });
+    expect(entries[2]).toMatchObject({ name: 'link.md', isSymbolicLink: true });
+  });
+
+  it('readBinary() decodes base64 to Uint8Array', async () => {
+    const content = 'hello binary';
+    const rpc = makeRpcClient({ 'fs.readBinary': { contentBase64: toB64(content) } });
+    const client = new WsRemoteFsClient(rpc as any);
+
+    const data = await client.readBinary('/vault/file.bin');
+    expect(new TextDecoder().decode(data)).toBe(content);
+  });
+
+  it('readBinaryRange() returns data + mtime + size', async () => {
+    const rpc = makeRpcClient({
+      'fs.readBinaryRange': { contentBase64: toB64('chunk'), mtime: 999, size: 500 },
+    });
+    const client = new WsRemoteFsClient(rpc as any);
+
+    const r = await client.readBinaryRange('/vault/big.bin', 0, 5);
+    expect(new TextDecoder().decode(r.data)).toBe('chunk');
+    expect(r.mtime).toBe(999);
+    expect(r.size).toBe(500);
+    expect(rpc.call).toHaveBeenCalledWith('fs.readBinaryRange', { path: '/vault/big.bin', offset: 0, length: 5 });
+  });
+});
+
+describe('WsRemoteFsClient — write side', () => {
+  it('writeBinary() encodes Uint8Array as base64', async () => {
+    const rpc = makeRpcClient({ 'fs.writeBinary': {} });
+    const client = new WsRemoteFsClient(rpc as any);
+
+    const data = new TextEncoder().encode('write me');
+    await client.writeBinary('/vault/out.bin', data);
+
+    expect(rpc.call).toHaveBeenCalledWith('fs.writeBinary', {
+      path: '/vault/out.bin',
+      contentBase64: toB64('write me'),
+    });
+  });
+
+  it('writeBinary() passes expectedMtime when supplied', async () => {
+    const rpc = makeRpcClient({ 'fs.writeBinary': {} });
+    const client = new WsRemoteFsClient(rpc as any);
+
+    await client.writeBinary('/vault/out.bin', new Uint8Array(), 12345);
+    const args = (rpc.call as ReturnType<typeof vi.fn>).mock.calls[0][1] as Record<string, unknown>;
+    expect(args['expectedMtime']).toBe(12345);
+  });
+
+  it('mkdirp() calls fs.mkdir with recursive:true', async () => {
+    const rpc = makeRpcClient({ 'fs.mkdir': {} });
+    const client = new WsRemoteFsClient(rpc as any);
+    await client.mkdirp('/vault/subdir');
+    expect(rpc.call).toHaveBeenCalledWith('fs.mkdir', { path: '/vault/subdir', recursive: true });
+  });
+
+  it('remove() delegates to fs.remove', async () => {
+    const rpc = makeRpcClient({ 'fs.remove': {} });
+    const client = new WsRemoteFsClient(rpc as any);
+    await client.remove('/vault/old.md');
+    expect(rpc.call).toHaveBeenCalledWith('fs.remove', { path: '/vault/old.md' });
+  });
+
+  it('rename() passes both paths', async () => {
+    const rpc = makeRpcClient({ 'fs.rename': {} });
+    const client = new WsRemoteFsClient(rpc as any);
+    await client.rename('/vault/old.md', '/vault/new.md');
+    expect(rpc.call).toHaveBeenCalledWith('fs.rename', { oldPath: '/vault/old.md', newPath: '/vault/new.md' });
+  });
+});
+
+describe('WsRemoteFsClient — lifecycle', () => {
+  it('isAlive() reflects rpc.isClosed()', () => {
+    const rpc = makeRpcClient();
+    const client = new WsRemoteFsClient(rpc as any);
+    expect(client.isAlive()).toBe(true);
+    rpc.close();
+    expect(client.isAlive()).toBe(false);
+  });
+
+  it('onClose() fires with unexpected:false on clean close', () => {
+    const rpc = makeRpcClient();
+    const client = new WsRemoteFsClient(rpc as any);
+    const cb = vi.fn();
+    client.onClose(cb);
+    rpc.close(); // no error → clean
+    expect(cb).toHaveBeenCalledWith({ unexpected: false });
+  });
+});

--- a/mobile/tests/WsRpcClient.test.ts
+++ b/mobile/tests/WsRpcClient.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WsRpcClient } from '../src/transport/WsRpcClient';
+import { RpcError } from '../src/transport/RpcError';
+
+// ── Minimal WsChannel stub ────────────────────────────────────────────────────
+
+function makeChannel() {
+  let messageHandler: ((body: Uint8Array) => void) | null = null;
+  let closeHandler: (() => void) | null = null;
+  const sent: string[] = [];
+  let closed = false;
+
+  return {
+    onMessage(cb: (body: Uint8Array) => void) {
+      messageHandler = cb;
+      return () => { messageHandler = null; };
+    },
+    onClose(cb: () => void) {
+      closeHandler = cb;
+      return () => { closeHandler = null; };
+    },
+    send(body: Uint8Array) {
+      if (closed) throw new Error('closed');
+      sent.push(new TextDecoder().decode(body));
+    },
+    close() { closed = true; closeHandler?.(); },
+    // test helpers
+    _deliver(obj: unknown) {
+      messageHandler?.(new TextEncoder().encode(JSON.stringify(obj)));
+    },
+    _close() { closeHandler?.(); },
+    _sent: sent,
+  };
+}
+
+// ── WsRpcClient tests ─────────────────────────────────────────────────────────
+
+describe('WsRpcClient — happy path', () => {
+  it('sends a JSON-RPC request and resolves with result', async () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+
+    const p = client.call('fs.stat', { path: '/foo' });
+
+    // Deliver matching response
+    const sent = JSON.parse(ch._sent[0]);
+    ch._deliver({ jsonrpc: '2.0', id: sent.id, result: { type: 'file', mtime: 100, size: 10, mode: 0o644 } });
+
+    const result = await p;
+    expect(result).toMatchObject({ type: 'file' });
+  });
+
+  it('increments the request id for each call', async () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+
+    // Fire two calls without waiting
+    const p1 = client.call('fs.exists', { path: '/a' });
+    const p2 = client.call('fs.exists', { path: '/b' });
+
+    const [req1, req2] = ch._sent.map(s => JSON.parse(s));
+    expect(req1.id).not.toBe(req2.id);
+
+    ch._deliver({ jsonrpc: '2.0', id: req1.id, result: { exists: true } });
+    ch._deliver({ jsonrpc: '2.0', id: req2.id, result: { exists: false } });
+
+    expect(await p1).toEqual({ exists: true });
+    expect(await p2).toEqual({ exists: false });
+  });
+});
+
+describe('WsRpcClient — error handling', () => {
+  it('rejects with RpcError when daemon returns error envelope', async () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+
+    const p = client.call('fs.stat', { path: '/missing' });
+    const req = JSON.parse(ch._sent[0]);
+    ch._deliver({ jsonrpc: '2.0', id: req.id, error: { code: -32020, message: 'not found' } });
+
+    await expect(p).rejects.toThrow(RpcError);
+    await expect(p).rejects.toMatchObject({ code: -32020 });
+  });
+
+  it('rejects pending calls when channel closes', async () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+
+    const p = client.call('fs.stat', { path: '/x' });
+    ch._close();
+
+    await expect(p).rejects.toThrow(RpcError);
+  });
+
+  it('rejects immediately when already closed', async () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+    ch._close();
+
+    await expect(client.call('fs.stat', { path: '/x' })).rejects.toThrow(RpcError);
+  });
+
+  it('times out a call that gets no response', async () => {
+    vi.useFakeTimers();
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any, { timeoutMs: 1_000 });
+
+    const p = client.call('fs.stat', { path: '/slow' });
+    vi.advanceTimersByTime(1_001);
+
+    await expect(p).rejects.toThrow(/timeout/i);
+    vi.useRealTimers();
+  });
+});
+
+describe('WsRpcClient — notifications', () => {
+  it('delivers server-push notifications to registered handlers', () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+    const handler = vi.fn();
+
+    client.onNotification('fs.watch', handler);
+    ch._deliver({ jsonrpc: '2.0', method: 'fs.watch', params: { path: '/vault', event: 'modify' } });
+
+    expect(handler).toHaveBeenCalledWith({ path: '/vault', event: 'modify' });
+  });
+
+  it('disposer removes the notification handler', () => {
+    const ch = makeChannel();
+    const client = new WsRpcClient(ch as any);
+    const handler = vi.fn();
+
+    const dispose = client.onNotification('fs.watch', handler);
+    dispose();
+    ch._deliver({ jsonrpc: '2.0', method: 'fs.watch', params: {} });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/tests/WsRpcConnection.test.ts
+++ b/mobile/tests/WsRpcConnection.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WsRpcConnection } from '../src/transport/WsRpcConnection';
+
+// ── Fake WebSocket ────────────────────────────────────────────────────────────
+
+function makeFakeWs(initialState: number = WebSocket.OPEN) {
+  const listeners: Record<string, Array<(ev: unknown) => void>> = {};
+  const frames: string[] = [];
+
+  const ws = {
+    readyState: initialState,
+    addEventListener(type: string, cb: (ev: unknown) => void) {
+      (listeners[type] ??= []).push(cb);
+    },
+    removeEventListener(type: string, cb: (ev: unknown) => void) {
+      listeners[type] = (listeners[type] ?? []).filter(h => h !== cb);
+    },
+    send(data: string) { frames.push(data); },
+    close() {},
+    // test helpers
+    emit(type: string, ev: unknown = {}) {
+      for (const h of listeners[type] ?? []) h(ev);
+    },
+    deliver(obj: unknown) {
+      const json = JSON.stringify(obj);
+      const frame = `Content-Length: ${new TextEncoder().encode(json).length}\r\n\r\n${json}`;
+      this.emit('message', { data: frame });
+    },
+    frames,
+  };
+  return ws;
+}
+
+function parseFrame(frame: string) {
+  return JSON.parse(frame.split('\r\n\r\n')[1]);
+}
+
+// ── WsRpcConnection tests ─────────────────────────────────────────────────────
+
+describe('WsRpcConnection.connect', () => {
+  it('resolves after auth + server.info succeed', async () => {
+    const ws = makeFakeWs();
+    const connectPromise = WsRpcConnection.connect(ws as unknown as WebSocket, {
+      token: 'secret-token',
+    });
+
+    // Wait for auth frame to be sent
+    await vi.waitFor(() => expect(ws.frames.length).toBeGreaterThanOrEqual(1));
+    const authReq = parseFrame(ws.frames[0]);
+    expect(authReq.method).toBe('auth');
+    expect(authReq.params.token).toBe('secret-token');
+
+    // Reply to auth → triggers server.info call
+    ws.deliver({ jsonrpc: '2.0', id: authReq.id, result: {} });
+
+    // Wait for server.info frame to be sent
+    await vi.waitFor(() => expect(ws.frames.length).toBeGreaterThanOrEqual(2));
+    const infoReq = parseFrame(ws.frames[1]);
+    expect(infoReq.method).toBe('server.info');
+
+    // Reply to server.info
+    ws.deliver({
+      jsonrpc: '2.0',
+      id: infoReq.id,
+      result: { version: '1.2.3', protocolVersion: 1, capabilities: [], vaultRoot: '/home/user/vault' },
+    });
+
+    const conn = await connectPromise;
+    expect(conn.serverInfo.version).toBe('1.2.3');
+    expect(conn.serverInfo.vaultRoot).toBe('/home/user/vault');
+    expect(conn.rpc.isClosed()).toBe(false);
+  });
+
+  it('rejects when auth RPC returns an error', async () => {
+    const ws = makeFakeWs();
+    const connectPromise = WsRpcConnection.connect(ws as unknown as WebSocket, { token: 'bad' });
+
+    await vi.waitFor(() => expect(ws.frames.length).toBeGreaterThanOrEqual(1));
+    const authReq = parseFrame(ws.frames[0]);
+    ws.deliver({ jsonrpc: '2.0', id: authReq.id, error: { code: -32011, message: 'auth invalid' } });
+
+    await expect(connectPromise).rejects.toMatchObject({ code: -32011 });
+  });
+
+  it('rejects when WebSocket closes before open (CONNECTING state)', async () => {
+    const ws = makeFakeWs(WebSocket.CONNECTING);
+    const connectPromise = WsRpcConnection.connect(ws as unknown as WebSocket, { token: 't' });
+    ws.emit('close', {});
+    await expect(connectPromise).rejects.toThrow(/closed before open/i);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the three missing mobile transport files from #216.

- **`WsRpcClient`** — JSON-RPC 2.0 over `WsChannel`; id-correlated pending map, 30 s call timeout, notification handlers, no Node.js deps
- **`WsRpcConnection`** — static `connect()` factory that sequences `auth` + `server.info` RPCs; handles CONNECTING→OPEN race via `waitForOpen()`
- **`WsRemoteFsClient`** — all `fs.*` methods mirroring desktop `RpcRemoteFsClient`; `Uint8Array` + `btoa`/`atob` instead of `Buffer`

## Test plan

- [x] 24 unit tests across 3 test files (`mobile/tests/`)
- [x] `WsRpcClient` — happy path, id correlation, timeout, notifications, disposers
- [x] `WsRpcConnection` — auth+server.info handshake, auth error rejection, close-before-open rejection
- [x] `WsRemoteFsClient` — stat/list/readBinary/writeBinary/rename/mkdirp, isAlive/onClose lifecycle

Closes #216
Refs #151