### PR TITLE
test(JumpHostTunnel): cover readFileSync catch, default auth, and verifyAsync rejection

### DIFF
--- a/plugin/tests/JumpHostTunnel.test.ts
+++ b/plugin/tests/JumpHostTunnel.test.ts
@@ -171,6 +171,29 @@ describe('createJumpTunnel: failure paths', () => {
 });
 
 describe('createJumpTunnel: auth handling', () => {
+  it('errors when the private key file cannot be read', async () => {
+    const jump: JumpHostConfig = {
+      ...baseJump,
+      authMethod: 'privateKey',
+      privateKeyPath: '/nonexistent/path/that/does/not/exist/key',
+    };
+    await expect(createJumpTunnel(
+      jump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/Cannot read jump host private key/);
+  });
+
+  it('throws for an unrecognised auth method', async () => {
+    const jump = {
+      ...baseJump,
+      authMethod: 'kerberos' as JumpHostConfig['authMethod'],
+    };
+    await expect(createJumpTunnel(
+      jump, 'target.example.com', 22, authResolver,
+      { clientFactory: () => fake },
+    )).rejects.toThrow(/Unknown jump host auth method/);
+  });
+
   it('errors clearly when password auth has no stored secret', async () => {
     const jump: JumpHostConfig = {
       ...baseJump,
@@ -351,5 +374,32 @@ describe('createJumpTunnel: host-key mismatch handler (#132 follow-up)', () => {
     await new Promise<void>((r) => setImmediate(() => r()));
     expect(handler).toHaveBeenCalledTimes(1);
     expect(verifyCb).toHaveBeenCalledWith(false);
+  });
+
+  it('async hostVerifier calls verify(false) when verifyAsync itself rejects (defence-in-depth)', async () => {
+    const store = new HostKeyStore();
+    // Simulate an impossible internal failure from verifyAsync.
+    vi.spyOn(store, 'verifyAsync').mockRejectedValueOnce(new Error('unexpected internal failure'));
+
+    const handler = vi.fn(async () => 'trust' as const);
+    await createJumpTunnel(
+      baseJump, 'target.example.com', 22, authResolver,
+      {
+        clientFactory: () => fake,
+        hostKeyStore: store,
+        hostKeyMismatchHandler: handler,
+      },
+    );
+    const cfg = fake.connectConfig as {
+      hostVerifier: (k: Buffer, verify: (v: boolean) => void) => void;
+    };
+    const verifyCb = vi.fn();
+    cfg.hostVerifier(Buffer.from('some-key'), verifyCb);
+    // Allow the rejection handler microtask to settle.
+    await new Promise<void>((r) => setImmediate(() => r()));
+    // The catch branch must call verify(false) even though the promise rejected.
+    expect(verifyCb).toHaveBeenCalledWith(false);
+    // The handler was never reached since verifyAsync rejected before consulting it.
+    expect(handler).not.toHaveBeenCalled();
   });
 });

--- a/plugin/tests/JumpHostTunnel.test.ts
+++ b/plugin/tests/JumpHostTunnel.test.ts
@@ -175,7 +175,8 @@ describe('createJumpTunnel: auth handling', () => {
     const jump: JumpHostConfig = {
       ...baseJump,
       authMethod: 'privateKey',
-      privateKeyPath: '/nonexistent/path/that/does/not/exist/key',
+      // Use os.tmpdir() so the path is valid on both POSIX and Windows.
+      privateKeyPath: path.join(os.tmpdir(), 'remote-ssh-test-nonexistent-key-does-not-exist'),
     };
     await expect(createJumpTunnel(
       jump, 'target.example.com', 22, authResolver,
@@ -186,7 +187,9 @@ describe('createJumpTunnel: auth handling', () => {
   it('throws for an unrecognised auth method', async () => {
     const jump = {
       ...baseJump,
-      authMethod: 'kerberos' as JumpHostConfig['authMethod'],
+      // Double cast: explicit unsound widening so tsc stays happy if
+      // type-checking is ever enabled for tests.
+      authMethod: 'kerberos' as unknown as JumpHostConfig['authMethod'],
     };
     await expect(createJumpTunnel(
       jump, 'target.example.com', 22, authResolver,
@@ -378,7 +381,7 @@ describe('createJumpTunnel: host-key mismatch handler (#132 follow-up)', () => {
 
   it('async hostVerifier calls verify(false) when verifyAsync itself rejects (defence-in-depth)', async () => {
     const store = new HostKeyStore();
-    // Simulate an impossible internal failure from verifyAsync.
+    // Simulate an unexpected rejection from verifyAsync (defence-in-depth path).
     vi.spyOn(store, 'verifyAsync').mockRejectedValueOnce(new Error('unexpected internal failure'));
 
     const handler = vi.fn(async () => 'trust' as const);


### PR DESCRIPTION
## Summary

Adds three tests to `tests/JumpHostTunnel.test.ts` that cover previously untested branches in `src/ssh/JumpHostTunnel.ts`:

- **`privateKey` readFileSync failure** (lines 172–176): passes a non-existent `privateKeyPath` and asserts the `Cannot read jump host private key` error surfaces correctly.
- **Unknown `authMethod` default case** (line 190): casts an invalid enum value and asserts the `Unknown jump host auth method` TypeScript exhaustiveness throw fires.
- **`verifyAsync` rejection handler** (lines 87–91): spies on `store.verifyAsync` to make it reject, then exercises the async `hostVerifier` callback and asserts the defence-in-depth `verify(false)` path is reached.

No threshold changes needed — main's existing thresholds (lines 65, branches 60, functions 60) are already met; these tests can only increase coverage.

## Test plan

- [ ] CI unit test suite (`npm run test`) passes with no regressions
- [ ] All three new `it(...)` blocks appear in the coverage report for `src/ssh/JumpHostTunnel.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)