### PR TITLE
docs: advisory polish — drop "this page covers" preambles + dedupe rationale

### DIFF
--- a/docs/en/architecture/index.md
+++ b/docs/en/architecture/index.md
@@ -5,7 +5,7 @@ tags: [architecture]
 
 # Architecture
 
-Design specs for the major subsystems. These document **why** decisions were made, not just **what** the code does.
+Design specs for the major subsystems — the **why** behind decisions, not just the **what** of the code. Read [[shadow-vault|Shadow vault]] first; it's the foundation the others build on.
 
 ## Documents
 

--- a/docs/en/getting-started/first-connect.md
+++ b/docs/en/getting-started/first-connect.md
@@ -5,8 +5,6 @@ tags: [getting-started]
 
 # First connect — what's actually happening
 
-The five-minute [[en/getting-started/quickstart|Quickstart]] glosses over what "connect" does. This page goes through it step-by-step so the first time something breaks, you know where to look.
-
 ## The shadow vault model
 
 obsidian-remote-ssh does not edit your remote files directly through Obsidian's vault layer. Instead it:

--- a/docs/en/operations/reconnect.md
+++ b/docs/en/operations/reconnect.md
@@ -5,7 +5,7 @@ tags: [operations]
 
 # Reconnect behavior
 
-When the SSH connection drops mid-session (network blip, sleep/wake, Wi-Fi roam), the plugin tries to recover automatically before surfacing an error to you.
+When the SSH connection drops mid-session, the plugin retries up to **5 times** with **×1.5 exponential backoff** (1 s → 1.5 s → 2.25 s → … capped at 30 s) before surfacing an error.
 
 ## Default policy
 

--- a/docs/en/security/token.md
+++ b/docs/en/security/token.md
@@ -5,7 +5,7 @@ tags: [security]
 
 # Token & socket
 
-The daemon authenticates clients via a shared-secret token read from a file. This page covers the lifecycle and what to worry about.
+The daemon authenticates clients via a 32-byte shared-secret token written to a `0600`-mode file at startup, never persisted across daemon restarts. The plugin reads it via SFTP and presents it on the `auth` RPC.
 
 ## What gets generated
 

--- a/docs/en/server/signing.md
+++ b/docs/en/server/signing.md
@@ -5,9 +5,7 @@ tags: [server, security, deploy]
 
 # Binary signing
 
-Every release binary is signed with [Cosign keyless](https://docs.sigstore.dev/cosign/signing/overview/) (Sigstore OIDC). No GPG key management, no trust roots to bootstrap — the signature is bound to the GitHub Actions workflow that produced it.
-
-This page covers the publisher side (what the release pipeline does). For verifying a binary you downloaded, see [[en/security/cosign-verify|Cosign verify]].
+Every release binary is signed with [Cosign keyless](https://docs.sigstore.dev/cosign/signing/overview/) (Sigstore OIDC) by the GitHub Actions workflow that produced it — no GPG key management, no trust roots to bootstrap. This page covers the publisher side; verifying a binary you downloaded is over at [[en/security/cosign-verify|Cosign verify]].
 
 ## What gets signed
 

--- a/docs/en/user-guide/host-keys.md
+++ b/docs/en/user-guide/host-keys.md
@@ -5,13 +5,7 @@ tags: [user-guide, security]
 
 # Host keys & trust
 
-obsidian-remote-ssh maintains its **own known-host store**, independent of `~/.ssh/known_hosts`. This page explains the trust model and what each dialog means.
-
-## Why a separate store
-
-OpenSSH's `known_hosts` is shared across every `ssh` invocation on your machine. The plugin's separate store keeps trust scoped to the plugin — adding the plugin does not suddenly trust hosts your shell SSH already knew, and removing the plugin does not leave orphan trust elsewhere.
-
-The store lives in the plugin's `data.json` under the `hostKeyStore` key. See [[en/security/host-keys#manual-edits|Security → Host-key trust → Manual edits]] for the on-disk format.
+obsidian-remote-ssh maintains its **own known-host store** (separate from `~/.ssh/known_hosts`) so trust stays scoped to the plugin. Rationale: see [[en/security/host-keys#why-a-separate-store|Security → Host-key trust → Why a separate store]]. The store lives in the plugin's `data.json` under the `hostKeyStore` key — on-disk format at [[en/security/host-keys#manual-edits|Manual edits]].
 
 ## First-connect (TOFU) flow
 

--- a/docs/en/user-guide/jump-host.md
+++ b/docs/en/user-guide/jump-host.md
@@ -16,7 +16,7 @@ In a profile, click **Add jump host**:
 | Jump host | `bastion.example.com` |
 | Port | `22` |
 | Username | `your-bastion-user` |
-| Auth | usually shares the parent's credentials; can override per hop |
+| Auth | inherits the profile's credentials by default; per-hop override available |
 
 Multiple hops chain in order: `you → bastion-1 → bastion-2 → target`.
 

--- a/docs/en/user-guide/ssh-config.md
+++ b/docs/en/user-guide/ssh-config.md
@@ -5,7 +5,7 @@ tags: [user-guide]
 
 # SSH config & keys
 
-obsidian-remote-ssh uses your existing SSH credentials (key files, agent) — it does not maintain its own keychain. This page covers how the plugin resolves credentials and what is supported.
+obsidian-remote-ssh uses your existing SSH credentials (key files, agent) — it does not maintain its own keychain.
 
 ## Authentication methods
 

--- a/docs/en/user-guide/terminal-pane.md
+++ b/docs/en/user-guide/terminal-pane.md
@@ -18,7 +18,7 @@ A terminal opens as a regular Obsidian pane; you can split it, drag it to a side
 
 ## What you get
 
-- Your remote user's default login shell (`$SHELL`, typically `bash` or `zsh`).
+- Your remote user's `$SHELL` (override in settings to pin a specific shell).
 - Full TTY: aliases, colours, `fzf`, `htop`, `vim`, `tmux` all work.
 - Resizes when you resize the pane.
 - Persists across pane re-opens within a session — closing the pane retains scrollback until you disconnect.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.3",
+  "version": "1.0.45-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.3",
+  "version": "1.0.45-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.3",
+  "version": "1.0.45-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.3",
+      "version": "1.0.45-beta.4",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.3",
+  "version": "1.0.45-beta.4",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Cleans up stylistic advisory items that accumulated across past doc-set review passes — none of them blocking, all worth doing as one cleanup batch.

### What changed

**Lead-paragraph rewrites (drop self-referential preambles)** — 6 files:
- `security/token.md` — replaced "This page covers..." with a one-sentence factual lede
- `getting-started/first-connect.md` — removed "The five-minute Quickstart glosses over..." meta sentence
- `user-guide/ssh-config.md` — dropped "This page covers how the plugin resolves credentials"
- `operations/reconnect.md` — rewrote vague "tries to recover automatically" opener into concrete policy
- `architecture/index.md` — tightened generic opener with reading-order hint
- `server/signing.md` — collapsed two-sentence preamble into one

**Stacked hedges removed** — 2 files:
- `user-guide/jump-host.md` — "usually shares the parent's credentials" → "inherits the profile's credentials by default"
- `user-guide/terminal-pane.md` — "$SHELL, typically bash or zsh" → drop hedge, mention override path

**Deduplication** — 1 file:
- `user-guide/host-keys.md` "Why a separate store" section (duplicated the same rationale in `security/host-keys.md`) collapsed to a one-line summary + cross-link to the canonical version

### Net diff

- 13 files changed
- +13 / −23 lines (net −10) — mostly snipping bloat without losing information

### Side effects on merge

- `release.yml` fires on `next` push → publishes **v1.0.45-beta.4** as a prerelease.

## Test plan

- [ ] CI green
- [ ] After merge: dev docs site re-renders the touched pages
- [ ] Cross-links work in `user-guide/host-keys.md` ("Why a separate store" + "Manual edits" anchors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)