### PR TITLE
docs(en): round 1 — release-flow, dev-setup, upgrading, privacy, uninstalling

### DIFF
--- a/docs/en/contributing/development-setup.md
+++ b/docs/en/contributing/development-setup.md
@@ -1,0 +1,157 @@
+---
+title: Development setup
+tags: [contributing, dev]
+---
+
+# Development setup
+
+How to get a working dev environment for the plugin and the daemon. Targets a contributor making their first PR; covers macOS, Linux, and Windows + WSL.
+
+## Toolchain
+
+| Tool | Min version | Why |
+|---|---|---|
+| Node.js | **20.x** (per `plugin/package.json` `engines.node`) | Plugin build (esbuild), unit tests (vitest 4 needs 20.19+), npm scripts |
+| Go | **1.25.x** (per `server/go.mod` + CI) | Daemon binary build |
+| Docker + docker compose | any recent | Integration tests use a sandbox sshd container |
+| `make` | any | `server/Makefile` orchestrates the Go cross-builds |
+| `gh` (GitHub CLI) | recent | PR management; not strictly required but heavily used in our flow |
+
+For Windows: install via WSL2 (Ubuntu 22.04 or newer) — the integration test sshd container assumes a Linux-ish environment.
+
+## First-time clone
+
+```bash
+git clone https://github.com/sotashimozono/obsidian-remote-ssh.git
+cd obsidian-remote-ssh
+
+# Plugin deps
+cd plugin
+npm ci
+
+# Verify Go works + binary builds
+cd ../server
+make build
+./bin/obsidian-remote-server --help
+```
+
+If `make build` succeeds and the help output renders, your toolchain is good.
+
+## Repo layout
+
+```
+obsidian-remote-ssh/
+├── plugin/                      # Obsidian plugin (TypeScript)
+│   ├── src/
+│   │   ├── transport/           # SSH + RPC client
+│   │   ├── adapter/             # Obsidian adapter shim
+│   │   ├── settings/            # UI for profiles
+│   │   ├── ssh/                 # Host-key store, auth resolver
+│   │   └── ui/                  # Status bar, modals, terminal pane
+│   ├── tests/                   # vitest unit + integration suites
+│   ├── e2e/                     # Playwright tests against real Obsidian
+│   ├── scripts/                 # build-server.mjs, bump-version.mjs, etc.
+│   └── package.json
+├── server/                      # Daemon (Go)
+│   ├── cmd/obsidian-remote-server/  # main package
+│   ├── internal/
+│   │   ├── proto/               # wire types (LSP-style framed JSON-RPC)
+│   │   ├── rpc/                 # framing + dispatcher
+│   │   ├── handlers/            # fs.* + auth + server.info
+│   │   ├── auth/                # token gen + validation
+│   │   └── watcher/             # inotify wrapper
+│   └── Makefile
+├── proto/                       # cross-language wire spec (README.md)
+├── docs/                        # Quartz markdown content (this doc set)
+├── docs-site/                   # Quartz framework
+├── deploy/docker/               # turn-key sshd container
+└── .github/workflows/           # CI / release / sync / docs deploys
+```
+
+The plugin and server are deliberately separate trees with their own toolchains. They communicate only over the JSON-RPC wire spec in `proto/README.md`.
+
+## Common workflows
+
+### Plugin: build + dev iterate
+
+```bash
+cd plugin
+npm run dev                     # esbuild in watch mode → main.js
+```
+
+Open Obsidian, point a vault at `<your-vault>/.obsidian/plugins/obsidian-remote-ssh-dev` (or symlink the build output there). Reload the plugin in Obsidian after each rebuild — there's no auto-reload.
+
+For the bundled daemon binary the plugin uploads on connect: run `npm run build:server` once. It builds the daemon for your local OS+arch and copies it into `plugin/server-bin/`.
+
+### Plugin: tests
+
+```bash
+npm test                        # unit tests, vitest, ~950 tests
+npm run test:integration        # SSH integration tests, requires Docker
+npm run test:e2e                # Playwright against real Obsidian (slowest)
+```
+
+Integration tests assume the test sshd container is up:
+
+```bash
+npm run sshd:start              # docker compose up the test sshd
+npm run test:integration
+npm run sshd:stop               # tear down
+```
+
+CI handles this orchestration automatically; locally it's manual.
+
+### Plugin: type check + lint
+
+```bash
+node node_modules/typescript/bin/tsc --noEmit  # type check
+npm run lint                                    # eslint
+```
+
+Both run on every PR; flag them locally before pushing.
+
+### Server: build + test
+
+```bash
+cd server
+make build                      # native binary → bin/obsidian-remote-server
+make cross                      # 4 binaries → dist/obsidian-remote-server-<os>-<arch>
+make test                       # go test ./...
+```
+
+### Run plugin against your dev daemon
+
+By default the plugin uploads its bundled daemon (the one in `plugin/server-bin/`). To iterate on the daemon, build a fresh `server/bin/obsidian-remote-server` and `cp` it over `plugin/server-bin/obsidian-remote-server-<os>-<arch>`. Reconnect from the plugin — the auto-deploy uploads your fresh binary.
+
+For tighter iteration, run the daemon directly under your test sshd container's user:
+
+```bash
+docker compose -f deploy/docker/docker-compose.yml exec -u obsidian sshd \
+  /workspace/server/bin/obsidian-remote-server \
+  --vault-root=/home/obsidian/vault \
+  --socket=/home/obsidian/.obsidian-remote/server.sock \
+  --token-file=/home/obsidian/.obsidian-remote/token \
+  --verbose
+```
+
+The plugin's reuse probe will then attach to your manually-started daemon on connect (skipping the bundled-binary upload).
+
+## Branching + commit conventions
+
+- Feature branches: `feat/<short-name>` → PR into `next`. See `CONTRIBUTING.md` Branching model.
+- Stable promotions: `release/X.Y.Z` → PR into `main`. See [[en/contributing/release-flow|Release flow]].
+- Commit messages: Conventional Commits (`type(scope): subject`). The full list of allowed types is in `commitlint.config.mjs`. CI rejects PRs whose commits don't conform (sync + promotion PRs are exempted at the workflow level).
+
+## Editor setup hints
+
+- **VSCode**: install ESLint + TypeScript extensions; the `tsconfig.json` in `plugin/` should be auto-detected.
+- **GoLand / VSCode Go**: open `server/` as its own root (it has its own `go.mod`).
+- **Windows + WSL**: clone inside WSL filesystem (not `/mnt/c/...`), otherwise file-watching for `npm run dev` is unreliable.
+
+## See also
+
+- [[en/contributing/release-flow|Release flow]] — how a change gets from your PR to a published release
+- [[en/contributing/testing-strategy|Testing strategy]] — what each test layer is for
+- [[en/contributing/documentation|Documentation guide]] — how to add/edit pages on this docs site
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — system view of the CI/CD machinery
+- [`CONTRIBUTING.md`](https://github.com/sotashimozono/obsidian-remote-ssh/blob/next/CONTRIBUTING.md) — canonical short-form contributor reference

--- a/docs/en/contributing/release-flow.md
+++ b/docs/en/contributing/release-flow.md
@@ -1,0 +1,110 @@
+---
+title: Release flow
+tags: [contributing, release]
+---
+
+# Release flow
+
+Step-by-step for cutting releases — both beta (every merge to `next`) and stable (manual promotion). Complements the system-level [[en/architecture/release-pipeline|Release & deploy pipeline]] architecture page.
+
+## Beta releases — automatic
+
+Every merge to `next` becomes a beta release. As a contributor you do not run anything by hand:
+
+1. Open a PR from your `feat/...` (or `fix/...` etc.) branch into `next`.
+2. Bump the beta version on your branch:
+   ```bash
+   cd plugin
+   npm run bump:beta            # X.Y.Z-beta.N → X.Y.Z-beta.(N+1)
+   ```
+   Use `npm run bump:beta:start` only when starting a fresh cycle right after a stable promotion (when `next` carries a plain `X.Y.Z` and needs a `-beta.0`).
+3. Commit, push, get review, merge.
+4. `release.yml` fires on the `next` push and publishes `vX.Y.Z-beta.N` as a GitHub prerelease with cosign-signed daemon binaries. BRAT consumers pick it up on next launch.
+
+## Stable releases — promotion via release branch
+
+When `next` has accumulated enough verified work to ship as the next stable, the **promotion flow** is:
+
+```bash
+git checkout -b release/X.Y.Z next
+cd plugin
+npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops -beta suffix)
+git commit -am "release: prepare X.Y.Z promotion"
+git push origin release/X.Y.Z
+gh pr create --base main --head release/X.Y.Z \
+  --title "release: promote next → main (X.Y.Z)"
+```
+
+The release branch is critical — it gives the bump commit a place to be CI-validated (commitlint, version-check, lint, type-check, tests, integration) **before** it reaches `main`. No admin override on `next` or `main` is needed.
+
+After the PR is reviewed and merged into `main`:
+
+1. `release.yml` fires on the main push → publishes **vX.Y.Z** stable + cosign-signed binaries + GitHub Release marked latest.
+2. `sync-main-to-next.yml` fires on the same main push → opens an auto-merging PR `main → next` so the merge commit rejoins.
+3. The next beta cycle starts on a normal `feat/...` branch with `npm run bump:beta:start` (`X.Y.Z → X.Y.(Z+1)-beta.0`).
+
+## What `bump:stable` does
+
+```mermaid
+graph LR
+  Pkg["package.json: 1.0.44-beta.5"] -->|bump:stable| Strip["strip -beta.N"]
+  Strip --> NewPkg["package.json: 1.0.44"]
+  NewPkg --> Hook["npm version lifecycle hook"]
+  Hook --> Sync["bump-version.mjs"]
+  Sync --> M1["plugin/manifest.json"]
+  Sync --> M2["manifest.json (root)"]
+  Sync --> M3["manifest-beta.json (root)"]
+  Sync --> V1["plugin/versions.json"]
+  Sync --> V2["versions.json (root)"]
+```
+
+The script (`plugin/scripts/bump-stable.mjs`) reads the current `-beta.N` suffix, strips it, runs `npm version <stripped>`. The `version` lifecycle hook calls `bump-version.mjs` which detects the plain version and updates **all** five manifest files (vs. a beta bump which only touches the bundled manifest + the BRAT mirror — see [[en/architecture/release-pipeline|Release pipeline]] for why).
+
+## Hot-fixing main without going through next
+
+If `main` has a critical bug that can't wait for the next promotion:
+
+1. Branch off `main` directly: `git checkout -b hotfix/X.Y.Z main`
+2. Make the fix + bump: `npm version patch --no-git-tag-version` to go `1.0.44 → 1.0.45`. (`bump:stable` won't help here — there's no `-beta` suffix to strip.)
+3. PR into `main`. version-check requires the head version to be plain `X.Y.Z` strictly greater than base — same rule as a normal promotion.
+4. After merge, the `sync-main-to-next.yml` workflow back-syncs to `next` automatically.
+
+## Pre-release sanity checks
+
+Before opening the promotion PR, on the release branch:
+
+```bash
+# Plugin builds clean
+cd plugin
+npm run build               # esbuild production bundle
+
+# Tests pass locally
+npm test                    # vitest unit tests
+
+# Server cross-builds
+make -C ../server cross     # 4 binaries land in server/dist/
+
+# Optional: verify the daemon binary you'll ship matches the
+# previous release's signature chain
+cosign verify-blob \
+  --bundle ../server/dist/obsidian-remote-server-linux-amd64.bundle \
+  --certificate-identity-regexp \
+    'https://github.com/sotashimozono/obsidian-remote-ssh/.github/workflows/release.yml@.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ../server/dist/obsidian-remote-server-linux-amd64
+```
+
+CI runs the same checks on the release branch's PR, so this is paranoia, not gating — useful when you'd rather find a problem before the PR is open.
+
+## What the release pipeline does NOT cover
+
+- **Documentation site deploy** — handled by `docs.yml` (separate workflow, triggers on changes to `docs/**` and `docs-site/**`).
+- **Container image builds** — `deploy/docker/` is built smoke-test in CI but not pushed anywhere.
+- **Notifications** — no Slack/Discord/email hooks; subscribe to GitHub Releases (Watch → Custom → Releases).
+
+## See also
+
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — the design behind release.yml + sync workflow + version-check
+- [[en/contributing/development-setup|Development setup]] — getting the dev environment working
+- [[en/changelog|Changelog & releases]] — major-milestone overview
+- [`CONTRIBUTING.md` → Branching model](https://github.com/sotashimozono/obsidian-remote-ssh/blob/next/CONTRIBUTING.md#branching-model--next-beta--main-stable) — canonical contributor reference

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -32,11 +32,12 @@ tags: [home]
 - **[[en/server/overview|Server / deploy]]** — Docker, systemd, Raspberry Pi, auto-deploy
 - **[[en/api/overview|API & protocol]]** — RPC methods, error codes, payload shapes, copy-pasteable [[en/api/examples|examples]]
 - **[[en/security/model|Security]]** — threat model, signing, token handling, host-key trust
-- **[[en/operations/troubleshooting|Operations]]** — logs, daemon panel, reconnect, common failures
+- **[[en/operations/troubleshooting|Operations]]** — logs, daemon panel, reconnect, upgrading, uninstalling, common failures
 - **[[en/architecture/index|Architecture]]** — shadow vault design, sync internals, performance
 - **[[en/glossary|Glossary]]** — terms used across the docs, defined once
 - **[[en/roadmap|Roadmap]]** — what's left before v1.0 + v2 mobile plan
 - **[[en/changelog|Changelog & releases]]** — major-milestone overview + how to find per-release notes
+- **[[en/privacy|Privacy & data handling]]** — what data this plugin handles, where it lives, what does (or does not) leave your machines
 - **[[en/faq|FAQ]]** — quick answers to recurring questions
 
 ## Release channels

--- a/docs/en/operations/uninstalling.md
+++ b/docs/en/operations/uninstalling.md
@@ -1,0 +1,105 @@
+---
+title: Uninstalling
+tags: [operations, uninstall]
+---
+
+# Uninstalling
+
+The plugin doesn't touch system files, so a clean uninstall is straightforward. Pick the depth you want — disable-only, full local removal, or full local + remote scrub.
+
+## Level 1 — disable the plugin (reversible)
+
+Settings → Community plugins → toggle "Remote SSH" off.
+
+The plugin stops loading. Your shadow vault windows close. The daemon on the remote keeps running for a while (until the daemon-side process is killed or the host reboots) but doesn't accept new connections from this plugin. Re-enable to bring it back; profiles, host-key trust, and BRAT subscription stay intact.
+
+## Level 2 — uninstall the plugin (local cleanup)
+
+Settings → Community plugins → "Remote SSH" → **Uninstall**.
+
+This deletes `<vault>/.obsidian/plugins/remote-ssh/` — the bundle, settings, host-key store, logs, telemetry, and bundled daemon binary. Profiles are gone. Host-key trust is gone (a future re-install will re-prompt TOFU on every host).
+
+Also delete the local shadow vaults (Obsidian doesn't know about them):
+
+```bash
+# Linux / macOS / WSL
+rm -rf ~/.obsidian-remote/vaults/
+
+# Windows (PowerShell)
+Remove-Item -Recurse -Force "$env:USERPROFILE\.obsidian-remote\vaults\"
+```
+
+Do this for **every** host's vault root if you have multiple profiles — the directory is keyed by `<profile-id>`, one subdirectory per profile.
+
+If you uninstalled BRAT to remove the beta channel as well, that's a separate Settings → Community plugins → BRAT → Uninstall.
+
+## Level 3 — scrub the remote host(s)
+
+For each host you ever connected to:
+
+```bash
+ssh user@host
+pkill -f obsidian-remote-server      # stop the daemon
+rm -rf ~/.obsidian-remote/           # delete daemon binary + token + socket + log
+```
+
+If you ran the daemon under [[en/cookbook/systemd-managed-daemon|systemd]]:
+
+```bash
+systemctl --user disable --now obsidian-remote-server
+rm ~/.config/systemd/user/obsidian-remote-server.service
+sudo rm -f /usr/local/bin/obsidian-remote-server
+systemctl --user daemon-reload
+```
+
+Optionally remove the linger setting if you enabled it:
+
+```bash
+sudo loginctl disable-linger $USER
+```
+
+## Level 4 — vault data (rarely wanted)
+
+The plugin **never modifies the structure of your vault** — your notes are at whatever path you set as **Remote vault path**. Removing the plugin does NOT delete your notes. To wipe the vault too:
+
+```bash
+ssh user@host 'rm -rf ~/notes'   # or whatever path you used
+```
+
+Make sure you have a backup first; this is irreversible.
+
+## What the plugin doesn't touch
+
+- `~/.ssh/` (your SSH keys + config) — never modified
+- `~/.ssh/known_hosts` — never read or written by the plugin (it has its own store)
+- System packages, init scripts, anything in `/etc/`, anything in `/usr/` — except `/usr/local/bin/obsidian-remote-server` if you put it there yourself per [[en/cookbook/systemd-managed-daemon|systemd recipe]]
+
+So a Level 3 scrub leaves your remote host in the same state it was before you installed.
+
+## Verifying nothing's left
+
+```bash
+# Local
+ls "<vault>/.obsidian/plugins/" | grep -i remote-ssh    # should print nothing
+ls ~/.obsidian-remote/vaults/ 2>/dev/null               # should print nothing
+
+# Each remote
+ssh user@host 'ls -la ~/.obsidian-remote/ 2>/dev/null'  # should print nothing or "no such file"
+ssh user@host 'pgrep -f obsidian-remote-server'         # should print nothing (no PID)
+```
+
+## Re-installing later
+
+If you re-install the plugin against the same host(s):
+
+- Profile list will be empty (rebuild from scratch)
+- Host-key store will be empty (TOFU prompt fires on first connect to each host)
+- Daemon redeploys fresh on first connect (the previous binary + token are gone)
+
+Vault data picks up where you left off because that lived on the remote untouched.
+
+## See also
+
+- [[en/privacy|Privacy & data handling]] — full inventory of where the plugin writes
+- [[en/faq|FAQ]] — quick answers including the short uninstall summary
+- [[en/cookbook/systemd-managed-daemon|systemd-managed daemon]] — relevant for Level 3 systemd cleanup

--- a/docs/en/operations/upgrading.md
+++ b/docs/en/operations/upgrading.md
@@ -1,0 +1,110 @@
+---
+title: Upgrading
+tags: [operations, upgrade]
+---
+
+# Upgrading the plugin + daemon
+
+The plugin and daemon are versioned together. Upgrading the plugin upgrades the bundled daemon binary; the next connect deploys it. **You usually do nothing on the remote.** This page covers the cases where that simple story breaks.
+
+## The default path
+
+```mermaid
+sequenceDiagram
+  participant U as You
+  participant Ob as Obsidian
+  participant P as Plugin (new version)
+  participant R as Remote
+  participant Old as Old daemon (X.Y.Z-1)
+  participant New as New daemon (X.Y.Z)
+
+  U->>Ob: BRAT auto-update / store update
+  Ob->>P: load new bundle
+  U->>P: connect
+  P->>R: tryReuseExistingDaemon
+  R->>Old: handshake
+  Old-->>P: server.info → version mismatch
+  P->>R: pkill -f obsidian-remote-server
+  P->>R: SFTP upload new binary
+  P->>R: SHA256 verify
+  P->>R: spawn New
+  R->>New: writes fresh token
+  P->>New: auth + handshake → OK
+  P->>U: shadow vault re-opens (~5-8 s extra vs. cached connect)
+```
+
+The reuse probe in `tryReuseExistingDaemon` does an `auth` + `server.info` round-trip. If the daemon's `server.info.version` differs from what the plugin expects (the bundled binary's version), the reuse fails and the deploy fallback kicks in. Net effect: a one-time ~5–8 second redeploy on the first connect after upgrade. Subsequent connects reuse the new daemon as normal.
+
+## Plugin upgrade paths
+
+### Stable channel (Community Plugins store)
+
+Settings → Community plugins → "Remote SSH" → **Update**. Obsidian downloads the new bundle and reloads the plugin. Reconnect any open shadow vaults to pick up the new daemon.
+
+### Beta channel (BRAT)
+
+BRAT auto-updates on Obsidian launch. Pin a specific version by toggling BRAT's "Auto-update at startup" off if you want to control upgrade timing.
+
+### Manual install
+
+Download the new release's `main.js`, `manifest.json`, `styles.css` from the [Releases](https://github.com/sotashimozono/obsidian-remote-ssh/releases/latest) page and replace the files under `<vault>/.obsidian/plugins/remote-ssh/`. Disable + re-enable the plugin in Obsidian to load the new bundle.
+
+## When you DO need to touch the remote
+
+### You're running a systemd-managed daemon
+
+If you put the daemon under [[en/cookbook/systemd-managed-daemon|systemd]] and the running version is **older** than what the new plugin bundle expects, the reuse probe will fail and the plugin will redeploy over your systemd-managed binary. Three options:
+
+1. **Let it redeploy** — accept that the systemd-managed binary gets overwritten by the bundled one. The systemd unit will re-execve into the new binary on its next restart.
+2. **Pre-upgrade the binary** — download the matching new release binary, `cosign verify`, `sudo install` over the existing one, `systemctl --user restart obsidian-remote-server`. Then the reuse probe finds a healthy version-matched daemon and skips the upload.
+3. **Pin your systemd binary version forever** — keep the plugin pinned to the matching version too. Useful only if you have a strong reason; usually means foregoing security patches.
+
+### Daemon binary went stale (host was offline during multiple plugin upgrades)
+
+Same flow as above — first connect after the host wakes up will see a version mismatch and redeploy. No manual action needed.
+
+### Major-version daemon upgrade (protocol bump)
+
+If a release bumps the protocol version (currently `protocolVersion: 1`; would become `2` for a breaking wire change), the reuse probe's handshake fails with `ProtocolVersionTooOld (-32021)`. The plugin then redeploys to bring the daemon to the matching protocol. This is the same code path as a normal version mismatch — handled automatically.
+
+## Verifying the upgrade landed
+
+In the plugin: **Settings → Daemon panel** → check the version badge.
+
+The plugin-side version is at **Settings → Community plugins → Remote SSH** (Obsidian shows the manifest version).
+
+For paranoia, check the binary on the remote:
+
+```bash
+ssh user@host '~/.obsidian-remote/server --version 2>&1 || strings ~/.obsidian-remote/server | grep -E "^[0-9]+\.[0-9]+\.[0-9]+" | head -1'
+```
+
+## Downgrading
+
+The same machinery handles downgrades — the reuse probe sees a version mismatch in either direction and redeploys. To downgrade:
+
+1. Obsidian: install the older plugin version (BRAT lets you pick a specific tag; manual install lets you `cp` an older release).
+2. Connect — the plugin uploads its now-older bundled daemon, replacing the newer one.
+
+The vault format is stable across the 1.x line, so downgrading is safe data-wise.
+
+## What survives an upgrade
+
+- **Vault contents** — untouched (lives on the remote)
+- **Profiles** — persisted in `data.json`, survives plugin upgrade
+- **Host-key trust** — persisted in `data.json` `hostKeyStore` key, survives
+- **Plugin settings (font size, debug logging, etc.)** — persisted
+- **Open shadow vault windows** — close on plugin reload; reopen via the command palette
+- **Daemon log on remote** — survives unless you `rm -rf ~/.obsidian-remote/`
+
+## What doesn't survive
+
+- **Daemon token** — regenerated every daemon restart (the plugin re-reads it transparently)
+- **Reconnect counters / queued ops** — reset on plugin reload
+
+## See also
+
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — version coherence + reuse-probe machinery
+- [[en/cookbook/systemd-managed-daemon|systemd-managed daemon]] — relevant when you're not letting auto-deploy own the daemon binary
+- [[en/operations/troubleshooting|Troubleshooting]] — what to check if connection fails after upgrade
+- [[en/changelog|Changelog & releases]] — what's new in the version you're upgrading to

--- a/docs/en/privacy.md
+++ b/docs/en/privacy.md
@@ -1,0 +1,98 @@
+---
+title: Privacy & data handling
+tags: [privacy, security]
+---
+
+# Privacy & data handling
+
+Plain answers about what data this plugin handles, where it lives, and what does (or does not) leave your machines. The plugin does not phone home; this page is the receipts.
+
+## What never leaves your environment
+
+- **Vault contents** — your notes live on YOUR remote host and are read/written via YOUR SSH session. No third party touches them.
+- **SSH credentials** — keys stay in `~/.ssh/`. The plugin reads them at connect time; nothing copied into plugin storage.
+- **Authentication tokens** — the daemon's per-session token (`~/.obsidian-remote/token` on the remote) is generated locally on the daemon, read by the plugin via SFTP, and never sent anywhere else.
+- **Host fingerprints** — your `data.json` `hostKeyStore` is local-only.
+- **Telemetry data** — see below; opt-in, file-only, never networked.
+
+## Network traffic
+
+| Protocol | Endpoint | When |
+|---|---|---|
+| **SSH** | Your remote host (you configured the address) | Every connect; carries SFTP + the RPC tunnel |
+| **HTTPS** to GitHub | `github.com` / `objects.githubusercontent.com` | Manual install: when you download release binaries. BRAT: at startup if BRAT auto-update fires (BRAT is a separate plugin, behaves per its own settings) |
+| **HTTPS** to Sigstore (Fulcio + Rekor) | `*.sigstore.dev` | Only if you run `cosign verify-blob` yourself; the plugin itself doesn't call out to Sigstore |
+
+The plugin's process makes **zero unsolicited outbound connections**. There's no analytics endpoint, no telemetry beacon, no update-check ping (the manifest update check is Obsidian's own, not ours).
+
+## Telemetry — opt-in, local-only
+
+Telemetry is **off by default**. Enable in **Settings → Telemetry**.
+
+When on, the plugin records two event kinds to a local file (`<vault>/.obsidian/plugins/remote-ssh/telemetry.jsonl`):
+
+| Event kind | Fields |
+|---|---|
+| `error` | `category` (auth / rpc / conflict / …), optional `code` |
+| `reconnect` | `state` (`idle` / `waiting` / `attempting` / `recovered` / `failed` / `cancelled`) |
+
+**No vault content, no SSH credentials, no host names, no IPs are recorded** — just bucket-counted error categories useful for your own diagnosis. There is no "send" button or background uploader. The data is yours; nuke the file when you don't need it.
+
+## Logs
+
+| Log | Location | What's in it |
+|---|---|---|
+| Plugin (client) | `<vault>/.obsidian/plugins/remote-ssh/console.log` | Operational lines mirroring Obsidian's developer console. Contains profile names, paths, error messages. Rotated by size: 5 MB × 4 files (`.log` + `.1` + `.2` + `.3`). |
+| Daemon (server) | `~/.obsidian-remote/server.log` on the remote | Daemon stdout/stderr. Contains paths + RPC method names. Truncated on each daemon restart. |
+| systemd journal | (if you run via systemd) `journalctl --user -u obsidian-remote-server` | Same content as the daemon log; managed by systemd's retention policy |
+
+**Debug logging** (off by default; toggle in **Settings → Advanced**) makes the plugin log significantly more verbose. Useful for [[en/operations/troubleshooting|troubleshooting]]; remember to turn it off afterwards.
+
+Logs do not include vault file contents. They do include vault-relative file paths in error contexts — e.g. "fs.write failed: notes/draft.md / EACCES". If your file paths themselves are sensitive, treat the logs as sensitive.
+
+## At-rest disk locations
+
+A complete inventory of what this plugin writes to disk:
+
+### On your local machine (laptop)
+
+```
+<vault>/.obsidian/plugins/remote-ssh/
+    main.js, manifest.json, styles.css     # plugin bundle
+    server-bin/obsidian-remote-server-*    # bundled daemon binary (signed)
+    data.json                              # profiles + hostKeyStore + settings
+    console.log[.1-.3]                     # operational log
+    telemetry.jsonl                        # opt-in counters
+
+~/.obsidian-remote/vaults/<profile-id>/    # local shadow vault per profile
+                                           # (mirrors remote files for Obsidian)
+```
+
+### On the remote host
+
+```
+~/.obsidian-remote/
+    server          # daemon binary (uploaded from plugin)
+    server.sock     # Unix socket (mode 0600)
+    token           # 32-byte token (mode 0600)
+    server.log      # daemon stdout/stderr
+
+<configured-vault-root>/                   # YOUR notes, untouched in shape
+```
+
+The plugin **never writes outside `~/.obsidian-remote/` and the configured vault root** on the remote. The shadow vault on your local machine is regenerated automatically and contains a cached copy of remote files you've opened.
+
+## What about Obsidian Sync / iCloud / Dropbox?
+
+This plugin is not Obsidian Sync — there's no third-party cloud involved at all. If you have Obsidian Sync ALSO enabled on the same vault, the two will fight (one wins last-write); pick one. iCloud / Dropbox / OneDrive folders for your `.obsidian/` directory work fine in parallel since this plugin only touches its own subdirectory under `plugins/remote-ssh/`.
+
+## Removing all traces
+
+See [[en/operations/uninstalling|Uninstalling]] for the complete scrub.
+
+## See also
+
+- [[en/security/model|Security threat model]] — what the plugin defends against (and what it doesn't)
+- [[en/security/token|Token & socket]] — daemon authentication details
+- [[en/security/host-keys|Host-key trust]] — fingerprint store internals
+- [[en/operations/logs|Logs & telemetry]] — operational view of the same files described here

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.5",
+  "version": "1.0.45-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.5",
+  "version": "1.0.45-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.5",
+  "version": "1.0.45-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.5",
+      "version": "1.0.45-beta.6",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.5",
+  "version": "1.0.45-beta.6",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

**Round 1 of the EN-completion plan** — 5 new pages closing the highest-value, lowest-fabrication-risk gaps in the EN docs. Brings doc set from 53 → 58 pages.

### What's new

| Page | Synthesises from | Audience |
|---|---|---|
| `contributing/release-flow.md` | CONTRIBUTING.md + en/architecture/release-pipeline.md | Contributors cutting a release |
| `contributing/development-setup.md` | package.json scripts + Makefile + repo layout | First-time contributor |
| `operations/upgrading.md` | reuse-probe behavior + version coherence (release-pipeline architecture) | Existing user upgrading |
| `privacy.md` (top-level) | Aggregates security/{model,token,host-keys} + operations/logs + telemetry settings | Anyone evaluating whether to install |
| `operations/uninstalling.md` | Existing FAQ entry expanded with 4-level depth + verification commands | User removing the plugin |

All 5 are **synthesis content** — pulled from already-shipped pages and the canonical `CONTRIBUTING.md`. No new technical claims invented; cross-links validate the parts already documented.

Wired into `docs/en/index.md` (privacy gets its own section card; upgrading + uninstalling described in the operations card).

### Side effects on merge

- `release.yml` fires on `next` push → publishes **v1.0.45-beta.6** as a prerelease.

## Test plan

- [ ] CI green
- [ ] After merge: dev docs site renders all 5 new pages
- [ ] All wikilinks resolve (especially the cross-references between the new pages)
- [ ] Mermaid diagrams in `release-flow.md` (graph LR) and `upgrading.md` (sequence) render

## What's next

Round 2 (cookbook expansion: hardware-key, reverse-proxy, multi-vault) will land in a separate PR. Round 3 (api/protocol-evolution, server/firewall, server/multi-user) and Round 4 (Obsidian Sync migration) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)