### PR TITLE
docs(cookbook): add backup/restore + host migration recipes

### DIFF
--- a/docs/en/cookbook/backup-restore.md
+++ b/docs/en/cookbook/backup-restore.md
@@ -1,0 +1,135 @@
+---
+title: Backup & restore
+tags: [cookbook, how-to, backup, ops]
+---
+
+# Backup & restore
+
+The plugin doesn't run its own backup. Your **vault files on the remote** are the only thing that matters; everything else is regenerable. This recipe walks through what to actually back up, where it lives, and how to restore.
+
+## What's worth backing up
+
+```mermaid
+graph LR
+  subgraph remote["On the remote (back this up)"]
+    V[Vault directory<br/>e.g. ~/notes — your actual files]
+  end
+  subgraph regen["Regenerable (skip)"]
+    D[~/.obsidian-remote/<br/>daemon binary + token + socket]
+    SV[Local shadow vault<br/>~/.obsidian-remote/vaults/<id>/]
+    PL[Plugin bundle<br/><vault>/.obsidian/plugins/remote-ssh/]
+  end
+```
+
+| Path | Back up? | Why |
+|---|:-:|---|
+| `<vault root>` on the remote (e.g. `/home/pi/notes/`) | **Yes** | Your actual notes — the irreplaceable bit |
+| `~/.obsidian-remote/server` (daemon binary) | No | Re-uploaded by the plugin on next connect |
+| `~/.obsidian-remote/token` | No | Regenerated on every daemon restart |
+| `~/.obsidian-remote/server.log` | Optional | Useful for post-incident debugging; rotates anyway |
+| `~/.obsidian-remote/vaults/<id>/` (local shadow) | No | Re-fetched from the remote on next connect |
+| `<vault>/.obsidian/plugins/remote-ssh/` | No | Re-installed via Community Plugins / BRAT / manual |
+| `<vault>/.obsidian/plugins/remote-ssh/data.json` | Maybe | Holds your profile list + host-key fingerprints. Convenient to back up but easy to recreate if lost. |
+
+## Three approaches by complexity
+
+### 1. rsync to a second host (lowest setup)
+
+```bash
+# On the remote, daily cron:
+0 3 * * * rsync -aHx --delete-after \
+  /home/pi/notes/ \
+  backup-host:/srv/backups/notes/
+```
+
+`-a` preserves permissions, `-H` preserves hard links (Obsidian doesn't use them but it's cheap), `-x` stops at filesystem boundaries. `--delete-after` means deletions on the source propagate.
+
+This is fine for a single backup target with no historical retention.
+
+### 2. restic (versioned, deduplicated)
+
+```bash
+# One-time setup
+sudo apt install restic
+restic init --repo /mnt/backup-disk/restic-vault
+
+# Daily snapshot (cron)
+0 3 * * * restic --repo /mnt/backup-disk/restic-vault \
+  backup /home/pi/notes \
+  --tag daily
+
+# Weekly retention prune
+0 4 * * 0 restic --repo /mnt/backup-disk/restic-vault \
+  forget --keep-daily 14 --keep-weekly 8 --keep-monthly 12 \
+  --prune
+```
+
+restic gives you:
+- Per-file deduplication (notes that don't change between snapshots take ~no space)
+- Encryption at rest (the repo is encrypted with your passphrase)
+- Point-in-time restore (`restic restore <snapshot-id> --target /tmp/restore`)
+- Native S3 / B2 / SFTP / rclone backends if you want off-site
+
+This is the recommended path for a vault you care about.
+
+### 3. borg / tarsnap (similar tier)
+
+[borg](https://borgbackup.readthedocs.io/) and [tarsnap](https://www.tarsnap.com/) cover the same ground as restic with different trade-offs (borg is broadly similar; tarsnap is a paid encrypted-cloud service with strong reputation but no local mode). Pick whichever you already trust.
+
+## Restore scenarios
+
+### A. Specific note deleted by mistake
+
+The plugin's [[en/user-guide/conflicts|conflict handling]] flow does **not** create backups of overwrites — there's no `.bak` recovery (see the page's warning). For a single note, restore from your latest backup:
+
+```bash
+# restic
+restic --repo /mnt/backup-disk/restic-vault \
+  restore latest --target /tmp/restore --include /home/pi/notes/lost-note.md
+cp /tmp/restore/home/pi/notes/lost-note.md /home/pi/notes/
+```
+
+The plugin's `fs.watch` subscription will pick the file up automatically — your in-Obsidian view refreshes within ~500 ms.
+
+### B. Whole vault corrupted / ransomware / disk failure
+
+If the remote's vault directory is gone or corrupted:
+
+1. Stop the daemon so it doesn't write into the broken state:
+   ```bash
+   pkill -f obsidian-remote-server
+   ```
+2. Restore the vault from backup:
+   ```bash
+   restic --repo /mnt/backup-disk/restic-vault \
+     restore latest --target /tmp/restore --include /home/pi/notes
+   rsync -aHx --delete /tmp/restore/home/pi/notes/ /home/pi/notes/
+   ```
+3. Reconnect from the plugin. The auto-deploy redeploys a fresh daemon (since the previous socket + token are gone) and the shadow vault re-syncs from the restored remote.
+
+### C. Remote host is dead — restore to a new host
+
+See [[en/cookbook/host-migration|Migrating between hosts]] for the full walkthrough. The short version: spin up a new host, restore the vault to it, update the plugin profile's `Host` field, reconnect (TOFU prompt for the new host key), done.
+
+### D. Local laptop died (you have the remote, no backup needed)
+
+Install the plugin on a new laptop. Re-add the same profile (Host / port / user / SSH key). On first connect:
+
+- Host-key TOFU dialog appears (the new laptop's host-key store is empty)
+- Trust the fingerprint
+- Plugin reuses the running daemon if it's still up, else redeploys
+- Shadow vault re-fetches from the remote
+
+Workspace state (open tabs, pane sizes) lives in the remote's `.obsidian/user/<client-id>/` subtree per [[en/configuration/this-device|This device]]. If you keep the same `Client ID` on the new laptop, the new Obsidian opens with the same layout. If you change it, you start fresh.
+
+## What about Obsidian's own snapshot features?
+
+Obsidian's "File recovery" core plugin keeps per-file snapshot history **inside the vault** (`.obsidian/snapshots/`). Because the vault lives on the remote in our model, those snapshots ARE on the remote and ARE captured by your remote-side backup automatically. You don't need to do anything special.
+
+Same for the "Sync" core plugin's history feature — that uses Obsidian Sync (which we're replacing); it doesn't apply.
+
+## See also
+
+- [[en/cookbook/host-migration|Migrating between hosts]] — full vault relocation
+- [[en/user-guide/conflicts|Conflict handling]] — important context on the lack of automatic conflict-side backups
+- [[en/server/raspberry-pi|Server / Raspberry Pi notes]] — relevant for "vault on SD card" durability discussion

--- a/docs/en/cookbook/host-migration.md
+++ b/docs/en/cookbook/host-migration.md
@@ -1,0 +1,151 @@
+---
+title: Migrating between hosts
+tags: [cookbook, how-to, ops, migration]
+---
+
+# Migrating between hosts
+
+Move your vault from one remote host to another (Pi → NAS, home server → VPS, old hardware → new) with no edit gap and no surprises. Takes ~15 minutes for a moderate vault.
+
+## Plan
+
+```mermaid
+sequenceDiagram
+  participant U as You
+  participant Old as Old host
+  participant New as New host
+  participant P as Plugin (laptop)
+
+  Note over U,P: 1. Set up new host + verify SSH
+  U->>New: install OS, add SSH key, mkdir vault dir
+
+  Note over U,P: 2. Stop edits + sync data
+  U->>P: disconnect from old
+  U->>Old: pkill daemon
+  U->>U: rsync old:vault → new:vault
+
+  Note over U,P: 3. Switch plugin
+  U->>P: edit profile: Host = new
+  U->>P: connect → TOFU new host key → daemon deploys
+
+  Note over U,P: 4. Verify + retire
+  U->>P: edit a note, see it on new host
+  U->>Old: rm -rf ~/notes ~/.obsidian-remote
+```
+
+## Step 1 — Set up the new host
+
+Whatever the new host is (RPi, NAS, VPS), make sure:
+
+- SSH is reachable from your laptop (`ssh user@new-host` works, no password)
+- The vault directory exists: `ssh user@new-host 'mkdir -p ~/notes'`
+- Disk has enough space — `du -sh /home/pi/notes` on the old host is your floor
+
+For a Pi setup from scratch, see [[en/cookbook/raspberry-pi-vault|Raspberry Pi vault from scratch]].
+
+## Step 2 — Stop edits + copy the vault
+
+**Disconnect from the plugin** so no in-flight writes interleave with the copy:
+
+- Command palette → "Remote SSH: Disconnect"
+- Or close the shadow vault window
+
+**Stop the daemon on the old host** (defensive — already disconnected, but the daemon may still be running waiting for reconnect):
+
+```bash
+ssh old-host 'pkill -f obsidian-remote-server'
+```
+
+**Copy the vault** with rsync. From your laptop (so the laptop is the rendezvous; or you can hop between hosts directly if they can reach each other):
+
+```bash
+# Pull from old to laptop, push to new
+ssh old-host 'tar czf - -C /home/pi notes' | \
+ssh new-host 'tar xzf - -C /home/pi'
+
+# OR — host-to-host if they can reach each other
+ssh old-host 'rsync -aHx /home/pi/notes/ new-host:/home/pi/notes/'
+```
+
+`rsync` is faster on subsequent runs (delta transfer); `tar | tar` is fine for a one-shot.
+
+**Verify** the copy is byte-equivalent:
+
+```bash
+old=$(ssh old-host 'cd /home/pi/notes && find . -type f -exec sha256sum {} +' | sort -k2 | sha256sum)
+new=$(ssh new-host 'cd /home/pi/notes && find . -type f -exec sha256sum {} +' | sort -k2 | sha256sum)
+[ "$old" = "$new" ] && echo OK || echo MISMATCH
+```
+
+## Step 3 — Switch the plugin profile
+
+In **Settings → Remote SSH → Profiles → My host**:
+
+- Update `Host` to the new hostname/IP
+- Leave everything else (Port, Username, Auth, Remote vault path) — same as old as long as paths align
+
+Save.
+
+**Connect**. The first connect to the new host will:
+
+1. Show a **TOFU dialog** with the new host's key fingerprint. Verify out-of-band (console session on the new host: `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`) before clicking **Trust & remember**. See [[en/security/host-keys|Host-key trust]].
+2. Upload + verify the daemon binary (~5 s).
+3. Open the shadow vault — same content, same in-Obsidian layout (because per-client `.obsidian/user/<client-id>/` came along in the rsync).
+
+## Step 4 — Verify the new host is canonical
+
+In Obsidian, edit a note. Then on the new host:
+
+```bash
+ssh new-host 'ls -lt /home/pi/notes | head -3'
+```
+
+Your edit should be on top with a recent mtime. The plugin is now talking to the new host.
+
+## Step 5 — Retire the old host
+
+Once you're satisfied:
+
+```bash
+# Remove the daemon's working directory
+ssh old-host 'rm -rf ~/.obsidian-remote'
+
+# Optional: remove the vault directory IF you have a backup elsewhere
+# (Probably wait a few days first, in case you spot something missing)
+ssh old-host 'rm -rf /home/pi/notes'
+
+# Remove the old host's fingerprint from your plugin's known-host store
+# (so a future profile pointing at the same hostname re-prompts TOFU)
+# Edit data.json under <vault>/.obsidian/plugins/remote-ssh/
+# and delete the "<old-host>:22" key from hostKeyStore.
+```
+
+## Variations
+
+### Migrating with edits in flight (zero-downtime)
+
+If you have collaborators editing the same vault from other devices, stopping all edits is impractical. Approximation:
+
+1. Schedule a "switchover window" (post a note in your shared channel: "vault read-only 18:00-18:15")
+2. Have everyone disconnect at 18:00
+3. Do the rsync, switch, verify
+4. Tell people to update their profile's `Host` field and reconnect
+
+There's no built-in dual-master mode; some delta will leak in either direction if people don't actually disconnect. The conflict-handling flow handles it but is unforgiving (no automatic backup of the rejected side — see [[en/user-guide/conflicts|Conflict handling]]).
+
+### Old host truly dead (no `ssh old-host` possible)
+
+Restore from your backup to the new host instead of rsyncing live. See [[en/cookbook/backup-restore#restore-scenarios|Backup → restore scenarios]] (scenario C).
+
+### Different vault path on the new host
+
+If the new host's vault path is different (e.g., old was `/home/pi/notes`, new is `/srv/vault`):
+
+1. rsync to the new path: `ssh old-host 'tar czf - -C /home/pi notes' | ssh new-host 'tar xzf - -C /srv && mv /srv/notes /srv/vault'`
+2. Update the profile's **Remote vault path** field too (in addition to Host)
+
+## See also
+
+- [[en/cookbook/raspberry-pi-vault|Raspberry Pi vault from scratch]] — for the "set up new host" step
+- [[en/cookbook/backup-restore|Backup & restore]] — complementary; backup is the prerequisite for "old host truly dead" migrations
+- [[en/security/host-keys|Host-key trust]] — what the TOFU dialog on first connect to the new host means

--- a/docs/en/cookbook/index.md
+++ b/docs/en/cookbook/index.md
@@ -15,5 +15,7 @@ Goal-oriented walkthroughs that compose pieces from the rest of these docs. If y
 | Generate an SSH key the plugin can use | [[en/cookbook/ssh-keygen\|Generating an SSH key]] |
 | Edit your vault from a Pi while a colleague edits via Tailscale | [[en/cookbook/share-via-tailscale\|Share a vault via Tailscale]] |
 | Replace the auto-deployed daemon with a systemd-managed one + cosign-verify it | [[en/cookbook/systemd-managed-daemon\|systemd-managed daemon]] |
+| Back up your vault (rsync / restic / borg) + restore from disk failure or accidental delete | [[en/cookbook/backup-restore\|Backup & restore]] |
+| Move your vault from one remote host to another (Pi → NAS, home → VPS, etc.) | [[en/cookbook/host-migration\|Migrating between hosts]] |
 
 If you want a recipe that's not here, open a [discussion](https://github.com/sotashimozono/obsidian-remote-ssh/discussions) — common asks become recipes.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.4",
+  "version": "1.0.45-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.4",
+  "version": "1.0.45-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.4",
+  "version": "1.0.45-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.4",
+      "version": "1.0.45-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.4",
+  "version": "1.0.45-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Adds 2 new cookbook recipes for common operational asks: backup/restore + host migration. Brings the cookbook from 4 → 6 recipes.

### `backup-restore.md`

- Mermaid diagram of "what to back up vs what regenerates" — the only thing that matters is the vault directory on the remote
- 3 approaches by complexity: rsync (lowest setup) / restic (recommended; versioned + dedup + encrypted) / borg+tarsnap (similar tier)
- 4 restore scenarios: single-file delete, whole-vault corruption, dead host (defers to migration page), dead laptop
- Explicit callout that the conflict-handling flow has no `.bak` recovery, linking to the conflicts page

### `host-migration.md`

- Sequence diagram of the relocation pattern
- Step-by-step: set up new host → disconnect+stop daemon → rsync → switch profile (Host field) → TOFU on new host → verify → retire old
- Byte-equivalence verification snippet (sha256sum across the tree)
- 3 variations: zero-downtime with collaborators, dead old host (defers to backup page), different vault path on new host

### Wired in

`cookbook/index.md` table extended with both new entries.

### Side effects on merge

- `release.yml` fires on `next` push → publishes **v1.0.45-beta.5** as a prerelease.

## Test plan

- [ ] CI green
- [ ] After merge: dev docs site renders both new pages with all mermaid diagrams + cross-links

🤖 Generated with [Claude Code](https://claude.com/claude-code)