### PR TITLE
docs(release-flow): cut promotions from a release branch, not direct push to next

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,20 +93,26 @@ Why this exists:
 
 #### Cutting a promotion (next → main)
 
-When `next` has accumulated enough verified work to ship:
+When `next` has accumulated enough verified work to ship, do the version bump on a **release branch**, not directly on `next`. This keeps every commit lint-checked + CI-validated without requiring branch-protection bypass:
 
 ```bash
+git checkout -b release/X.Y.Z next
 cd plugin
 npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops -beta suffix)
-git commit -am "release: prepare 1.0.44 promotion"
-git push origin next         # release.yml SKIPS this push (gate: stable-on-next)
-gh pr create --base main --head next --title "release: promote next → main (1.0.44)"
+git commit -am "release: prepare X.Y.Z promotion"
+git push origin release/X.Y.Z
+gh pr create --base main --head release/X.Y.Z \
+  --title "release: promote next → main (X.Y.Z)"
 ```
 
+CI runs the full suite (commitlint, version-check, lint, type-check, tests) on the release branch's head before merge — no admin override.
+
 After CI green and merge:
-- `release.yml` fires on the main push → publishes **v1.0.44** stable.
+- `release.yml` fires on the main push → publishes **v X.Y.Z** stable + cosign-signed binaries.
 - `sync-main-to-next.yml` fires on the main push → opens + auto-merges `sync: main → next` so `next` gets the merge commit.
-- Your next beta cycle starts with `npm run bump:beta:start` (`1.0.44 → 1.0.45-beta.0`).
+- Your next beta cycle starts with `npm run bump:beta:start` (`X.Y.Z → X.Y.(Z+1)-beta.0`) on a normal `feat/...` branch.
+
+> Why a release branch? Pre-2026-05 the docs said "push directly to `next`, then PR next → main". That worked but required admin bypass on `next`'s branch protection (the bump commit hadn't been through CI yet). Branch protection on `main` and `next` now disallows admin bypass, so the bump must live on its own branch + go through CI.
 
 ### Commit messages — Conventional Commits, enforced
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.44",
+  "version": "1.0.45-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.44",
+  "version": "1.0.45-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.44",
+  "version": "1.0.45-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.44",
+      "version": "1.0.45-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.44",
+  "version": "1.0.45-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Updates the documented `next → main` promotion flow to use a `release/X.Y.Z` branch instead of pushing the bump commit directly to `next`. Same outcome but the bump commit is CI-validated before merge — no admin bypass required.

### Why

Today's documented flow has the contributor:
1. Run `bump:stable` on next
2. `git push origin next` (the bump commit, never CI-checked)
3. Open a promotion PR

Step 2 needs admin bypass on `next`'s branch protection. The follow-up branch-protection tighten (next session) will disallow admin bypass entirely. So the flow needs to move the bump onto its own branch first.

### Changes

- `CONTRIBUTING.md` "Cutting a promotion" section rewritten to use `release/X.Y.Z` branch.
- A short rationale note explains why we changed (so the next person reading the doc understands).
- Bumps `next` from 1.0.44 (stable, just promoted) to **1.0.45-beta.0** — opens the new beta cycle.

### Side effects on merge

- `release.yml` fires on the `next` push → publishes **v1.0.45-beta.0** as a GitHub prerelease.
- BRAT users get the new cycle on their next launch.

### Follow-up (not in this PR)

After this merges:
1. `gh api -X PUT repos/.../branches/{main,next}/protection` to set `enforce_admins=true` + verify branch protection blocks future direct pushes.
2. Verify the new release-branch flow works end-to-end on the next promotion.

## Test plan

- [ ] CI green
- [ ] After merge: `v1.0.45-beta.0` prerelease published; BRAT picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)