### PR TITLE
docs(cookbook): round 2 — hardware-key auth + reverse proxy + multi-vault

### DIFF
--- a/docs/en/cookbook/hardware-key.md
+++ b/docs/en/cookbook/hardware-key.md
@@ -1,0 +1,140 @@
+---
+title: Hardware-key SSH auth (YubiKey, TouchID, Secure Enclave)
+tags: [cookbook, how-to, ssh, security, hardware]
+---
+
+# Hardware-key SSH auth
+
+Sign SSH connections with a key that lives in tamper-resistant hardware — your YubiKey, your laptop's Secure Enclave, or any FIDO2 authenticator. The plugin uses your normal `ssh-agent`, so anything `ssh` can authenticate with works here too.
+
+## Why hardware-back the key
+
+The private key never leaves the secure element. A laptop compromise gives an attacker your `ssh-agent` socket while you're logged in (limited blast radius), but not the key material itself. For high-value vaults (work notes, journals, anything you don't want a stolen laptop to give up), this is the cheapest meaningful upgrade over a passphrase-protected key on disk.
+
+## Three flavours
+
+| Flavour | Hardware | Best for |
+|---|---|---|
+| **YubiKey / Nitrokey** (`sk-ssh-ed25519`) | USB FIDO2 token | Cross-machine portability — same key on any laptop with the YubiKey plugged in |
+| **macOS Secure Enclave** (`ssh-agent` + `--apple-use-keychain`) | Apple Silicon / T2 chip | macOS-only; touchless re-use after one TouchID prompt |
+| **Windows Hello SSH agent** (Win11 24H2+) | TPM | Windows-only; same idea, Windows Hello prompt |
+
+## Recipe 1 — YubiKey (`sk-ssh-ed25519`)
+
+Generate a resident key on the YubiKey:
+
+```bash
+# OpenSSH 8.2+ required
+ssh-keygen -t ed25519-sk -O resident -O verify-required \
+  -C "obsidian-vault@yubikey" \
+  -f ~/.ssh/id_ed25519_sk
+```
+
+- `-O resident` stores the key handle on the YubiKey itself (so you can re-import on another machine with `ssh-keygen -K`).
+- `-O verify-required` forces a touch on every signature — the YubiKey blinks when SSH wants to authenticate.
+
+Copy the public key to the remote:
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519_sk.pub user@host
+```
+
+In the plugin profile:
+
+| Field | Value |
+|---|---|
+| Authentication | **SSH agent** |
+| (no key path needed — the agent has it) |  |
+
+On connect, the YubiKey blinks; touch it. Done.
+
+### Importing on a second machine
+
+```bash
+# Plug in the YubiKey, then:
+ssh-keygen -K            # extracts the resident key into ~/.ssh/id_ed25519_sk + .pub
+ssh-add ~/.ssh/id_ed25519_sk
+```
+
+The key handle on the YubiKey is enough to reconstruct the local files. The actual private key never leaves the device.
+
+## Recipe 2 — macOS Secure Enclave
+
+macOS ships an `ssh-agent` that integrates with the keychain + Secure Enclave. The first time you `ssh-add` a key, you can store the passphrase in the keychain (TouchID-gated):
+
+```bash
+# Generate a key (or use an existing ed25519)
+ssh-keygen -t ed25519 -C "obsidian-vault@mac"
+
+# Add to agent + keychain
+ssh-add --apple-use-keychain ~/.ssh/id_ed25519
+```
+
+Persist across reboots — `~/.ssh/config`:
+
+```
+Host *
+  AddKeysToAgent yes
+  UseKeychain yes
+  IdentityFile ~/.ssh/id_ed25519
+```
+
+Now SSH (and the plugin) auth with one TouchID prompt per session. The key material stays in the Secure Enclave; the agent socket is the user-space surface.
+
+### True Secure-Enclave-resident keys (advanced)
+
+If you want the key generated INSIDE the Secure Enclave (so it can never be exported even by a root user), use [Secretive](https://github.com/maxgoedjen/secretive) — open-source app that exposes Secure-Enclave keys via an SSH agent socket. Set `SSH_AUTH_SOCK` to Secretive's socket; everything downstream (including the plugin) just sees `ssh-agent`.
+
+## Recipe 3 — Windows Hello (Win11 24H2+)
+
+Recent Windows builds bundle an `ssh-agent` that integrates with Windows Hello. Enable it:
+
+```powershell
+# Run as Administrator
+Set-Service -Name ssh-agent -StartupType Automatic
+Start-Service ssh-agent
+```
+
+Generate a key tied to Windows Hello:
+
+```powershell
+# OpenSSH 9.5+ on Windows; use a TPM-backed key
+ssh-keygen -t ecdsa -b 256 -f $HOME\.ssh\id_ecdsa_hello
+ssh-add $HOME\.ssh\id_ecdsa_hello
+```
+
+The PIN/biometric prompt fires on every signature.
+
+In the plugin profile:
+
+| Field | Value |
+|---|---|
+| Authentication | **SSH agent** |
+
+## Caveats
+
+- **YubiKey USB-A vs USB-C** — the FIDO2 protocol is the same; only the connector differs. The plugin doesn't care.
+- **Multi-machine workflow** — `sk-ssh-ed25519` resident keys re-import via `ssh-keygen -K` on each machine; remember to re-add to that machine's agent (`ssh-add ~/.ssh/id_ed25519_sk`).
+- **Touch fatigue** — `verify-required` means a touch per RPC round-trip if the agent doesn't cache. The plugin makes many fast RPCs after the initial auth. Most setups cache the signature for the SSH session's lifetime, so you touch once per connect; verify your specific agent's behaviour.
+- **CI / unattended use** — hardware-key auth is interactive by design; not suitable for cron jobs that need to ssh in without a human present.
+
+## Verifying it's actually using hardware
+
+```bash
+# What's loaded in the agent right now
+ssh-add -l
+# Should show your hardware-backed key with `(SK)` for sk-* types
+# or the keychain origin for macOS
+
+# Force the agent to use ONLY hardware
+SSH_AUTH_SOCK=$YUBIKEY_AGENT_SOCK ssh -v user@host 2>&1 | head -30
+```
+
+The plugin reads `SSH_AUTH_SOCK` from Obsidian's environment. On macOS/Linux, the agent that started Obsidian is the one used. On Windows + WSL, this is more nuanced — set `SSH_AUTH_SOCK` in the WSL shell that launches Obsidian.
+
+## See also
+
+- [[en/cookbook/ssh-keygen|Generating an SSH key]] — the non-hardware-backed flow + general SSH key concepts
+- [[en/user-guide/ssh-config|SSH config & keys]] — how the plugin resolves credentials
+- [[en/security/model|Security threat model]] — what hardware-key auth defends against (and what it doesn't)
+- [[en/cookbook/share-via-tailscale|Share a vault via Tailscale]] — combine with Tailscale for "hardware-key auth + tailnet-only reach"

--- a/docs/en/cookbook/index.md
+++ b/docs/en/cookbook/index.md
@@ -17,5 +17,8 @@ Goal-oriented walkthroughs that compose pieces from the rest of these docs. If y
 | Replace the auto-deployed daemon with a systemd-managed one + cosign-verify it | [[en/cookbook/systemd-managed-daemon\|systemd-managed daemon]] |
 | Back up your vault (rsync / restic / borg) + restore from disk failure or accidental delete | [[en/cookbook/backup-restore\|Backup & restore]] |
 | Move your vault from one remote host to another (Pi → NAS, home → VPS, etc.) | [[en/cookbook/host-migration\|Migrating between hosts]] |
+| Use a YubiKey / TouchID / Windows Hello to sign SSH connections | [[en/cookbook/hardware-key\|Hardware-key SSH auth]] |
+| Front the Docker sshd with nginx / Caddy / SSH ProxyJump | [[en/cookbook/reverse-proxy\|Reverse proxy in front of Docker sshd]] |
+| Edit work + personal + family vaults from one Obsidian install | [[en/cookbook/multi-vault\|Editing multiple vaults from one Obsidian]] |
 
 If you want a recipe that's not here, open a [discussion](https://github.com/sotashimozono/obsidian-remote-ssh/discussions) — common asks become recipes.

--- a/docs/en/cookbook/multi-vault.md
+++ b/docs/en/cookbook/multi-vault.md
@@ -1,0 +1,119 @@
+---
+title: Editing multiple vaults from one Obsidian
+tags: [cookbook, how-to, multi-vault]
+---
+
+# Editing multiple vaults from one Obsidian
+
+Run several SSH profiles from a single Obsidian install — work vault on one host, personal vault on another, family-shared vault on a third. The plugin supports this natively; this recipe walks through the model + the few sharp edges.
+
+## The model
+
+```mermaid
+graph LR
+  subgraph Ob["One Obsidian install"]
+    LV[Local 'launcher' vault<br/>where the plugin lives]
+  end
+  subgraph Profiles["Profiles defined in the plugin"]
+    P1[work-pi]
+    P2[personal-vps]
+    P3[family-nas]
+  end
+  subgraph Shadows["Shadow vaults (auto-managed)"]
+    S1[~/.obsidian-remote/vaults/<work-id>/]
+    S2[~/.obsidian-remote/vaults/<personal-id>/]
+    S3[~/.obsidian-remote/vaults/<family-id>/]
+  end
+  subgraph Remotes["Real vaults (on the remote hosts)"]
+    R1[work-pi:/home/me/work-notes]
+    R2[vps:/home/me/personal]
+    R3[nas:/srv/family-vault]
+  end
+  LV --- P1
+  LV --- P2
+  LV --- P3
+  P1 --> S1
+  P2 --> S2
+  P3 --> S3
+  S1 -.synced.- R1
+  S2 -.synced.- R2
+  S3 -.synced.- R3
+```
+
+- **One launcher vault** holds the plugin + its profile list (`data.json`).
+- **One profile per remote vault** in plugin settings.
+- Each profile spawns its **own shadow vault** at `~/.obsidian-remote/vaults/<profile-id>/` when you connect.
+- Each shadow vault is a real Obsidian vault on disk — Obsidian opens it as a separate window.
+
+So at any moment you can have 0, 1, 2, or 3 shadow vault windows open in parallel. The launcher vault stays open in its own window as the "control panel".
+
+## Setting it up
+
+### 1. Pick a launcher vault
+
+Any vault works. Many users dedicate a small "Hub" vault for this purpose — minimal content, just the plugin + maybe a README explaining the setup. Others use their everyday local vault as the launcher.
+
+### 2. Add profiles
+
+Settings → Remote SSH → **Add profile** → repeat for each remote.
+
+Profile naming tip: prefix with the host context for quick scanning in the connect menu — `work-pi`, `personal-vps`, `family-nas`.
+
+### 3. Connect to each as you need it
+
+Command palette → "Remote SSH: Connect" → pick a profile → a new window opens with that vault's contents. Repeat for the next profile if you want both open simultaneously. Commands are scoped per launcher vault, not global.
+
+## What scales linearly
+
+- **Daemon binaries** — one per remote host (each profile uploads to its host's `~/.obsidian-remote/server`)
+- **SSH connections** — one per active connect; idle profiles cost nothing
+- **Shadow vault disk usage** — sum of all opened files across all shadows
+- **Logs** — one daemon log per remote host, but the plugin's `console.log` is shared
+
+## What's shared
+
+- **Plugin `data.json`** — profile list, host-key store, settings (font size, debug logging, etc.) — all in the launcher vault's plugin folder
+- **`Client ID` (This device setting)** — single value used for ALL profiles. So every remote sees `~/.obsidian/user/<same-client-id>/` as your workspace subtree
+- **Host-key store** — fingerprints for every remote you've ever connected to, in the same `data.json` `hostKeyStore`
+- **Telemetry** — single `telemetry.jsonl` aggregating events across all profiles
+
+## Sharp edges
+
+### "All my profiles disappeared!"
+
+Happens when you switch launcher vaults. The plugin's `data.json` lives **inside the vault**, so opening a different vault means looking at that vault's separate plugin state.
+
+If you want the same profile list available from multiple launcher vaults, two options:
+
+1. **Pick one launcher vault and use it consistently.** Easiest.
+2. **Symlink `data.json`** between launcher vaults' plugin folders. Caveat: file-watch and atomic-write semantics across symlinks can race; not officially supported.
+
+### Workspace state collisions
+
+Per-Client-ID `~/.obsidian/user/<id>/` subtrees prevent your different LAPTOPS from stomping each other's workspace state on the same vault. They do NOT separate per-profile workspace state on the same laptop — every profile uses the same `Client ID`. Usually fine because each shadow vault has its own `.obsidian/user/<id>/workspace.json` per profile by virtue of being a separate vault.
+
+The collision case: same `<client-id>`, different profiles, but the plugin re-uses the same Obsidian `vault.adapter` chain. In practice this works because shadows are physically separate vaults; flag it as a known sharp edge.
+
+### Memory + CPU
+
+Each open shadow vault is a full Obsidian window — significant per-window cost. Don't keep 5+ open simultaneously unless you have RAM to spare. Idle profiles cost nothing — only opened ones are loaded.
+
+### Per-vault settings
+
+Obsidian settings (theme, hotkeys, enabled plugins) are per-vault. Each shadow vault gets its own `.obsidian/` directory on the remote, so it can have its own Obsidian config independent of the launcher vault. This is usually a feature (work vault on light theme, personal vault on dark) but means new-shadow-vault setup includes "configure Obsidian for this vault".
+
+## Use cases
+
+| Scenario | Setup |
+|---|---|
+| **Work + personal** | 1 launcher vault, 2 profiles (work-host, personal-host). Switch contexts via the connect menu. |
+| **Per-project vaults** | 1 launcher vault, N profiles (one per project's remote). Connect to whichever project you're working on. |
+| **Multi-device editing the SAME remote vault** | Different config — see [[en/architecture/collab\|Collaboration architecture]] and [[en/configuration/this-device\|Client ID]]. NOT what this recipe is about. |
+| **Shared family vault + private personal** | Launcher vault locally + 2 profiles (family-shared on NAS, personal on home server). Family members connect to family-shared from their own launchers. |
+
+## See also
+
+- [[en/configuration/profiles|Profiles]] — full setting reference
+- [[en/configuration/this-device|This device]] — Client ID and per-device behavior
+- [[en/architecture/shadow-vault|Shadow vault architecture]] — how the per-profile shadow model works under the hood
+- [[en/cookbook/host-migration|Migrating between hosts]] — moving an individual profile's vault to a new remote

--- a/docs/en/cookbook/reverse-proxy.md
+++ b/docs/en/cookbook/reverse-proxy.md
@@ -1,0 +1,131 @@
+---
+title: Reverse proxy in front of Docker sshd
+tags: [cookbook, how-to, docker, reverse-proxy, deploy]
+---
+
+# Reverse proxy in front of Docker sshd
+
+Front the [[en/server/docker|Docker turn-key sshd]] with a reverse proxy so multiple users / multiple vault containers / TLS termination can co-exist on one public host. Useful for: family-vault hosting, small-team deployments, hosting a vault under your own domain.
+
+## When this is the right shape
+
+The Docker setup ships one sshd container on one port (default 2222). For most personal use that's fine — point your laptop at `your-host:2222` and connect. You want this recipe when:
+
+- You're running multiple vault containers (one per user / project) and want each to be reachable by a clean hostname rather than `:2222`, `:2223`, …
+- You want TLS-terminated SSH-over-HTTPS (uncommon but exists, e.g. for restrictive networks)
+- You already have nginx / Caddy / Traefik fronting other services and want to keep one ingress
+
+## SSH does not speak HTTP
+
+Important up front: SSH is a TCP stream protocol, **not HTTP**. Standard reverse proxies (nginx, Caddy in their default config) terminate HTTP. To proxy SSH you need their **stream / TCP** modules, which are a different config syntax.
+
+```mermaid
+flowchart LR
+  C[Client SSH] -->|TCP :22| RP[Reverse proxy<br/>stream/TCP module]
+  RP -->|TCP :2222| D1[Container 1<br/>vault A sshd]
+  RP -->|TCP :2223| D2[Container 2<br/>vault B sshd]
+```
+
+Or, if you want a single port + container disambiguation by SNI / hostname, you need the SSH ProxyJump pattern instead — covered at the bottom.
+
+## Recipe A — nginx stream module (one port per container)
+
+`/etc/nginx/nginx.conf` (NOT in `http {}`; goes at the top level):
+
+```nginx
+stream {
+  upstream vault_alice {
+    server 127.0.0.1:2222;     # alice's container
+  }
+  upstream vault_bob {
+    server 127.0.0.1:2223;     # bob's container
+  }
+
+  # Listen on different public ports per upstream
+  server {
+    listen 22001;
+    proxy_pass vault_alice;
+    proxy_protocol off;        # sshd doesn't speak PROXY protocol
+  }
+  server {
+    listen 22002;
+    proxy_pass vault_bob;
+  }
+}
+```
+
+Reload nginx:
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+In each user's plugin profile, set Host to the public host + the appropriate port (`your-host:22001`, `your-host:22002`).
+
+## Recipe B — Caddy with `layer4` (single port, SNI-based routing)
+
+Caddy's experimental [layer4 plugin](https://github.com/mholt/caddy-l4) can route TCP based on early-protocol bytes. SSH's first packet doesn't include an SNI field (it's not TLS), so true SNI routing isn't available, but you can match on **client IP** or **port-of-arrival** patterns.
+
+For most use cases, the nginx-style "one port per upstream" is simpler. Use layer4 only if you have a constraint forcing single-port.
+
+## Recipe C — ProxyJump (no proxy needed; the trick is in `~/.ssh/config`)
+
+If you control the client side (your laptop), the cleanest setup is to skip the reverse proxy entirely and use SSH's native ProxyJump:
+
+`~/.ssh/config` on the laptop:
+
+```
+Host bastion
+  HostName your-public-host.example.com
+  Port 22
+  User bastion-user
+
+Host vault-alice
+  HostName 127.0.0.1
+  Port 2222
+  User obsidian
+  ProxyJump bastion
+
+Host vault-bob
+  HostName 127.0.0.1
+  Port 2223
+  User obsidian
+  ProxyJump bastion
+```
+
+Then in the plugin profile, set Host to `vault-alice` or `vault-bob` (the alias). Note: the plugin's "Import from SSH config" dropdown picks these up.
+
+This avoids running a TCP proxy at all — SSH's own session multiplexing does the routing.
+
+## TLS in front (SSH-over-WebSocket)
+
+Some restrictive networks block port 22 outright. The workaround is to tunnel SSH through a TLS connection. There are a few ways:
+
+- **`websocat` / `wstunnel`** — wrap the SSH stream in a WebSocket (over TLS), terminate at your nginx. The client side wraps + the server side unwraps.
+- **`sslh`** — listens on port 443 and demuxes between SSH / HTTPS / OpenVPN based on the first packet's signature.
+
+Out of scope for this recipe — these are full deployments in their own right. Search "SSH over HTTPS reverse proxy" for the current best-of-breed.
+
+## Hardening checklist
+
+- **Don't expose the raw container ports** publicly (`bind 127.0.0.1:2222` instead of `0.0.0.0:2222` in your docker-compose). Force traffic through your proxy.
+- **Persistent host keys** — make sure each Docker container's host keys persist across recreate (the existing `deploy/docker` setup mounts a `hostkeys/` volume; preserve this when scaling to multiple containers).
+- **Per-user `authorized_keys`** — one user per container with their own keys; don't share an `authorized_keys` file across containers if isolation matters.
+- **Rate limiting** — fail2ban / nginx-side connection limits if you're internet-exposed.
+
+## Plugin profile values
+
+Whatever the proxy setup, the plugin profile values are simple:
+
+| Field | What goes here |
+|---|---|
+| Host | Either the public hostname (Recipe A) or the SSH config alias (Recipe C) |
+| Port | The proxy's listening port (A) or 22 with ProxyJump (C) |
+| Username | Whatever the container's user is (`obsidian` for the default Docker setup) |
+
+The plugin doesn't know it's behind a proxy — and it doesn't need to.
+
+## See also
+
+- [[en/server/docker|Server / Docker turn-key sshd]] — the sshd container this recipe fronts
+- [[en/user-guide/jump-host|Jump hosts]] — same idea as Recipe C but configured per-profile in the plugin instead of `~/.ssh/config`
+- [[en/cookbook/share-via-tailscale|Share via Tailscale]] — alternative to reverse-proxy hosting (Tailscale handles the network without an exposed port)

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.6",
+  "version": "1.0.45-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.6",
+  "version": "1.0.45-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.6",
+  "version": "1.0.45-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.6",
+      "version": "1.0.45-beta.7",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.6",
+  "version": "1.0.45-beta.7",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

**Round 2 of the EN-completion plan** — 3 new cookbook recipes for common operational asks. Brings cookbook from 6 → 9 recipes; doc set from 58 → 61 pages.

### What's new

| Recipe | Audience |
|---|---|
| `hardware-key.md` | Anyone who wants stronger SSH auth than a passphrase-protected key on disk — covers YubiKey FIDO2, macOS Secure Enclave, Windows Hello |
| `reverse-proxy.md` | Operators hosting multiple vaults on one public host or wanting clean per-tenant routing |
| `multi-vault.md` | Users running work + personal + family vaults from one Obsidian — the model + sharp edges |

### Approach

All three are user-side / operational synthesis (no plugin internals invented). The plugin's role is just "use whatever ssh-agent / SSH config / profile setup you give it" — which is documented elsewhere; these recipes connect those existing dots into concrete walkthroughs.

Cross-links:
- `hardware-key.md` ←→ `ssh-keygen.md`, `ssh-config.md`, `security/model.md`
- `reverse-proxy.md` ←→ `server/docker.md`, `user-guide/jump-host.md`
- `multi-vault.md` ←→ `configuration/profiles.md`, `configuration/this-device.md`, `architecture/shadow-vault.md`

### Side effects on merge

- `release.yml` fires on `next` push → publishes **v1.0.45-beta.7** as a prerelease.

## Test plan

- [ ] CI green
- [ ] Dev docs site renders all 3 + the cookbook landing's 3 new rows
- [ ] Mermaid in `reverse-proxy.md` (flowchart) and `multi-vault.md` (graph LR) render

## What's next

Round 3 (api/protocol-evolution, server/firewall, server/multi-user) and Round 4 (Obsidian Sync migration — high-risk) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)