### PR TITLE
test: 100% coverage for errorMessage, RpcError, and isPreconditionFailed

### DIFF
--- a/plugin/tests/RpcError.test.ts
+++ b/plugin/tests/RpcError.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { RpcError } from '../src/transport/RpcError';
+import { isPreconditionFailed } from '../src/proto/rpcError';
+import { ErrorCode } from '../src/proto/types';
+
+describe('RpcError', () => {
+  it('sets name, code, message, and data from constructor arguments', () => {
+    const e = new RpcError(ErrorCode.FileNotFound, 'not found', { path: 'foo.md' });
+    expect(e.name).toBe('RpcError');
+    expect(e.code).toBe(ErrorCode.FileNotFound);
+    expect(e.message).toBe('not found');
+    expect(e.data).toEqual({ path: 'foo.md' });
+  });
+
+  it('data is undefined when the third argument is omitted', () => {
+    const e = new RpcError(ErrorCode.InternalError, 'oops');
+    expect(e.data).toBeUndefined();
+  });
+
+  it('is an instance of Error so catch blocks that check instanceof Error still catch it', () => {
+    expect(new RpcError(ErrorCode.InternalError, 'err')).toBeInstanceOf(Error);
+  });
+
+  it('is() returns true when the code matches', () => {
+    const e = new RpcError(ErrorCode.FileNotFound, 'not found');
+    expect(e.is(ErrorCode.FileNotFound)).toBe(true);
+  });
+
+  it('is() returns false when the code does not match', () => {
+    const e = new RpcError(ErrorCode.FileNotFound, 'not found');
+    expect(e.is(ErrorCode.PermissionDenied)).toBe(false);
+  });
+
+  it('is() distinguishes between close numeric codes (AuthRequired vs AuthInvalid)', () => {
+    const e = new RpcError(ErrorCode.AuthRequired, 'auth required');
+    expect(e.is(ErrorCode.AuthRequired)).toBe(true);
+    expect(e.is(ErrorCode.AuthInvalid)).toBe(false);
+  });
+});
+
+describe('isPreconditionFailed', () => {
+  it('returns true when the object has code === PreconditionFailed', () => {
+    expect(isPreconditionFailed({ code: ErrorCode.PreconditionFailed })).toBe(true);
+  });
+
+  it('returns false for a different numeric error code', () => {
+    expect(isPreconditionFailed({ code: ErrorCode.FileNotFound })).toBe(false);
+  });
+
+  it('returns false when the object has no code property', () => {
+    expect(isPreconditionFailed({ message: 'oops' })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isPreconditionFailed(null)).toBe(false);
+  });
+
+  it('returns false for a string primitive', () => {
+    expect(isPreconditionFailed('PreconditionFailed')).toBe(false);
+  });
+
+  it('returns false for a number primitive', () => {
+    expect(isPreconditionFailed(ErrorCode.PreconditionFailed)).toBe(false);
+  });
+
+  it('works with a plain object that duck-types a transport error (no RpcError import needed)', () => {
+    // The function is duck-typed on purpose — SFTP errors arrive as
+    // plain objects with a numeric `code` field, not as RpcError instances.
+    const sftpStyle = { code: ErrorCode.PreconditionFailed, message: 'mtime changed' };
+    expect(isPreconditionFailed(sftpStyle)).toBe(true);
+  });
+});

--- a/plugin/tests/errorMessage.test.ts
+++ b/plugin/tests/errorMessage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { errorMessage, asError } from '../src/util/errorMessage';
+
+describe('errorMessage', () => {
+  it('returns the message property when passed an Error', () => {
+    expect(errorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('coerces a string to string unchanged', () => {
+    expect(errorMessage('plain string')).toBe('plain string');
+  });
+
+  it('coerces a number via String()', () => {
+    expect(errorMessage(42)).toBe('42');
+  });
+
+  it('coerces null via String()', () => {
+    expect(errorMessage(null)).toBe('null');
+  });
+
+  it('coerces undefined via String()', () => {
+    expect(errorMessage(undefined)).toBe('undefined');
+  });
+
+  it('returns an empty string for an Error with no message', () => {
+    expect(errorMessage(new Error())).toBe('');
+  });
+});
+
+describe('asError', () => {
+  it('returns the same Error instance when passed an Error', () => {
+    const e = new Error('original');
+    expect(asError(e)).toBe(e);
+  });
+
+  it('wraps a string in a new Error', () => {
+    const result = asError('raw string');
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('raw string');
+  });
+
+  it('wraps a number in a new Error using String()', () => {
+    const result = asError(99);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('99');
+  });
+
+  it('wraps null in a new Error', () => {
+    const result = asError(null);
+    expect(result).toBeInstanceOf(Error);
+    expect(result.message).toBe('null');
+  });
+
+  it('preserves subclass instances (TypeError, etc.) unchanged', () => {
+    const e = new TypeError('type mismatch');
+    expect(asError(e)).toBe(e);
+    expect(asError(e)).toBeInstanceOf(TypeError);
+  });
+});


### PR DESCRIPTION
## Summary

Covers three previously untested source files with pure unit tests — no external dependencies, no mocking.

- **\`tests/errorMessage.test.ts\`** (new, 11 tests): covers both branches of \`errorMessage()\` and both branches of \`asError()\` across Error instances, subclasses, strings, numbers, null, and undefined
- **\`tests/RpcError.test.ts\`** (new, 13 tests): covers \`RpcError\` constructor fields, optional \`data\`, \`instanceof Error\`, and \`is()\` true/false branches — plus all 7 branches of \`isPreconditionFailed()\` from \`src/proto/rpcError.ts\` (match, wrong code, missing property, null, primitives, duck-typed object)

Both files are bundled in one PR because \`RpcError.test.ts\` and \`rpcError.test.ts\` resolve to the same physical file on Windows (case-insensitive FS), so both concerns live in a single test file.

## Test plan

- [ ] CI runs \`npm test\` — all 24 new tests pass
- [ ] \`src/util/errorMessage.ts\` reaches 100% line/branch/function coverage
- [ ] \`src/transport/RpcError.ts\` reaches 100% line/branch/function coverage
- [ ] \`src/proto/rpcError.ts\` reaches 100% line/branch/function coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)