### PR TITLE
docs(en): round 3 — protocol-evolution + firewall + multi-user

### DIFF
--- a/docs/en/api/overview.md
+++ b/docs/en/api/overview.md
@@ -22,6 +22,7 @@ The daemon speaks **JSON-RPC 2.0** with **LSP-style framing** on a Unix socket. 
 - **[[en/api/watch|Watch / notifications]]** — `fs.watch`, `fs.unwatch`, `fs.changed` (server-push)
 - **[[en/api/errors|Error codes]]** — full error reference
 - **[[en/api/examples|Examples]]** — copy-pasteable JSON-RPC envelopes for every common operation
+- **[[en/api/protocol-evolution|Protocol evolution & versioning]]** — what's a breaking change vs capabilities-gated, the strict-equality regime, future-bump triggers
 
 ## Protocol version
 

--- a/docs/en/api/protocol-evolution.md
+++ b/docs/en/api/protocol-evolution.md
@@ -1,0 +1,108 @@
+---
+title: Protocol evolution & versioning
+tags: [api, reference, protocol]
+---
+
+# Protocol evolution & versioning
+
+How the wire protocol changes over time, what's safe vs breaking, and how clients should detect server capabilities.
+
+## Two version axes
+
+The wire has **two** versions:
+
+| Axis | Field | Today | Bumps when |
+|---|---|---|---|
+| **Protocol version** | `server.info.protocolVersion` (int) | `1` | A breaking change to existing methods (params/result shape, semantics, error codes) |
+| **Capabilities** | `server.info.capabilities` (sorted string array) | All registered method names — currently 22 | A new method is added (non-breaking); an old method is removed (breaking) |
+
+The protocol version is **the major-axis compatibility number**. Capabilities are the per-method feature flags within a protocol version.
+
+## The strictness rule (today)
+
+The plugin's `RpcConnection` checks `info.protocolVersion !== PROTOCOL_VERSION` (strict equality) and rejects with `ProtocolVersionTooOld (-32021)` on any mismatch. Per `plugin/src/transport/RpcConnection.ts:71`:
+
+```typescript
+if (info.protocolVersion !== PROTOCOL_VERSION) {
+  // → fall through to redeploy or fail the connect
+}
+```
+
+So today, **plugin and daemon must agree exactly on the protocol version**. There's no forward- or backward-compat negotiation. The `tryReuseExistingDaemon` probe relies on this: a version mismatch fails the handshake, the deploy fallback uploads the matching binary, version matches, connect succeeds. See [[en/operations/upgrading|Upgrading]] for the lifecycle view.
+
+This is intentional pre-2.0 — the cost of a redeploy is small (~5 s) and the strictness avoids "subtly broken" runs where a client uses a method the daemon implements differently.
+
+## What's a breaking change
+
+Bumps `protocolVersion` (1 → 2):
+
+- Renaming an existing method
+- Removing a method
+- Removing or renaming a field in an existing method's params or result
+- Changing the type of a field (e.g. `mtime: number` → `mtime: string`)
+- Changing semantics of an existing field (e.g. "mtime is unix-ms" → "mtime is unix-seconds")
+- Changing the framing format (currently LSP-style `Content-Length: <N>\r\n\r\n`)
+- Adding a required field to an existing method's params
+
+## What's a non-breaking change (capabilities-gated)
+
+Stays at `protocolVersion: 1`; new methods/fields advertised via `capabilities`:
+
+- Adding a new method (e.g. a future `fs.search`) — added to `capabilities`; clients feature-detect by checking `capabilities.includes("fs.search")` before calling
+- Adding an optional field to an existing method's params (server defaults if absent)
+- Adding an optional field to an existing method's result (clients ignore unknown fields)
+- Adding a new error code (clients should map unknown codes to a generic "unrecognized error" rather than crash)
+
+## How clients should feature-detect
+
+```typescript
+const info = await rpc.call("server.info", {});
+if (info.protocolVersion !== EXPECTED_PROTOCOL_VERSION) {
+  // hard reject — strict-equality regime
+  throw new Error("protocol version mismatch");
+}
+if (info.capabilities.includes("fs.thumbnail")) {
+  // safe to call rpc.call("fs.thumbnail", ...)
+}
+```
+
+The plugin uses this exact pattern for `fs.thumbnail` — added partway through the 0.4.x cycle. Older daemons without it would fail the capability check; the plugin falls back to `fs.readBinary` + client-side resize.
+
+## Cross-version operability matrix
+
+For protocol version 1 (the only one shipped to date):
+
+| Client version | Daemon version | Result |
+|---|---|---|
+| 1.0.X | 1.0.X (same) | Match — full speed (reuse probe attaches to running daemon) |
+| 1.0.X | 1.0.Y (Y < X) | Mismatch on `info.version` string — reuse probe fails, plugin redeploys to bring daemon to 1.0.X |
+| 1.0.X | 1.0.Y (Y > X) | Same flow — older client redeploys older binary over the newer one |
+| 1.0.X | 2.0.X (future) | `protocolVersion 2 ≠ 1` → `ProtocolVersionTooOld` → redeploy fallback uploads the bundled (1.0.X-matching) daemon |
+
+The reuse probe is the safety net. **Users do not see protocol drift errors** — they see a one-time ~5-second redeploy on the first connect after upgrading either side.
+
+## When we'd bump to protocol 2
+
+The pre-1.0 line saw zero breaking proto changes, and 1.x is committed to the same. Hypothetical triggers for a `protocolVersion 2`:
+
+- A wire-format change (e.g. moving from JSON-RPC to gRPC for performance)
+- A semantics change like "mtime now means content-modification time, not metadata-modification time" — semantically incompatible at the per-message level
+- A protocol-level auth change (e.g. moving from per-startup token to per-call signed nonce)
+
+When that happens:
+
+1. Daemon supports both protocol versions for one release (returns `protocolVersion: 2` from new daemons; old clients see this and redeploy).
+2. Plugin bundle gets updated to expect protocol 2.
+3. Capabilities reset / re-curated as part of the 2.0 audit.
+
+## Mobile / WSS transport (v2.0 milestone)
+
+The mobile-relay plan ([[en/roadmap|tracked under #151]]) introduces a WSS transport alongside SSH. The transport is independent of the JSON-RPC protocol — same `auth` / `server.info` / `fs.*` methods, different framing + connection setup. The protocol version itself does **not** need to bump just to add a new transport.
+
+## See also
+
+- [[en/api/overview|API overview]] — the wire format + framing
+- [[en/api/authentication|Authentication]] — `auth` + `server.info` handshake details
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — how version coherence is enforced from the release-machinery side
+- [[en/operations/upgrading|Upgrading]] — what users see when versions don't match
+- [[en/glossary|Glossary]] — protocolVersion definition

--- a/docs/en/server/firewall.md
+++ b/docs/en/server/firewall.md
@@ -1,0 +1,125 @@
+---
+title: Firewall, ports & NAT
+tags: [server, deploy, networking]
+---
+
+# Firewall, ports & NAT
+
+What ports the plugin uses (and which it doesn't), how to expose a remote vault host across networks, and what to put in the firewall rules.
+
+## TL;DR
+
+**The plugin opens zero new network ports.** The daemon binds a Unix socket only — no TCP listener. All traffic flows through your existing SSH connection. If `ssh user@host` reaches your remote, the plugin reaches your remote.
+
+## Why no extra port
+
+The daemon uses `net.Listen("unix", ~/.obsidian-remote/server.sock)` per `server/cmd/obsidian-remote-server/main.go:99`. Unix sockets are filesystem objects, scoped to the local machine; they cannot be reached by network peers. The plugin connects to the socket via an SSH local stream forward (the `openUnixStream` call in `tryReuseExistingDaemon`), which tunnels socket bytes over the SSH session.
+
+```mermaid
+flowchart LR
+  C[Plugin on laptop] -->|SSH on :22| sshd[sshd on remote]
+  sshd -->|local stream forward| sock["/home/user/.obsidian-remote/server.sock<br/>(Unix socket — no TCP)"]
+  sock --> D[Daemon process]
+```
+
+So the only port that needs to be open is the one your sshd already uses (typically 22, sometimes a custom port like 2222 for Docker).
+
+## Common topologies
+
+### Local network (same LAN)
+
+No firewall changes needed. Your laptop connects directly:
+
+```
+laptop  ── LAN (192.168.x.0/24) ──  remote (192.168.x.50:22)
+```
+
+If the remote's host firewall is on (`ufw enable` on Ubuntu, etc.), allow inbound SSH:
+```bash
+sudo ufw allow ssh                # allows port 22
+# or for a custom sshd port
+sudo ufw allow 2222/tcp
+```
+
+### Behind home NAT (you're on the road, vault is at home)
+
+Three sane options, in increasing order of "effort but worth it":
+
+| Option | Effort | Trade-off |
+|---|---|---|
+| **Tailscale / Headscale / WireGuard mesh** | Low (one install per device) | Best path — no router changes, no public exposure. See [[en/cookbook/share-via-tailscale\|the Tailscale recipe]]. |
+| **Cloudflare Tunnel / ngrok / boringproxy** | Medium | TLS-terminated reverse tunnel; the remote host dials out to the tunnel provider. No router config; depends on the provider. |
+| **Port-forward 22 on your home router** | Medium-high (router config + harden sshd) | Direct internet exposure. Acceptable IF you've got pubkey-only auth, fail2ban, non-22 port number, and no password logins. Easy to misconfigure. |
+
+For most users: **just use Tailscale**. It removes the entire NAT class of problems.
+
+### Cloud VPS / managed host
+
+The host has a public IP. Allow inbound SSH at the cloud provider's firewall layer (security group on AWS, firewall rule on Hetzner / DigitalOcean / OVH):
+
+```
+inbound TCP 22  from  0.0.0.0/0  → allow      (or restrict to your IP)
+```
+
+Stack a host-level firewall on top (`ufw allow ssh`) for defense in depth.
+
+### Behind corporate NAT / restrictive network
+
+If port 22 outbound is blocked (some corporate networks, hotel WiFi, etc.):
+
+- **SSH over a custom port** — bind sshd to 443 or 8443; outbound 443 is almost universally allowed
+- **SSH over WebSocket** — `wstunnel` / `websocat` wrap SSH in TLS; see the [[en/cookbook/reverse-proxy#tls-in-front-ssh-over-websocket\|TLS-in-front section of the reverse-proxy recipe]]
+- **Tailscale's DERP relays** — Tailscale falls back to TLS relays automatically when direct UDP can't establish; works on most corporate networks
+
+## What to NOT firewall
+
+The plugin doesn't need:
+
+- Any inbound port other than SSH on your remote
+- Any outbound port from the daemon (it doesn't make outbound network calls)
+- Any port on your laptop (the plugin is the SSH client, opens outbound only)
+
+The Unix socket the daemon listens on (`~/.obsidian-remote/server.sock`) is filesystem-scoped — no `iptables` rule applies to it.
+
+## Verifying the wire
+
+From your laptop:
+
+```bash
+# Can you SSH at all?
+ssh -v user@remote-host echo OK
+# Should print "OK" with verbose handshake. If not, fix SSH first.
+
+# Can the plugin reach the socket via the SSH forward?
+# (Plugin does this internally; manual test for paranoia.)
+ssh user@remote-host 'test -S ~/.obsidian-remote/server.sock && echo socket-OK'
+# Should print "socket-OK" once the daemon is running.
+```
+
+If both succeed, the network path is fine. Any plugin failure beyond this is in the auth / RPC layer, not the firewall.
+
+## Hardening sshd (since this is the only port)
+
+Quick sanity on a non-trivially-exposed remote:
+
+```ini
+# /etc/ssh/sshd_config (or /etc/ssh/sshd_config.d/99-hardening.conf)
+PasswordAuthentication no            # pubkey only
+PermitRootLogin no                   # never login as root over SSH
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+MaxAuthTries 3
+LoginGraceTime 30
+ClientAliveInterval 60               # detect dropped clients
+```
+
+Reload: `sudo systemctl reload ssh` (or `sshd` on some distros).
+
+Combined with fail2ban for brute-force defense and `ufw` allowing only your SSH port, this is sufficient for most home / personal-server scenarios.
+
+## See also
+
+- [[en/server/overview|Server overview]] — what the daemon needs from the host (no network requirements beyond what's listed there)
+- [[en/cookbook/share-via-tailscale|Share via Tailscale]] — the recommended NAT-traversal path
+- [[en/cookbook/reverse-proxy|Reverse proxy in front of Docker sshd]] — multi-tenant fronting + TLS-in-front
+- [[en/security/model|Security threat model]] — what attack vectors SSH alone doesn't defend against

--- a/docs/en/server/multi-user.md
+++ b/docs/en/server/multi-user.md
@@ -1,0 +1,146 @@
+---
+title: Multi-user hosting
+tags: [server, deploy, multi-user]
+---
+
+# Multi-user hosting
+
+Hosting vaults for several users on one remote host. Covers the natural per-user-account model, how to share one OS user across humans (and why you usually shouldn't), and the multi-vault-per-user case.
+
+## The natural model: one OS user per human
+
+Each human gets their own OS user account on the remote. Each runs their own daemon under their own account, against their own vault directory.
+
+```mermaid
+graph TB
+  subgraph host["One remote host"]
+    subgraph alice["alice user"]
+      A1[~/.obsidian-remote/server<br/>daemon binary]
+      A2[~/.obsidian-remote/server.sock<br/>token, log]
+      A3[/home/alice/notes<br/>vault]
+    end
+    subgraph bob["bob user"]
+      B1[~/.obsidian-remote/server<br/>daemon binary]
+      B2[~/.obsidian-remote/server.sock<br/>token, log]
+      B3[/home/bob/notes<br/>vault]
+    end
+    subgraph dad["dad user"]
+      D1[~/.obsidian-remote/server<br/>daemon binary]
+      D2[~/.obsidian-remote/server.sock<br/>token, log]
+      D3[/home/dad/notes<br/>vault]
+    end
+  end
+```
+
+This works **without any special config** because the plugin's defaults are home-relative:
+
+- Socket path: `~/.obsidian-remote/server.sock` → resolves to `/home/alice/.obsidian-remote/server.sock` for alice, `/home/bob/...` for bob, etc.
+- Token path: same pattern
+- Daemon binary path: same pattern
+- Vault path: each user sets their own
+
+So three users sharing one host, each with their own vault, each connecting from their own laptop using their own SSH key — works out of the box. Each spawns their own daemon process under their own UID.
+
+### Setup checklist
+
+```bash
+# As root on the remote
+sudo adduser alice
+sudo adduser bob
+sudo adduser dad
+
+# Each user adds their own ~/.ssh/authorized_keys
+ssh-copy-id alice@remote-host    # (alice runs from her laptop)
+ssh-copy-id bob@remote-host
+ssh-copy-id dad@remote-host
+
+# Each user creates their vault directory on first login
+ssh alice@remote-host 'mkdir -p ~/notes'
+```
+
+In the plugin (each user on their own laptop):
+
+| Field | Value |
+|---|---|
+| Username | `alice` (their own OS user) |
+| Authentication | their own SSH key |
+| Remote vault path | `~/notes` (or wherever they want) |
+
+Daemons coexist via UID isolation. Sockets, tokens, and logs all live under the per-user `~/.obsidian-remote/`. No collision possible.
+
+### Resource accounting
+
+Each user's daemon counts against their resource limits (`ulimit`, cgroups, systemd `MemoryMax` if you wrap it per-user). For a Pi with 5 users idling, the steady-state cost is ~25 MB total RSS. Concurrent edit bursts add a bit per active session.
+
+For a hardened deployment, set per-user systemd resource caps (see [[en/cookbook/systemd-managed-daemon|systemd-managed daemon]]) so one runaway client can't starve the others.
+
+## One OS user, multiple humans (anti-pattern)
+
+Sometimes asked: "can I have alice + bob + dad share one `obsidian` user account, each running their own profile from their laptop?"
+
+You can, but **it's an anti-pattern** because:
+
+- The token in `~obsidian/.obsidian-remote/token` is **single** — once one user's plugin authenticates, the daemon's session is pinned to that connection. A second concurrent connect kicks the first.
+- Daemons restart on plugin reconnect (the `tryReuseExistingDaemon` probe + deploy fallback). When the daemon restarts, the token regenerates, and the OTHER user's plugin discovers their cached token is invalid on next call → also has to redeploy. Cascading thrash.
+- Vault file ownership ends up shared (`obsidian:obsidian`) so any audit-trail of "who changed what" relies on Obsidian-level metadata, not OS-level uid info.
+
+The Docker setup (`deploy/docker/`) ships exactly this single-user pattern by design — fine for a single human or a "one container per human" deployment. For multiple humans on one host, give them separate OS accounts.
+
+## One OS user, multiple vaults (this works fine)
+
+If a single human wants several distinct vaults on one host (work, personal, family) under one OS account:
+
+- Use **multiple plugin profiles**, each pointing at a different vault path under the same SSH user
+- All profiles share the same daemon (one socket per OS user)
+- See [[en/cookbook/multi-vault|Editing multiple vaults from one Obsidian]] for the laptop side
+
+Daemon arguments support this: the daemon takes `--vault-root` at startup. Connecting to a different vault root requires a different daemon (different `--vault-root` arg), which means a different socket. The plugin handles this by auto-deploying with a per-profile socket path:
+
+| Profile | Socket path |
+|---|---|
+| Work vault | `~/.obsidian-remote/server.sock` (default) |
+| Personal vault | `~/.obsidian-remote/server-personal.sock` (override in profile Transport settings) |
+
+Each profile spawns its own daemon process pointed at its own vault root.
+
+## Container-isolated multi-user
+
+For more isolation than OS users (or to make per-user resource limits trivial), run **one Docker container per user**:
+
+```yaml
+# docker-compose.yml
+services:
+  vault-alice:
+    extends:
+      file: deploy/docker/docker-compose.yml
+      service: sshd
+    volumes:
+      - ./vault-alice:/home/obsidian/vault
+      - ./alice-authorized_keys:/home/obsidian/.ssh/authorized_keys:ro
+    ports:
+      - "22001:2222"
+  vault-bob:
+    extends:
+      file: deploy/docker/docker-compose.yml
+      service: sshd
+    volumes:
+      - ./vault-bob:/home/obsidian/vault
+      - ./bob-authorized_keys:/home/obsidian/.ssh/authorized_keys:ro
+    ports:
+      - "22002:2222"
+```
+
+Each container has its own sshd, its own `obsidian` user, its own daemon, its own vault. Filesystem isolation is at the container boundary. See [[en/cookbook/reverse-proxy|Reverse proxy]] for fronting multiple containers under one public hostname.
+
+## Auth + identity caveats
+
+- **Per-OS-user model**: SSH-level audit (auth.log, last) shows real human → real OS user. Best for accountability.
+- **Shared OS user**: SSH still records the source IP / pubkey, but everything inside the daemon is "user obsidian did X" with no further provenance.
+- **Container-per-user**: Like per-OS-user but with stronger filesystem boundaries; each container's auth.log is independent.
+
+## See also
+
+- [[en/cookbook/multi-vault|Editing multiple vaults from one Obsidian]] — laptop-side multi-vault, complementary
+- [[en/server/docker|Server / Docker turn-key sshd]] — base for container-isolated multi-user
+- [[en/cookbook/reverse-proxy|Reverse proxy]] — fronting multiple containers
+- [[en/configuration/profiles|Profiles]] — per-profile socket-path override for the multi-vault case

--- a/docs/en/server/overview.md
+++ b/docs/en/server/overview.md
@@ -42,6 +42,10 @@ See [[en/security/cosign-verify|Cosign verify]] to check a binary you downloaded
 - **Read+write** access to the configured vault root.
 - **Bind permission** for the Unix socket (in `~/.obsidian-remote/` by default).
 - **CPU, memory**: ~5 MB RSS idle; rises with watcher subscriptions and concurrent transfers. RPi Zero 2 W handles a moderate vault; RPi 4 effortless.
-- **Network**: nothing. The daemon binds a local Unix socket. The plugin tunnels it through SSH; no port exposure required on the remote.
+- **Network**: nothing. The daemon binds a local Unix socket. The plugin tunnels it through SSH; no port exposure required on the remote — see [[en/server/firewall|Firewall, ports & NAT]].
 
-Next: [[en/server/auto-deploy|Auto-deploy]] / [[en/server/docker|Docker]] / [[en/server/systemd|systemd]].
+## Operating multiple users on one host
+
+The defaults are home-relative, so multiple OS users on one host coexist out of the box — each spawns their own daemon under their own UID. See [[en/server/multi-user|Multi-user hosting]] for the full discussion + the anti-pattern of sharing one OS user.
+
+Next: [[en/server/auto-deploy|Auto-deploy]] / [[en/server/docker|Docker]] / [[en/server/systemd|systemd]] / [[en/server/firewall|Firewall]] / [[en/server/multi-user|Multi-user]].

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.7",
+  "version": "1.0.45-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.7",
+  "version": "1.0.45-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.7",
+  "version": "1.0.45-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.7",
+      "version": "1.0.45-beta.8",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.7",
+  "version": "1.0.45-beta.8",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

**Round 3 of the EN-completion plan** — 3 medium-risk pages, each verified against actual source before writing. Brings doc set 61 → 64 pages.

### What's new

| Page | Why medium-risk | Verification done |
|---|---|---|
| `api/protocol-evolution.md` | Versioning policy details — easy to over- or under-claim | `ProtocolVersion = 1` const at `proto/types.go:13`; strict-equality check at `RpcConnection.ts:71` |
| `server/firewall.md` | Network claim ("zero ports") needs to be exactly right | Daemon binds Unix-only via `net.Listen("unix", …)` at `cmd/obsidian-remote-server/main.go:99` — confirmed no TCP listener anywhere |
| `server/multi-user.md` | Per-user defaults claim needs to actually hold | Defaults are home-relative throughout `ServerDeployer.ts` + main.go; verified for socket / token / binary / log paths |

### Cross-links

- `api/protocol-evolution.md` ↔ `api/overview.md`, `api/authentication.md`, `architecture/release-pipeline.md`, `operations/upgrading.md`
- `server/firewall.md` ↔ `server/overview.md`, `cookbook/share-via-tailscale.md`, `cookbook/reverse-proxy.md`
- `server/multi-user.md` ↔ `cookbook/multi-vault.md`, `server/docker.md`, `cookbook/reverse-proxy.md`

`api/overview.md` and `server/overview.md` updated to surface the new pages.

### Side effects on merge

- `release.yml` fires on `next` push → publishes **v1.0.45-beta.8** as a prerelease.

## Test plan

- [ ] CI green
- [ ] Dev docs site renders all 3 + the updated overview pages
- [ ] Mermaid in `firewall.md` (flowchart) and `multi-user.md` (graph TB with subgraphs) renders cleanly

## What's next

Round 4 (1 page): `migration/from-obsidian-sync.md` — the highest-fabrication-risk one. Will defer / scope carefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)