### PR TITLE
test(errorTaxonomy): cover mapSyscallCode null-return (unknown code) branch

### DIFF
--- a/plugin/tests/ErrorTaxonomy.test.ts
+++ b/plugin/tests/ErrorTaxonomy.test.ts
@@ -138,6 +138,16 @@ describe('classifyError — message fallbacks', () => {
     expect(c.original).toBeInstanceOf(Error);
     expect(c.original.message).toBe('boom');
   });
+
+  it('error with a syscall code absent from mapSyscallCode falls through to "unknown"', () => {
+    // ENOENT is a real Node code, but mapSyscallCode does not classify it —
+    // the inner if(cat) guard is skipped and execution reaches the fallback.
+    const e = new Error('ENOENT: no such file or directory');
+    (e as Error & { code: string }).code = 'ENOENT';
+    const c = classifyError(e);
+    expect(c.category).toBe('unknown');
+    assertWellFormed(c);
+  });
 });
 
 // ── classifyToNotice convenience ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds one test for a previously uncovered branch in `src/transport/errorTaxonomy.ts`.

### Background

`classifyError` checks the `.code` property of thrown errors against `mapSyscallCode`. Every existing test uses codes that *are* in the switch (`ENOTFOUND`, `ECONNREFUSED`, etc.), so the inner `if (cat)` guard at line 131 was always `true` — the false branch (code present but unrecognised) was never exercised.

### What the new test does

Passes an `Error` with `code: 'ENOENT'` (a real Node code, but absent from `mapSyscallCode`'s switch). This makes `mapSyscallCode` return `null`, so:
- `if (sysCode)` → `true` (ENOENT is truthy) — this part was already covered
- `if (cat)` → `false` — **newly covered**
- execution falls through to message-pattern matching → `category: 'unknown'`

## Test plan

- [ ] CI passes the new test
- [ ] Branch coverage for `src/transport/errorTaxonomy.ts` lines 130-132 increases

🤖 Generated with [Claude Code](https://claude.ai/claude-code)