### PR TITLE
test: cover writeAtomic errors, waitForToken lastErr, and Port edge cases

### DIFF
--- a/plugin/tests/ObsidianRegistry.test.ts
+++ b/plugin/tests/ObsidianRegistry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -135,5 +135,45 @@ describe('ObsidianRegistry', () => {
     const dir = path.dirname(configPath);
     const tmps = fs.readdirSync(dir).filter(f => f.startsWith(path.basename(configPath) + '.tmp-'));
     expect(tmps).toEqual([]);
+  });
+});
+
+// ── writeAtomic error propagation ────────────────────────────────────────
+
+describe('ObsidianRegistry writeAtomic error propagation', () => {
+  let configPath: string;
+
+  beforeEach(() => {
+    configPath = makeTmpConfigPath();
+    fs.writeFileSync(configPath, JSON.stringify({ vaults: {} }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // Clean up the config file and any leftover tmp files.
+    const tmpPrefix = path.basename(configPath) + '.tmp-remote-ssh-';
+    const dir = path.dirname(configPath);
+    try {
+      fs.readdirSync(dir)
+        .filter(f => f.startsWith(tmpPrefix))
+        .forEach(f => { try { fs.unlinkSync(path.join(dir, f)); } catch { /* ignore */ } });
+    } catch { /* ignore */ }
+    try { fs.unlinkSync(configPath); } catch { /* may not exist */ }
+  });
+
+  it('propagates an error thrown by fs.writeFileSync inside writeAtomic', () => {
+    vi.spyOn(fs, 'writeFileSync').mockImplementationOnce(() => {
+      throw new Error('ENOSPC: no space left on device');
+    });
+    expect(() => new ObsidianRegistry(configPath).register('/new/vault'))
+      .toThrow('ENOSPC: no space left on device');
+  });
+
+  it('propagates an error thrown by fs.renameSync inside writeAtomic', () => {
+    vi.spyOn(fs, 'renameSync').mockImplementationOnce(() => {
+      throw new Error('EXDEV: cross-device link not permitted');
+    });
+    expect(() => new ObsidianRegistry(configPath).register('/new/vault'))
+      .toThrow('EXDEV: cross-device link not permitted');
   });
 });

--- a/plugin/tests/ServerDeployer.test.ts
+++ b/plugin/tests/ServerDeployer.test.ts
@@ -231,6 +231,16 @@ describe('ServerDeployer', () => {
     })).rejects.toThrow(/did not write/);
   });
 
+  it('includes the last readRemoteFile error in the deadline-exceeded message', async () => {
+    const { ssh } = fakeSsh({
+      onReadFile: () => { throw new Error('SFTP: permission denied on token file'); },
+    });
+    await expect(new ServerDeployer(ssh).deploy({
+      localBinaryPath: BIN.path, remoteVaultRoot: '/y',
+      waitForTokenTimeoutMs: 200,
+    })).rejects.toThrow(/last error: SFTP: permission denied on token file/);
+  });
+
   it('stop() reuses the deploy()-time kill pattern and cleans up binary + socket + token', async () => {
     const { ssh, execLog } = fakeSsh({ onReadFile: () => Buffer.from('tok') });
     const deployer = new ServerDeployer(ssh);

--- a/plugin/tests/SshConfigReader.test.ts
+++ b/plugin/tests/SshConfigReader.test.ts
@@ -49,6 +49,28 @@ describe('readSshConfig: missing / empty file', () => {
   });
 });
 
+describe('readSshConfig: Port edge cases', () => {
+  it('falls back port to 22 when Port value is non-numeric', () => {
+    const p = write([
+      'Host srv',
+      '  HostName srv.example.com',
+      '  Port notanumber',
+    ].join('\n'));
+    expect(readSshConfig(p)[0].port).toBe(22);
+  });
+
+  it('applies a Port set in Host * defaults to hosts that do not override it', () => {
+    const p = write([
+      'Host *',
+      '  Port 2222',
+      '',
+      'Host srv',
+      '  HostName srv.example.com',
+    ].join('\n'));
+    expect(readSshConfig(p)[0].port).toBe(2222);
+  });
+});
+
 describe('readSshConfig: single host', () => {
   it('reads HostName / User / Port / IdentityFile', () => {
     const p = write([


### PR DESCRIPTION
## Summary

- **ObsidianRegistry** (`tests/ObsidianRegistry.test.ts`): two new tests for `writeAtomic` error propagation using `vi.spyOn` on `fs.writeFileSync` and `fs.renameSync`, covering the previously untested throw paths in the atomic-write helper
- **ServerDeployer** (`tests/ServerDeployer.test.ts`): asserts the deadline-exceeded error includes the \`(last error: …)\` suffix when \`readRemoteFile\` always rejects, covering the \`lastErr\` branch in \`waitForToken\`
- **SshConfigReader** (`tests/SshConfigReader.test.ts`): two Port edge-case tests — non-numeric \`Port\` value (\`parseInt\` NaN → 22 fallback) and \`Port\` set in a \`Host *\` defaults block — covering two branches in \`parseBlocks\` and \`mergeDefaults\` that had no prior test

## Test plan

- [ ] CI runs \`npm test\` (vitest) — all new tests pass
- [ ] Coverage lines/branches/functions stay above thresholds or improve
- [ ] No new test leaks tmp files (afterEach cleanup verified for renameSync test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)