### PR TITLE
test(ShadowVaultBootstrap): cover parse-failure and symlink-fallback branches

### DIFF
--- a/plugin/tests/RpcConnection.test.ts
+++ b/plugin/tests/RpcConnection.test.ts
@@ -37,6 +37,10 @@ interface ServerScript {
   info?: { protocolVersion: number };
   /** Make `auth` reject with a custom error envelope. */
   authReject?: { code: number; message: string };
+  /** Make `auth` reply result.ok = false (token accepted but server refused). */
+  authOkFalse?: boolean;
+  /** Make `server.info` reply with an error envelope instead of a result. */
+  infoError?: { code: number; message: string };
 }
 
 /**
@@ -53,6 +57,10 @@ function startFakeDaemon(serverSide: Duplex, script: ServerScript = {}): () => v
         framed.writeMessage(Buffer.from(JSON.stringify({
           jsonrpc: '2.0', id: req.id, error: script.authReject,
         }), 'utf8'));
+      } else if (script.authOkFalse) {
+        framed.writeMessage(Buffer.from(JSON.stringify({
+          jsonrpc: '2.0', id: req.id, result: { ok: false },
+        }), 'utf8'));
       } else {
         framed.writeMessage(Buffer.from(JSON.stringify({
           jsonrpc: '2.0', id: req.id, result: { ok: true },
@@ -61,6 +69,12 @@ function startFakeDaemon(serverSide: Duplex, script: ServerScript = {}): () => v
       return;
     }
     if (req.method === 'server.info') {
+      if (script.infoError) {
+        framed.writeMessage(Buffer.from(JSON.stringify({
+          jsonrpc: '2.0', id: req.id, error: script.infoError,
+        }), 'utf8'));
+        return;
+      }
       const info = script.info ?? { protocolVersion: PROTOCOL_VERSION };
       framed.writeMessage(Buffer.from(JSON.stringify({
         jsonrpc: '2.0', id: req.id,
@@ -111,6 +125,26 @@ describe('establishRpcConnection', () => {
       expect(e).toBeInstanceOf(RpcError);
       expect((e as RpcError).code).toBe(ErrorCode.ProtocolVersionTooOld);
     }
+    stop();
+  });
+
+  it('rejects with AuthInvalid when auth returns result.ok = false', async () => {
+    const pair = duplexPair();
+    const stop = startFakeDaemon(pair.serverSide, { authOkFalse: true });
+    await expect(
+      establishRpcConnection({ stream: pair.clientSide, token: 'any' }),
+    ).rejects.toMatchObject({ code: ErrorCode.AuthInvalid });
+    stop();
+  });
+
+  it('rejects and closes when server.info returns an error envelope', async () => {
+    const pair = duplexPair();
+    const stop = startFakeDaemon(pair.serverSide, {
+      infoError: { code: -32000, message: 'method unavailable' },
+    });
+    await expect(
+      establishRpcConnection({ stream: pair.clientSide, token: 'good' }),
+    ).rejects.toThrow('method unavailable');
     stop();
   });
 });

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -439,5 +439,148 @@ describe('ShadowVaultBootstrap.bootstrap', () => {
     const result = await r.bootstrap(profile, [profile]);
     const installed = fs.readFileSync(path.join(result.layout.pluginDir, 'main.js'), 'utf-8');
     expect(installed).toContain('updated bundle');
+  });
+});
+
+describe('ShadowVaultBootstrap: seedCommunityPlugins error branches', () => {
+  let scratch: ReturnType<typeof makeScratch>;
+  beforeEach(() => { scratch = makeScratch(); });
+  afterEach(() => { scratch.cleanup(); });
+
+  it('rewrites shadow community-plugins.json when the existing file contains invalid JSON', async () => {
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+
+    // First bootstrap creates the shadow config dir and community-plugins.json.
+    const first = await r.bootstrap(profile, [profile]);
+
+    // Corrupt the file so the next parse fails.
+    fs.writeFileSync(
+      path.join(first.layout.configDir, 'community-plugins.json'),
+      '{not valid json!!!}',
+    );
+
+    // Second bootstrap should detect the parse failure, warn, and rewrite.
+    const second = await r.bootstrap(profile, [profile]);
+    const list = JSON.parse(
+      fs.readFileSync(path.join(second.layout.configDir, 'community-plugins.json'), 'utf-8'),
+    );
+    expect(list).toEqual(['remote-ssh']);
+  });
+
+  it('rewrites shadow community-plugins.json when the file is valid JSON but not an array', async () => {
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+
+    const first = await r.bootstrap(profile, [profile]);
+
+    // Valid JSON object — not an array.
+    fs.writeFileSync(
+      path.join(first.layout.configDir, 'community-plugins.json'),
+      JSON.stringify({ remote_ssh: true }),
+    );
+
+    const second = await r.bootstrap(profile, [profile]);
+    const list = JSON.parse(
+      fs.readFileSync(path.join(second.layout.configDir, 'community-plugins.json'), 'utf-8'),
+    );
+    expect(list).toEqual(['remote-ssh']);
+  });
+});
+
+describe('ShadowVaultBootstrap: collectPendingPluginSuggestions edge cases', () => {
+  let scratch: ReturnType<typeof makeScratch>;
+  beforeEach(() => { scratch = makeScratch(); });
+  afterEach(() => { scratch.cleanup(); });
+
+  it('omits suggestions when source community-plugins.json is valid JSON but not an array', async () => {
+    fs.writeFileSync(
+      path.join(scratch.sourceConfigDir, 'community-plugins.json'),
+      JSON.stringify({ corrupted: true }),
+    );
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+    const result = await r.bootstrap(profile, [profile]);
+
+    const data = JSON.parse(fs.readFileSync(result.layout.pluginDataFile, 'utf-8'));
+    expect(data.pendingPluginSuggestions).toEqual([]);
+  });
+
+  it('omits suggestions when source community-plugins.json is invalid JSON', async () => {
+    fs.writeFileSync(
+      path.join(scratch.sourceConfigDir, 'community-plugins.json'),
+      '{invalid!}',
+    );
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+    const result = await r.bootstrap(profile, [profile]);
+
+    const data = JSON.parse(fs.readFileSync(result.layout.pluginDataFile, 'utf-8'));
+    expect(data.pendingPluginSuggestions).toEqual([]);
+  });
+
+  it('still lists a plugin suggestion even when its data.json is invalid JSON (sourceData is null)', async () => {
+    fs.writeFileSync(
+      path.join(scratch.sourceConfigDir, 'community-plugins.json'),
+      JSON.stringify(['dataview']),
+    );
+    const dataviewDir = path.join(scratch.sourceConfigDir, 'plugins', 'dataview');
+    fs.mkdirSync(dataviewDir, { recursive: true });
+    fs.writeFileSync(path.join(dataviewDir, 'data.json'), '{invalid!}');
+
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+    const result = await r.bootstrap(profile, [profile]);
+
+    const data = JSON.parse(fs.readFileSync(result.layout.pluginDataFile, 'utf-8'));
+    expect(data.pendingPluginSuggestions).toHaveLength(1);
+    expect(data.pendingPluginSuggestions[0].id).toBe('dataview');
+    expect(data.pendingPluginSuggestions[0].sourceData).toBeNull();
+  });
+});
+
+describe('ShadowVaultBootstrap: readBaseDataJson parse-failure fallback', () => {
+  let scratch: ReturnType<typeof makeScratch>;
+  beforeEach(() => { scratch = makeScratch(); });
+  afterEach(() => { scratch.cleanup(); });
+
+  it('starts from {} when shadow data.json exists but contains invalid JSON', async () => {
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+
+    const first = await r.bootstrap(profile, [profile]);
+
+    // Corrupt the shadow data.json.
+    fs.writeFileSync(first.layout.pluginDataFile, '{not json!}');
+
+    // Second bootstrap should discard the corrupted file and rebuild from source or {}.
+    const second = await r.bootstrap(profile, [profile]);
+    const data = JSON.parse(fs.readFileSync(second.layout.pluginDataFile, 'utf-8'));
+    // profiles and activeProfileId are always written — just assert they're present
+    // and no crash occurred despite the corrupted input.
+    expect(data.profiles).toEqual([profile]);
+    expect(data.activeProfileId).toBe('p1');
+  });
+});
+
+describe('ShadowVaultBootstrap: installPlugin symlink fallback', () => {
+  let scratch: ReturnType<typeof makeScratch>;
+  beforeEach(() => { scratch = makeScratch(); });
+  afterEach(() => { scratch.cleanup(); vi.restoreAllMocks(); });
+
+  it('falls back to copyFileSync when symlinkSync throws, and plugin files are still present', async () => {
+    // Simulate an environment where symlinks are not permitted (e.g. restricted Windows).
+    vi.spyOn(fs, 'symlinkSync').mockImplementation(() => {
+      throw Object.assign(new Error('EPERM: operation not permitted, symlink'), { code: 'EPERM' });
+    });
+
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1' });
+    const result = await r.bootstrap(profile, [profile]);
+
+    expect(result.pluginInstallMethod).toBe('copy');
+    // The files should have been copied successfully.
+    expect(fs.existsSync(path.join(result.layout.pluginDir, 'main.js'))).toBe(true);
+    expect(fs.existsSync(path.join(result.layout.pluginDir, 'manifest.json'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds 7 tests for previously uncovered branches in `src/shadow/ShadowVaultBootstrap.ts`.

**`seedCommunityPlugins()`**
- Rewrites shadow `community-plugins.json` when the existing file is invalid JSON (parse error → warn + rewrite)
- Rewrites when the existing file is valid JSON but not an array (non-array shape → fall-through rewrite)

**`collectPendingPluginSuggestions()`**
- Returns `[]` when the source `community-plugins.json` is valid JSON but not an array
- Returns `[]` when the source `community-plugins.json` is invalid JSON (parse error → warn + return [])
- Still returns a suggestion entry with `sourceData: null` when a plugin's `data.json` is invalid JSON

**`readBaseDataJson()`**
- Survives a corrupt shadow `data.json` — discards it gracefully and continues without crash

**`installPlugin()`**
- Falls back to `copyFileSync` when `symlinkSync` throws `EPERM`, and plugin files are still present in the shadow plugin dir

## Test plan

- [ ] CI passes all 7 new tests across the new `describe` blocks
- [ ] Coverage for `src/shadow/ShadowVaultBootstrap.ts` increases (several catch-blocks and the copy-fallback path now hit)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)