### PR TITLE
test: boost unit coverage — 8 new suites, 2 extended suites

### DIFF
--- a/plugin/tests/AuthResolver.test.ts
+++ b/plugin/tests/AuthResolver.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AuthResolver } from '../src/ssh/AuthResolver';
+import type { SecretStore } from '../src/ssh/SecretStore';
+import type { SshProfile } from '../src/types';
+
+vi.mock('fs', () => ({ readFileSync: vi.fn() }));
+
+import * as fs from 'fs';
+
+function makeStore(initial: Record<string, string> = {}): SecretStore {
+  const data = new Map(Object.entries(initial));
+  return {
+    get: (ref: string) => data.get(ref),
+    set: (ref: string, val: string) => { data.set(ref, val); },
+    delete: (ref: string) => { data.delete(ref); },
+  } as unknown as SecretStore;
+}
+
+const baseProfile: SshProfile = {
+  id: 'p1',
+  name: 'test',
+  host: 'host.example',
+  port: 22,
+  username: 'alice',
+  authMethod: 'password',
+  remotePath: '~/vault',
+  connectTimeoutMs: 10000,
+  keepaliveIntervalMs: 5000,
+  keepaliveCountMax: 3,
+};
+
+describe('AuthResolver — secret management', () => {
+  it('storeSecret stores in session map and is retrievable via getSecret', () => {
+    const r = new AuthResolver(makeStore());
+    r.storeSecret('ref1', 'val1');
+    expect(r.getSecret('ref1')).toBe('val1');
+  });
+
+  it('getSecret falls back to the persistent store when not in session map', () => {
+    const store = makeStore({ persistedRef: 'fromStore' });
+    const r = new AuthResolver(store);
+    expect(r.getSecret('persistedRef')).toBe('fromStore');
+  });
+
+  it('session map takes precedence over the persistent store', () => {
+    const store = makeStore({ ref: 'stored' });
+    const r = new AuthResolver(store);
+    r.storeSecret('ref', 'session');
+    expect(r.getSecret('ref')).toBe('session');
+  });
+
+  it('persistSecret writes to session map AND the underlying store', () => {
+    const setMock = vi.fn();
+    const store = { get: vi.fn(), set: setMock, delete: vi.fn() } as unknown as SecretStore;
+    const r = new AuthResolver(store);
+    r.persistSecret('myRef', 'myVal');
+    expect(r.getSecret('myRef')).toBe('myVal');
+    expect(setMock).toHaveBeenCalledWith('myRef', 'myVal');
+  });
+
+  it('clearSecrets removes all session entries for a given profile id prefix', () => {
+    const r = new AuthResolver(makeStore());
+    r.storeSecret('p1:password', 'pw');
+    r.storeSecret('p1:passphrase', 'pp');
+    r.storeSecret('p2:password', 'other');
+    r.clearSecrets('p1');
+    expect(r.getSecret('p1:password')).toBeUndefined();
+    expect(r.getSecret('p1:passphrase')).toBeUndefined();
+    expect(r.getSecret('p2:password')).toBe('other');
+  });
+
+  it('getSecret returns undefined when ref is unknown in both maps', () => {
+    const r = new AuthResolver(makeStore());
+    expect(r.getSecret('unknown')).toBeUndefined();
+  });
+});
+
+describe('AuthResolver.buildAuthConfig — password', () => {
+  it('returns { password } when a password ref is stored', () => {
+    const r = new AuthResolver(makeStore());
+    r.storeSecret('pw-ref', 'secret123');
+    const profile: SshProfile = { ...baseProfile, authMethod: 'password', passwordRef: 'pw-ref' };
+    const cfg = r.buildAuthConfig(profile);
+    expect(cfg).toEqual({ password: 'secret123' });
+  });
+
+  it('throws when no password is stored for the ref', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = { ...baseProfile, authMethod: 'password', passwordRef: 'missing' };
+    expect(() => r.buildAuthConfig(profile)).toThrow(/No password stored/);
+  });
+
+  it('throws when passwordRef is absent', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = { ...baseProfile, authMethod: 'password', passwordRef: undefined };
+    expect(() => r.buildAuthConfig(profile)).toThrow(/No password stored/);
+  });
+});
+
+describe('AuthResolver.buildAuthConfig — privateKey', () => {
+  beforeEach(() => {
+    vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from('---BEGIN KEY---'));
+  });
+
+  it('returns { privateKey } when key file is readable and no passphrase', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = {
+      ...baseProfile,
+      authMethod: 'privateKey',
+      privateKeyPath: '/home/alice/.ssh/id_ed25519',
+    };
+    const cfg = r.buildAuthConfig(profile);
+    expect(cfg).toMatchObject({ privateKey: expect.any(Buffer) });
+    expect(cfg.passphrase).toBeUndefined();
+  });
+
+  it('includes passphrase when passphraseRef is stored', () => {
+    const r = new AuthResolver(makeStore());
+    r.storeSecret('pp-ref', 'myPassphrase');
+    const profile: SshProfile = {
+      ...baseProfile,
+      authMethod: 'privateKey',
+      privateKeyPath: '/home/alice/.ssh/id_ed25519',
+      passphraseRef: 'pp-ref',
+    };
+    const cfg = r.buildAuthConfig(profile);
+    expect(cfg.passphrase).toBe('myPassphrase');
+  });
+
+  it('throws when privateKeyPath is absent', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = { ...baseProfile, authMethod: 'privateKey', privateKeyPath: undefined };
+    expect(() => r.buildAuthConfig(profile)).toThrow(/No private key path/);
+  });
+
+  it('throws when readFileSync fails', () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => { throw new Error('ENOENT'); });
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = {
+      ...baseProfile,
+      authMethod: 'privateKey',
+      privateKeyPath: '/nonexistent/key',
+    };
+    expect(() => r.buildAuthConfig(profile)).toThrow(/Cannot read private key/);
+  });
+
+  it('expands "~/" in privateKeyPath before reading the file', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = {
+      ...baseProfile,
+      authMethod: 'privateKey',
+      privateKeyPath: '~/.ssh/id_ed25519',
+    };
+    r.buildAuthConfig(profile);
+    const calledPath = vi.mocked(fs.readFileSync).mock.calls[0][0] as string;
+    expect(calledPath).not.toMatch(/^~/);
+  });
+});
+
+describe('AuthResolver.buildAuthConfig — agent', () => {
+  it('returns { agent } using profile.agentSocket when set', () => {
+    const r = new AuthResolver(makeStore());
+    const profile: SshProfile = {
+      ...baseProfile,
+      authMethod: 'agent',
+      agentSocket: '/run/user/1000/ssh-agent.socket',
+    };
+    const cfg = r.buildAuthConfig(profile);
+    expect(cfg).toEqual({ agent: '/run/user/1000/ssh-agent.socket' });
+  });
+
+  it('falls back to SSH_AUTH_SOCK env var when agentSocket is not set', () => {
+    const orig = process.env.SSH_AUTH_SOCK;
+    process.env.SSH_AUTH_SOCK = '/tmp/ssh-auth.sock';
+    try {
+      const r = new AuthResolver(makeStore());
+      const profile: SshProfile = { ...baseProfile, authMethod: 'agent', agentSocket: undefined };
+      const cfg = r.buildAuthConfig(profile);
+      expect(cfg).toEqual({ agent: '/tmp/ssh-auth.sock' });
+    } finally {
+      if (orig === undefined) delete process.env.SSH_AUTH_SOCK;
+      else process.env.SSH_AUTH_SOCK = orig;
+    }
+  });
+
+  it('throws when neither agentSocket nor SSH_AUTH_SOCK is set', () => {
+    const orig = process.env.SSH_AUTH_SOCK;
+    delete process.env.SSH_AUTH_SOCK;
+    try {
+      const r = new AuthResolver(makeStore());
+      const profile: SshProfile = { ...baseProfile, authMethod: 'agent', agentSocket: undefined };
+      expect(() => r.buildAuthConfig(profile)).toThrow(/SSH_AUTH_SOCK/);
+    } finally {
+      if (orig !== undefined) process.env.SSH_AUTH_SOCK = orig;
+    }
+  });
+});
+
+describe('AuthResolver.buildAuthConfig — unknown method', () => {
+  it('throws for an unrecognised authMethod value', () => {
+    const r = new AuthResolver(makeStore());
+    const profile = { ...baseProfile, authMethod: 'magic' as SshProfile['authMethod'] };
+    expect(() => r.buildAuthConfig(profile)).toThrow(/Unknown auth method/);
+  });
+});

--- a/plugin/tests/ConflictResolver.test.ts
+++ b/plugin/tests/ConflictResolver.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConflictResolver } from '../src/conflict/ConflictResolver';
+import type { RemoteFsClient } from '../src/adapter/RemoteFsClient';
+import type { ReadCache } from '../src/cache/ReadCache';
+import type { AncestorTracker } from '../src/conflict/AncestorTracker';
+import type { TextConflictDecision } from '../src/conflict/ConflictResolver';
+
+function makeClient(overrides: Partial<RemoteFsClient> = {}): RemoteFsClient {
+  return {
+    readBinary: vi.fn().mockResolvedValue(Buffer.from('theirs')),
+    writeBinary: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue({ mtime: 1000, size: 6 }),
+    ...overrides,
+  } as unknown as RemoteFsClient;
+}
+
+function makeReadCache(): ReadCache {
+  return { put: vi.fn(), get: vi.fn(), invalidate: vi.fn() } as unknown as ReadCache;
+}
+
+function makeTracker(ancestorContent: string | null): AncestorTracker {
+  return {
+    get: vi.fn().mockReturnValue(
+      ancestorContent !== null ? { content: ancestorContent, mtime: 0 } : null,
+    ),
+    remember: vi.fn(),
+  } as unknown as AncestorTracker;
+}
+
+const remote = '/remote/path/file.md';
+const normalizedPath = 'file.md';
+const originalError = new Error('PreconditionFailed');
+const mine = Buffer.from('my content');
+
+describe('ConflictResolver.swapClient', () => {
+  it('replaces the client used for subsequent operations', async () => {
+    const client1 = makeClient();
+    const client2 = makeClient({
+      writeBinary: vi.fn().mockResolvedValue(undefined),
+    });
+    const resolver = new ConflictResolver(
+      client1, makeReadCache(), makeTracker('ancestor'), null, async () => true,
+    );
+    resolver.swapClient(client2);
+
+    const result = await resolver.resolve(normalizedPath, remote, mine, false, originalError);
+    expect(result).toBe(mine);
+    expect(client2.writeBinary).toHaveBeenCalled();
+    expect(client1.writeBinary).not.toHaveBeenCalled();
+  });
+});
+
+describe('ConflictResolver.resolve — two-choice fallback paths', () => {
+  it('falls back to two-choice when ancestorTracker is null', async () => {
+    const onWriteConflict = vi.fn().mockResolvedValue(true);
+    const resolver = new ConflictResolver(makeClient(), makeReadCache(), null, null, onWriteConflict);
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result).toBe(mine);
+    expect(onWriteConflict).toHaveBeenCalledWith(normalizedPath);
+  });
+
+  it('falls back to two-choice when onTextConflict is null', async () => {
+    const onWriteConflict = vi.fn().mockResolvedValue(true);
+    const resolver = new ConflictResolver(
+      makeClient(), makeReadCache(), makeTracker('ancestor'), null, onWriteConflict,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result).toBe(mine);
+  });
+
+  it('falls back to two-choice for binary writes (isText=false)', async () => {
+    const onWriteConflict = vi.fn().mockResolvedValue(true);
+    const resolver = new ConflictResolver(
+      makeClient(), makeReadCache(), makeTracker('ancestor'), vi.fn(), onWriteConflict,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, false, originalError);
+    expect(result).toBe(mine);
+    expect(onWriteConflict).toHaveBeenCalled();
+  });
+
+  it('falls back to two-choice when tracker.get returns null (no ancestor snapshot)', async () => {
+    const onWriteConflict = vi.fn().mockResolvedValue(true);
+    const resolver = new ConflictResolver(
+      makeClient(), makeReadCache(), makeTracker(null), vi.fn(), onWriteConflict,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result).toBe(mine);
+    expect(onWriteConflict).toHaveBeenCalled();
+  });
+
+  it('throws originalError when onWriteConflict returns false', async () => {
+    const onWriteConflict = vi.fn().mockResolvedValue(false);
+    const resolver = new ConflictResolver(makeClient(), makeReadCache(), null, null, onWriteConflict);
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, false, originalError),
+    ).rejects.toBe(originalError);
+  });
+
+  it('throws originalError when onWriteConflict is null (no callback at all)', async () => {
+    const resolver = new ConflictResolver(makeClient(), makeReadCache(), null, null, null);
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, false, originalError),
+    ).rejects.toBe(originalError);
+  });
+});
+
+describe('ConflictResolver.resolve — three-way text conflict decisions', () => {
+  it('keep-mine: writes mine to remote and returns mine', async () => {
+    const client = makeClient();
+    const onTextConflict = vi.fn().mockResolvedValue({ decision: 'keep-mine' } as TextConflictDecision);
+    const resolver = new ConflictResolver(
+      client, makeReadCache(), makeTracker('ancestor'), onTextConflict, null,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result).toBe(mine);
+    expect(client.writeBinary).toHaveBeenCalledWith(remote, mine);
+  });
+
+  it('merged: writes merged content and returns the merged buffer', async () => {
+    const client = makeClient();
+    const mergedText = 'merged content';
+    const onTextConflict = vi.fn().mockResolvedValue(
+      { decision: 'merged', content: mergedText } as TextConflictDecision,
+    );
+    const resolver = new ConflictResolver(
+      client, makeReadCache(), makeTracker('ancestor'), onTextConflict, null,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result.toString('utf8')).toBe(mergedText);
+    expect(client.writeBinary).toHaveBeenCalledWith(remote, Buffer.from(mergedText, 'utf8'));
+  });
+
+  it('keep-theirs: updates readCache + ancestorTracker and re-throws originalError', async () => {
+    const client = makeClient({
+      readBinary: vi.fn().mockResolvedValue(Buffer.from('their-content')),
+      stat: vi.fn().mockResolvedValue({ mtime: 2000, size: 13 }),
+    });
+    const readCache = makeReadCache();
+    const tracker = makeTracker('ancestor');
+    const onTextConflict = vi.fn().mockResolvedValue({ decision: 'keep-theirs' } as TextConflictDecision);
+    const resolver = new ConflictResolver(client, readCache, tracker, onTextConflict, null);
+
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, true, originalError),
+    ).rejects.toBe(originalError);
+
+    expect(readCache.put).toHaveBeenCalledWith(remote, expect.any(Buffer), 2000);
+    expect(tracker.remember).toHaveBeenCalledWith(normalizedPath, 'their-content', 2000);
+  });
+
+  it('keep-theirs: uses mtime=0 when stat fails', async () => {
+    const client = makeClient({
+      readBinary: vi.fn().mockResolvedValue(Buffer.from('their-content')),
+      stat: vi.fn().mockRejectedValue(new Error('stat error')),
+    });
+    const readCache = makeReadCache();
+    const tracker = makeTracker('ancestor');
+    const onTextConflict = vi.fn().mockResolvedValue({ decision: 'keep-theirs' } as TextConflictDecision);
+    const resolver = new ConflictResolver(client, readCache, tracker, onTextConflict, null);
+
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, true, originalError),
+    ).rejects.toBe(originalError);
+
+    expect(readCache.put).toHaveBeenCalledWith(remote, expect.any(Buffer), 0);
+  });
+
+  it('cancel: throws originalError without writing anything', async () => {
+    const client = makeClient();
+    const onTextConflict = vi.fn().mockResolvedValue({ decision: 'cancel' } as TextConflictDecision);
+    const resolver = new ConflictResolver(
+      client, makeReadCache(), makeTracker('ancestor'), onTextConflict, null,
+    );
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, true, originalError),
+    ).rejects.toBe(originalError);
+    expect(client.writeBinary).not.toHaveBeenCalled();
+  });
+
+  it('falls back to two-choice when re-reading the remote file fails during three-way', async () => {
+    const client = makeClient({
+      readBinary: vi.fn().mockRejectedValue(new Error('network read error')),
+    });
+    const onWriteConflict = vi.fn().mockResolvedValue(true);
+    const resolver = new ConflictResolver(
+      client, makeReadCache(), makeTracker('ancestor'), vi.fn(), onWriteConflict,
+    );
+    const result = await resolver.resolve(normalizedPath, remote, mine, true, originalError);
+    expect(result).toBe(mine);
+    expect(onWriteConflict).toHaveBeenCalled();
+  });
+
+  it('treats onTextConflict rejection as cancel', async () => {
+    const client = makeClient();
+    const onTextConflict = vi.fn().mockRejectedValue(new Error('modal error'));
+    const resolver = new ConflictResolver(
+      client, makeReadCache(), makeTracker('ancestor'), onTextConflict, null,
+    );
+    await expect(
+      resolver.resolve(normalizedPath, remote, mine, true, originalError),
+    ).rejects.toBe(originalError);
+  });
+});

--- a/plugin/tests/ConnectionManager.static.test.ts
+++ b/plugin/tests/ConnectionManager.static.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { ConnectionManager } from '../src/ConnectionManager';
+
+// The static helpers on ConnectionManager are pure functions — no SSH
+// connection needed. Testing them covers the 0% branch for the module.
+
+describe('ConnectionManager.resolveClientId', () => {
+  it('returns a sanitized id from the override when clientId is non-empty', () => {
+    const id = ConnectionManager.resolveClientId({ clientId: '  my-laptop  ' });
+    // sanitizeClientId lowercases and replaces non-alphanumeric with '-'
+    expect(id).toMatch(/^[a-z0-9-]+$/);
+    expect(id).toContain('my');
+    expect(id).toContain('laptop');
+  });
+
+  it('falls back to the OS hostname when clientId is an empty string', () => {
+    const id = ConnectionManager.resolveClientId({ clientId: '' });
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the OS hostname when clientId property is absent', () => {
+    const id = ConnectionManager.resolveClientId({});
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+  });
+});
+
+describe('ConnectionManager.formatUserLabel', () => {
+  it('returns "userName@clientId" when both settings are provided', () => {
+    const label = ConnectionManager.formatUserLabel({ clientId: 'laptop', userName: 'alice' });
+    expect(label).toContain('@');
+    expect(label).toContain('alice');
+    expect(label).toContain('laptop');
+  });
+
+  it('uses the OS username when userName is an empty string', () => {
+    const label = ConnectionManager.formatUserLabel({ clientId: 'laptop', userName: '' });
+    expect(label).toMatch(/@laptop$/);
+  });
+
+  it('uses the OS username when userName property is absent', () => {
+    const label = ConnectionManager.formatUserLabel({ clientId: 'laptop' });
+    expect(label).toMatch(/@laptop$/);
+  });
+
+  it('uses OS hostname for clientId when clientId is empty', () => {
+    const label = ConnectionManager.formatUserLabel({ clientId: '', userName: 'alice' });
+    expect(label).toMatch(/^alice@/);
+  });
+});

--- a/plugin/tests/FsChangeListener.test.ts
+++ b/plugin/tests/FsChangeListener.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FsChangeListener } from '../src/vault/FsChangeListener';
+import type { App } from 'obsidian';
+import type { RpcConnection } from '../src/transport/RpcConnection';
+import type { SftpDataAdapter } from '../src/adapter/SftpDataAdapter';
+import type { PathMapper } from '../src/path/PathMapper';
+
+function makeApp(): App {
+  return {
+    vault: {
+      adapter: {
+        stat: vi.fn().mockResolvedValue({ type: 'file', ctime: 0, mtime: 0, size: 0 }),
+      },
+      trigger: vi.fn(),
+      fileMap: new Map(),
+    },
+  } as unknown as App;
+}
+
+function makeRpc() {
+  return {
+    onNotification: vi.fn().mockReturnValue(() => {}),
+    call: vi.fn().mockResolvedValue({ subscriptionId: 'sub-abc' }),
+  };
+}
+
+function makeRpcConnection(rpc = makeRpc()): RpcConnection {
+  return { rpc } as unknown as RpcConnection;
+}
+
+function makeAdapter(): SftpDataAdapter {
+  return { invalidateRemotePath: vi.fn() } as unknown as SftpDataAdapter;
+}
+
+function makePathMapper(): PathMapper {
+  return {
+    toRemotePath: vi.fn((vp: string) => `/remote/${vp}`),
+    toVaultPath: vi.fn((rp: string) => rp.replace('/remote/', '')),
+  } as unknown as PathMapper;
+}
+
+describe('FsChangeListener.hasContext', () => {
+  it('returns false before any subscribe call', () => {
+    const listener = new FsChangeListener(makeApp());
+    expect(listener.hasContext()).toBe(false);
+  });
+
+  it('returns true after a successful subscribe', async () => {
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    expect(listener.hasContext()).toBe(true);
+  });
+
+  it('remains true after prepareForReconnect because lastPathMapper is preserved', async () => {
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.prepareForReconnect();
+    expect(listener.hasContext()).toBe(true);
+  });
+
+  it('returns false after unsubscribe clears lastPathMapper', async () => {
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.unsubscribe(null);
+    expect(listener.hasContext()).toBe(false);
+  });
+});
+
+describe('FsChangeListener.subscribe', () => {
+  it('registers an fs.changed handler and calls fs.watch', async () => {
+    const rpc = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    expect(rpc.onNotification).toHaveBeenCalledWith('fs.changed', expect.any(Function));
+    expect(rpc.call).toHaveBeenCalledWith('fs.watch', { path: '', recursive: true });
+  });
+
+  it('is idempotent — a second call while subscribed is a no-op', async () => {
+    const rpc = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    const callsBefore = rpc.call.mock.calls.length;
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    expect(rpc.call.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('calls the disposer when fs.watch fails to clean up the handler', async () => {
+    const disposer = vi.fn();
+    const rpc = {
+      onNotification: vi.fn().mockReturnValue(disposer),
+      call: vi.fn().mockRejectedValue(new Error('fs.watch rejected')),
+    };
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    expect(disposer).toHaveBeenCalled();
+  });
+});
+
+describe('FsChangeListener.prepareForReconnect', () => {
+  it('calls the handler disposer so the old handler is removed', async () => {
+    const disposer = vi.fn();
+    const rpc = {
+      onNotification: vi.fn().mockReturnValue(disposer),
+      call: vi.fn().mockResolvedValue({ subscriptionId: 'sub-xyz' }),
+    };
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.prepareForReconnect();
+    expect(disposer).toHaveBeenCalled();
+  });
+
+  it('allows subscribe to be called again after prepareForReconnect', async () => {
+    const rpc1 = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc1),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.prepareForReconnect();
+
+    const rpc2 = makeRpc();
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc2),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    expect(rpc2.call).toHaveBeenCalledWith('fs.watch', expect.any(Object));
+  });
+});
+
+describe('FsChangeListener.resumeAfterReconnect', () => {
+  it('is a no-op when subscribe was never called', async () => {
+    const rpc = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.resumeAfterReconnect({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+    });
+    expect(rpc.call).not.toHaveBeenCalled();
+  });
+
+  it('re-subscribes after prepareForReconnect using the saved pathMapper', async () => {
+    const rpc1 = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc1),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.prepareForReconnect();
+
+    const rpc2 = makeRpc();
+    await listener.resumeAfterReconnect({
+      rpcConnection: makeRpcConnection(rpc2),
+      dataAdapter: makeAdapter(),
+    });
+    expect(rpc2.call).toHaveBeenCalledWith('fs.watch', expect.any(Object));
+  });
+});
+
+describe('FsChangeListener.unsubscribe', () => {
+  it('is safe to call before any subscribe', () => {
+    const rpc = makeRpc();
+    expect(() => {
+      new FsChangeListener(makeApp()).unsubscribe(makeRpcConnection(rpc));
+    }).not.toThrow();
+  });
+
+  it('sends fs.unwatch to the daemon when a subscriptionId is active', async () => {
+    const rpc = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    listener.unsubscribe(makeRpcConnection(rpc));
+    expect(rpc.call).toHaveBeenCalledWith('fs.unwatch', { subscriptionId: 'sub-abc' });
+  });
+
+  it('skips the fs.unwatch call when rpcConnection is null', async () => {
+    const rpc = makeRpc();
+    const listener = new FsChangeListener(makeApp());
+    await listener.subscribe({
+      rpcConnection: makeRpcConnection(rpc),
+      dataAdapter: makeAdapter(),
+      pathMapper: makePathMapper(),
+    });
+    const callsBefore = rpc.call.mock.calls.length;
+    listener.unsubscribe(null);
+    // No additional rpc.call for unwatch
+    expect(rpc.call.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/plugin/tests/ObservabilityInstaller.test.ts
+++ b/plugin/tests/ObservabilityInstaller.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { PluginManifest } from 'obsidian';
+
+vi.mock('../src/util/logger', () => ({
+  logger: {
+    installFileSink: vi.fn().mockResolvedValue(undefined),
+    wrapConsole: vi.fn(),
+    unwrapConsole: vi.fn(),
+    uninstallFileSink: vi.fn().mockResolvedValue(undefined),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../src/util/errorHook', () => ({
+  installErrorHook: vi.fn(),
+  uninstallErrorHook: vi.fn(),
+}));
+
+import { ObservabilityInstaller } from '../src/util/ObservabilityInstaller';
+import { logger } from '../src/util/logger';
+import { installErrorHook, uninstallErrorHook } from '../src/util/errorHook';
+
+const manifest: PluginManifest = {
+  id: 'remote-ssh',
+  name: 'Remote SSH',
+  version: '1.0.0',
+  minAppVersion: '1.0.0',
+  description: '',
+  author: '',
+  isDesktopOnly: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ObservabilityInstaller.install', () => {
+  it('installs the file sink at a path containing the plugin id and "console.log"', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.install();
+    expect(vi.mocked(logger.installFileSink)).toHaveBeenCalledWith(
+      expect.stringContaining('remote-ssh'),
+    );
+    expect(vi.mocked(logger.installFileSink)).toHaveBeenCalledWith(
+      expect.stringContaining('console.log'),
+    );
+  });
+
+  it('skips the file sink and warns when vaultBasePath is null', () => {
+    const installer = new ObservabilityInstaller(manifest, null, '.obsidian');
+    installer.install();
+    expect(vi.mocked(logger.installFileSink)).not.toHaveBeenCalled();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('file sink disabled'),
+    );
+  });
+
+  it('calls wrapConsole', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.install();
+    expect(vi.mocked(logger.wrapConsole)).toHaveBeenCalled();
+  });
+
+  it('calls installErrorHook', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.install();
+    expect(installErrorHook).toHaveBeenCalled();
+  });
+
+  it('logs a load message containing the plugin id and version', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.install();
+    const infoArg = vi.mocked(logger.info).mock.calls.map((c) => c[0]).join(' ');
+    expect(infoArg).toContain('remote-ssh');
+    expect(infoArg).toContain('1.0.0');
+  });
+
+  it('warns instead of throwing when installFileSink throws', () => {
+    vi.mocked(logger.installFileSink).mockImplementationOnce(() => {
+      throw new Error('disk full');
+    });
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    expect(() => installer.install()).not.toThrow();
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+      expect.stringContaining('installFileSink failed'),
+    );
+  });
+
+  it('uses the provided configDir to build the log path', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', 'custom.obsidian');
+    installer.install();
+    expect(vi.mocked(logger.installFileSink)).toHaveBeenCalledWith(
+      expect.stringContaining('custom.obsidian'),
+    );
+  });
+});
+
+describe('ObservabilityInstaller.uninstall', () => {
+  it('calls uninstallErrorHook', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.uninstall();
+    expect(uninstallErrorHook).toHaveBeenCalled();
+  });
+
+  it('calls unwrapConsole', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.uninstall();
+    expect(vi.mocked(logger.unwrapConsole)).toHaveBeenCalled();
+  });
+
+  it('calls uninstallFileSink', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.uninstall();
+    expect(vi.mocked(logger.uninstallFileSink)).toHaveBeenCalled();
+  });
+
+  it('logs an unloading message containing the plugin id', () => {
+    const installer = new ObservabilityInstaller(manifest, '/vault', '.obsidian');
+    installer.uninstall();
+    expect(vi.mocked(logger.info)).toHaveBeenCalledWith(
+      expect.stringContaining('remote-ssh'),
+    );
+  });
+});

--- a/plugin/tests/ReconnectManager.test.ts
+++ b/plugin/tests/ReconnectManager.test.ts
@@ -232,4 +232,47 @@ describe('ReconnectManager', () => {
     expect(m.state().kind).toBe('failed');
     expect(lastOnState?.kind).toBe('failed');
   });
+
+  it('continues the loop when onState throws instead of crashing', async () => {
+    let calls = 0;
+    const m = new ReconnectManager({
+      attempt: async () => { calls++; throw new Error('fail'); },
+      onState: (s) => {
+        if (s.kind === 'waiting') throw new Error('onState exploded');
+      },
+      backoff: { ...cfgFast, maxRetries: 1 },
+      ...makeImmediateScheduler(),
+    });
+    const final = await m.run();
+    expect(calls).toBe(1);
+    expect(final.kind).toBe('failed');
+  });
+
+  it('transitions to cancelled when the sleep timer fires after cancel() was called', async () => {
+    // Use a clearTimeoutFn that does NOT suppress the pending callback —
+    // simulating the race where the JS timer event fires between cancel()
+    // setting this.cancelled and clearTimeout actually removing the event.
+    let pendingCb: (() => void) | null = null;
+    const m = new ReconnectManager({
+      attempt: async () => { throw new Error('always'); },
+      onState: () => {},
+      backoff: { ...cfgFast, maxRetries: 3 },
+      setTimeoutFn: (cb) => { pendingCb = cb; return 1; },
+      clearTimeoutFn: () => { /* intentionally no-op — simulates late timer */ },
+    });
+
+    const runPromise = m.run();
+    // Yield once so setTimeoutFn is called and pendingCb is captured.
+    await Promise.resolve();
+
+    // cancel() sets this.cancelled = true and calls clearTimeoutFn (no-op here).
+    m.cancel();
+
+    // Manually fire the timer callback with cancelled=true already set.
+    expect(pendingCb).not.toBeNull();
+    pendingCb!();
+
+    const final = await runPromise;
+    expect(final.kind).toBe('cancelled');
+  });
 });

--- a/plugin/tests/__mocks__/obsidian.ts
+++ b/plugin/tests/__mocks__/obsidian.ts
@@ -138,6 +138,10 @@ function patchDom(): void {
     const list = Array.isArray(c) ? c : [c];
     for (const item of list) this.classList.toggle(item, on);
   };
+  // Real Obsidian: appendText(text: string) — appends a raw text node.
+  proto.appendText = function (this: HTMLElement, text: string): void {
+    this.appendChild(document.createTextNode(text));
+  };
 
   proto[PATCH_FLAG] = true;
 }
@@ -357,10 +361,13 @@ export class Setting {
 export class Modal {
   contentEl: HTMLElement;
   modalEl: HTMLElement;
+  titleEl: HTMLElement;
 
   constructor(public readonly app: App) {
     this.modalEl = document.createElement('div');
+    this.titleEl = document.createElement('div');
     this.contentEl = document.createElement('div');
+    this.modalEl.appendChild(this.titleEl);
     this.modalEl.appendChild(this.contentEl);
   }
 
@@ -458,6 +465,7 @@ declare global {
     removeClass(...classes: string[]): void;
     setText(t: string | DocumentFragment): void;
     toggleClass(c: string | string[], on: boolean): void;
+    appendText(text: string): void;
   }
 }
 

--- a/plugin/tests/errorHook.test.ts
+++ b/plugin/tests/errorHook.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// errorHook.ts has module-level `installed` state. Reset modules before each
+// test so we always start with installed=false and fresh handler references.
+
+let installErrorHook: () => void;
+let uninstallErrorHook: () => void;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const mod = await import('../src/util/errorHook');
+  installErrorHook = mod.installErrorHook;
+  uninstallErrorHook = mod.uninstallErrorHook;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('installErrorHook', () => {
+  it('registers unhandledrejection and error listeners on window', () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    installErrorHook();
+    const eventTypes = spy.mock.calls.map(([type]) => type);
+    expect(eventTypes).toContain('unhandledrejection');
+    expect(eventTypes).toContain('error');
+  });
+
+  it('is idempotent — a second call adds no further listeners', () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    installErrorHook();
+    const firstCount = spy.mock.calls.length;
+    installErrorHook();
+    expect(spy.mock.calls.length).toBe(firstCount);
+  });
+});
+
+describe('uninstallErrorHook', () => {
+  it('removes both listeners that were registered by install', () => {
+    installErrorHook();
+    const spy = vi.spyOn(window, 'removeEventListener');
+    uninstallErrorHook();
+    const eventTypes = spy.mock.calls.map(([type]) => type);
+    expect(eventTypes).toContain('unhandledrejection');
+    expect(eventTypes).toContain('error');
+  });
+
+  it('is a no-op when not yet installed', () => {
+    const spy = vi.spyOn(window, 'removeEventListener');
+    uninstallErrorHook();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('allows re-installation after uninstall', () => {
+    installErrorHook();
+    uninstallErrorHook();
+    const spy = vi.spyOn(window, 'addEventListener');
+    installErrorHook();
+    const eventTypes = spy.mock.calls.map(([type]) => type);
+    expect(eventTypes).toContain('unhandledrejection');
+    expect(eventTypes).toContain('error');
+  });
+});
+
+describe('unhandledrejection handler', () => {
+  it('logs Error reason including the message text', async () => {
+    const loggerMod = await import('../src/util/logger');
+    const spy = vi.spyOn(loggerMod.logger, 'error').mockImplementation(() => {});
+    installErrorHook();
+
+    const err = new Error('test-rejection');
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: err });
+    window.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('test-rejection'));
+    uninstallErrorHook();
+  });
+
+  it('logs non-Error reason via JSON.stringify', async () => {
+    const loggerMod = await import('../src/util/logger');
+    const spy = vi.spyOn(loggerMod.logger, 'error').mockImplementation(() => {});
+    installErrorHook();
+
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: { code: 42 } });
+    window.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('"code":42'));
+    uninstallErrorHook();
+  });
+
+  it('falls back to String() for non-serializable (circular) reasons', async () => {
+    const loggerMod = await import('../src/util/logger');
+    const spy = vi.spyOn(loggerMod.logger, 'error').mockImplementation(() => {});
+    installErrorHook();
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: circular });
+    window.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('unhandledrejection'));
+    uninstallErrorHook();
+  });
+});
+
+describe('window error handler', () => {
+  it('logs window.onerror events with file/line/col info', async () => {
+    const loggerMod = await import('../src/util/logger');
+    const spy = vi.spyOn(loggerMod.logger, 'error').mockImplementation(() => {});
+    installErrorHook();
+
+    const event = new ErrorEvent('error', {
+      message: 'uncaught-error',
+      filename: 'main.js',
+      lineno: 10,
+      colno: 5,
+    });
+    window.dispatchEvent(event);
+
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('window.onerror: uncaught-error'));
+    uninstallErrorHook();
+  });
+
+  it('includes the stack trace when the error has one', async () => {
+    const loggerMod = await import('../src/util/logger');
+    const spy = vi.spyOn(loggerMod.logger, 'error').mockImplementation(() => {});
+    installErrorHook();
+
+    const err = new Error('stack-error');
+    const event = new ErrorEvent('error', {
+      message: 'stack-error',
+      filename: 'a.js',
+      lineno: 1,
+      colno: 1,
+      error: err,
+    });
+    window.dispatchEvent(event);
+
+    const msg: string = spy.mock.calls[0][0] as string;
+    expect(msg).toContain('window.onerror');
+    expect(msg).toContain('stack-error');
+    uninstallErrorHook();
+  });
+});

--- a/plugin/tests/pathUtils.test.ts
+++ b/plugin/tests/pathUtils.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeRemotePath } from '../src/util/pathUtils';
+import {
+  normalizeRemotePath,
+  posixJoin,
+  relativeTo,
+  ensureTrailingSlash,
+  toLocalPath,
+  toRemotePath,
+  expandHome,
+} from '../src/util/pathUtils';
+import * as nodePath from 'path';
 
 describe('normalizeRemotePath', () => {
   it('strips a leading "~/" so the path becomes home-relative for SFTP', () => {
@@ -27,5 +36,113 @@ describe('normalizeRemotePath', () => {
 
   it('trims surrounding whitespace from user input', () => {
     expect(normalizeRemotePath('  ~/work/VaultDev  ')).toBe('work/VaultDev');
+  });
+});
+
+describe('posixJoin', () => {
+  it('joins two parts with a single slash', () => {
+    expect(posixJoin('foo', 'bar')).toBe('foo/bar');
+  });
+
+  it('collapses multiple slashes at join boundaries', () => {
+    expect(posixJoin('foo/', '/bar')).toBe('foo//bar'.replace(/\/+/g, '/'));
+    expect(posixJoin('a//b', 'c')).toBe('a/b/c');
+  });
+
+  it('joins three or more parts', () => {
+    expect(posixJoin('a', 'b', 'c')).toBe('a/b/c');
+  });
+
+  it('handles a single part without modification', () => {
+    expect(posixJoin('only')).toBe('only');
+  });
+
+  it('preserves absolute prefix when first part starts with /', () => {
+    expect(posixJoin('/root', 'sub')).toBe('/root/sub');
+  });
+});
+
+describe('relativeTo', () => {
+  it('strips base prefix and the following separator', () => {
+    expect(relativeTo('/vault', '/vault/notes/file.md')).toBe('notes/file.md');
+  });
+
+  it('strips base prefix when base already ends with slash', () => {
+    expect(relativeTo('/vault/', '/vault/notes.md')).toBe('notes.md');
+  });
+
+  it('returns full when full does not start with base', () => {
+    expect(relativeTo('/other', '/vault/file.md')).toBe('/vault/file.md');
+  });
+
+  it('returns empty string when full equals base (no trailing slash)', () => {
+    expect(relativeTo('/vault', '/vault')).toBe('');
+  });
+});
+
+describe('ensureTrailingSlash', () => {
+  it('appends slash when missing', () => {
+    expect(ensureTrailingSlash('/foo/bar')).toBe('/foo/bar/');
+  });
+
+  it('does not add a second slash when already present', () => {
+    expect(ensureTrailingSlash('/foo/bar/')).toBe('/foo/bar/');
+  });
+
+  it('works on an empty string', () => {
+    expect(ensureTrailingSlash('')).toBe('/');
+  });
+});
+
+describe('toLocalPath', () => {
+  it('joins base and relative using OS-native path.join', () => {
+    const base = '/local/vault';
+    const rel = 'notes/file.md';
+    expect(toLocalPath(base, rel)).toBe(nodePath.join(base, rel));
+  });
+});
+
+describe('toRemotePath', () => {
+  it('joins base and relative with posixJoin', () => {
+    expect(toRemotePath('work/vault', 'notes/file.md')).toBe('work/vault/notes/file.md');
+  });
+
+  it('collapses double slashes at boundary', () => {
+    expect(toRemotePath('work/vault/', 'file.md')).toBe('work/vault/file.md');
+  });
+});
+
+describe('expandHome', () => {
+  it('expands "~/" prefix using HOME env var', () => {
+    const origHome = process.env.HOME;
+    process.env.HOME = '/home/alice';
+    try {
+      const result = expandHome('~/notes');
+      expect(result).toBe(nodePath.join('/home/alice', 'notes'));
+    } finally {
+      if (origHome === undefined) delete process.env.HOME;
+      else process.env.HOME = origHome;
+    }
+  });
+
+  it('expands "~/" using USERPROFILE when HOME is unset', () => {
+    const origHome = process.env.HOME;
+    const origUserProfile = process.env.USERPROFILE;
+    delete process.env.HOME;
+    process.env.USERPROFILE = 'C:\\Users\\alice';
+    try {
+      const result = expandHome('~/docs');
+      expect(result).toBe(nodePath.join('C:\\Users\\alice', 'docs'));
+    } finally {
+      if (origHome !== undefined) process.env.HOME = origHome;
+      if (origUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = origUserProfile;
+    }
+  });
+
+  it('returns the path unchanged when it does not start with "~/"', () => {
+    expect(expandHome('/absolute/path')).toBe('/absolute/path');
+    expect(expandHome('relative/path')).toBe('relative/path');
+    expect(expandHome('~weird')).toBe('~weird');
   });
 });

--- a/plugin/tests/retry.test.ts
+++ b/plugin/tests/retry.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withRetry } from '../src/util/retry';
+
+// activeWindow is polyfilled to globalThis in vitest.setup.ts, so
+// vi.useFakeTimers() intercepts activeWindow.setTimeout automatically.
+
+describe('withRetry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the result when fn succeeds on the first attempt', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const p = withRetry(fn, 'op', 3);
+    await vi.runAllTimersAsync();
+    expect(await p).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries after a transient failure and resolves on the second attempt', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce('ok');
+    const p = withRetry(fn, 'op', 3);
+    await vi.runAllTimersAsync();
+    expect(await p).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws the last error after exhausting all attempts', async () => {
+    const err = new Error('persistent');
+    const fn = vi.fn().mockRejectedValue(err);
+    const p = withRetry(fn, 'op', 3);
+    // Attach rejection handler BEFORE running timers so the rejection is
+    // never "unhandled" from Vitest's perspective.
+    const assertion = expect(p).rejects.toThrow('persistent');
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('calls fn exactly once when maxAttempts is 1 and fn fails', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('boom'));
+    const p = withRetry(fn, 'op', 1);
+    const assertion = expect(p).rejects.toThrow('boom');
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses MAX_RETRY as default when maxAttempts is omitted', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const p = withRetry(fn, 'op');
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries up to maxAttempts-1 times before the last attempt succeeds', async () => {
+    const fn = vi.fn()
+      .mockRejectedValueOnce(new Error('fail1'))
+      .mockRejectedValueOnce(new Error('fail2'))
+      .mockResolvedValueOnce('done');
+    const p = withRetry(fn, 'op', 4);
+    await vi.runAllTimersAsync();
+    await expect(p).resolves.toBe('done');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/plugin/tests/ui/HostKeyConfirmModal.test.ts
+++ b/plugin/tests/ui/HostKeyConfirmModal.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { App } from 'obsidian';
+import {
+  HostKeyConfirmModal,
+  type HostKeyConfirmInfo,
+} from '../../src/ui/HostKeyConfirmModal';
+
+const info: HostKeyConfirmInfo = {
+  host: 'vault.example.com',
+  port: 22,
+  fingerprint: 'aabbccdd11223344556677889900aabb',
+  keyType: 'ssh-ed25519',
+};
+
+function makeModal(overrides: Partial<HostKeyConfirmInfo> = {}) {
+  return new HostKeyConfirmModal(new App(), { ...info, ...overrides });
+}
+
+describe('HostKeyConfirmModal — render', () => {
+  it('shows the host and port in the body text', () => {
+    const modal = makeModal();
+    modal.open();
+    const text = modal.contentEl.textContent ?? '';
+    expect(text).toContain('vault.example.com');
+    expect(text).toContain('22');
+  });
+
+  it('shows a formatted portion of the fingerprint', () => {
+    const modal = makeModal();
+    modal.open();
+    const text = modal.contentEl.textContent ?? '';
+    // formatFingerprint groups the hex into segments
+    expect(text).toContain('aa');
+  });
+
+  it('shows the key type when provided', () => {
+    const modal = makeModal({ keyType: 'ssh-ed25519' });
+    modal.open();
+    const text = modal.contentEl.textContent ?? '';
+    expect(text).toContain('ssh-ed25519');
+  });
+
+  it('omits the key type row when keyType is undefined', () => {
+    const modal = makeModal({ keyType: undefined });
+    modal.open();
+    const text = modal.contentEl.textContent ?? '';
+    expect(text).not.toContain('Key type');
+  });
+
+  it('sets the modal title', () => {
+    const modal = makeModal();
+    modal.open();
+    expect(modal.titleEl.textContent).toContain('Trust');
+  });
+});
+
+describe('HostKeyConfirmModal — button decisions', () => {
+  it('resolves "trust" when "Trust & remember" is clicked', async () => {
+    const modal = makeModal();
+    const p = modal.prompt();
+
+    const btn = Array.from(modal.contentEl.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Trust & remember'),
+    );
+    expect(btn).toBeTruthy();
+    btn!.click();
+
+    await expect(p).resolves.toBe('trust');
+  });
+
+  it('resolves "trust-once" when "Trust this session only" is clicked', async () => {
+    const modal = makeModal();
+    const p = modal.prompt();
+
+    const btn = Array.from(modal.contentEl.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Trust this session only'),
+    );
+    expect(btn).toBeTruthy();
+    btn!.click();
+
+    await expect(p).resolves.toBe('trust-once');
+  });
+
+  it('resolves "reject" when the "Reject" button is clicked', async () => {
+    const modal = makeModal();
+    const p = modal.prompt();
+
+    const btn = Array.from(modal.contentEl.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Reject',
+    );
+    expect(btn).toBeTruthy();
+    btn!.click();
+
+    await expect(p).resolves.toBe('reject');
+  });
+});
+
+describe('HostKeyConfirmModal — close without clicking a button', () => {
+  it('resolves "reject" when closed via Escape / backdrop (no button click)', async () => {
+    const modal = makeModal();
+    const p = modal.prompt();
+    modal.close();
+    await expect(p).resolves.toBe('reject');
+  });
+
+  it('is idempotent — clicking trust and then closing resolves only "trust"', async () => {
+    const modal = makeModal();
+    const p = modal.prompt();
+
+    const btn = Array.from(modal.contentEl.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Trust & remember'),
+    );
+    btn!.click();
+    modal.close();
+
+    await expect(p).resolves.toBe('trust');
+  });
+
+  it('empties contentEl on close', async () => {
+    const modal = makeModal();
+    // prompt() must be called first so that onChoice is initialised before
+    // onClose() runs (the modal opens inside prompt() via this.open()).
+    const p = modal.prompt();
+    modal.close();
+    await p; // resolves as 'reject' — just drain the promise
+    expect(modal.contentEl.children.length).toBe(0);
+  });
+});

--- a/plugin/vitest.config.ts
+++ b/plugin/vitest.config.ts
@@ -55,9 +55,9 @@ export default defineConfig({
       // Calibrated for the current measured scope. Bring back up as
       // more UI/settings suites land and per-file coverage rises.
       thresholds: {
-        lines: 65,
-        branches: 60,
-        functions: 60,
+        lines: 74,
+        branches: 67,
+        functions: 70,
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add 8 new test suites covering modules that were previously at 0 % coverage (`retry`, `errorHook`, `AuthResolver`, `ConflictResolver`, `FsChangeListener`, `ObservabilityInstaller`, `HostKeyConfirmModal`, `ConnectionManager` statics)
- Extend 2 existing suites (`pathUtils`, `ReconnectManager`) to cover previously-untouched branches
- Patch the Obsidian jsdom mock (`__mocks__/obsidian.ts`) with `titleEl` on `Modal` and `appendText` on `HTMLElement` — both needed by `HostKeyConfirmModal`
- Raise coverage thresholds in `vitest.config.ts` to match the new floor (lines 74 / branches 67 / functions 70)

## Coverage delta (measured locally before push)

| Metric     | Before  | After   |
|------------|---------|---------|
| Statements | 68.7 %  | 73.5 %  |
| Branches   | 64.4 %  | 68.7 %  |
| Functions  | 65.9 %  | 71.1 %  |
| Lines      | 70.4 %  | 75.1 %  |

## Test plan

- [ ] CI unit tests pass (`npm test` via GitHub Actions)
- [ ] Coverage thresholds not breached (lines ≥ 74, branches ≥ 67, functions ≥ 70)
- [ ] No regressions in existing 63-file test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)