### PR TITLE
docs(en): round 5 — daemon CLI + data.json schema + perf tuning + comparison

### DIFF
--- a/docs/en/comparison.md
+++ b/docs/en/comparison.md
@@ -1,0 +1,183 @@
+---
+title: Comparison vs other Obsidian sync tools
+tags: [comparison, overview]
+---
+
+# Comparison vs other Obsidian sync tools
+
+There are many ways to "make my Obsidian vault available on more than one device". This page compares **obsidian-remote-ssh** to the most common alternatives so you can pick the right tool — including cases where the right tool is **not** this plugin.
+
+> **Spirit of this page.** No tool is "best"; tools are best-fit for a model. The comparison is honest about where this plugin loses. If your model fits Obsidian Sync better, use Obsidian Sync.
+
+## At-a-glance
+
+| | obsidian-remote-ssh | Obsidian Sync | Syncthing | Dropbox / iCloud / OneDrive | Obsidian Git | Nextcloud | [Remotely Save](https://github.com/remotely-save/remotely-save) plugin |
+|---|---|---|---|---|---|---|---|
+| **Topology** | One canonical copy on YOUR remote (server-of-truth) | Cloud (Obsidian's servers) is server-of-truth | Peer-to-peer; every device holds a full copy | Cloud is server-of-truth | Git remote is server-of-truth | Cloud-of-yours (self-hosted) is server-of-truth | Cloud is server-of-truth |
+| **Editing model** | Direct remote edit (no full local copy) | Local edit + background sync | Local edit + background sync | Local edit + background sync | Local edit + manual commit/push | Local edit + background sync | Local edit + manual sync |
+| **Auth** | SSH keys (yours) | Obsidian account | Device IDs (yours) | Service account | Git auth (SSH/HTTPS) | Nextcloud account | Per-backend (S3/OneDrive/Dropbox/WebDAV…) |
+| **At-rest encryption** | Remote host's responsibility (LUKS / FileVault / encrypted ZFS dataset) | E2EE option with your password | Per-folder encryption | Service-side, not E2EE by default | Whatever the git host does | Server-side; E2EE addon | Per-backend; some support E2EE |
+| **In-flight encryption** | SSH | TLS + E2EE option | TLS | TLS | SSH/HTTPS | TLS | Per-backend (TLS) |
+| **Conflict model** | mtime preconditions; daemon-mediated; conflict surfaced to UI | Vector clock; cloud-mediated; mostly auto | mtime + version vectors; can produce `*-conflict-*` files | mtime; produces `*-conflict-*` files routinely | Git merge; you resolve in editor / CLI | Server arbitrates; can produce `(conflict copy)` files | Per-backend; unresolved conflicts go to a conflict folder |
+| **Mobile (iOS / Android Obsidian)** | No, desktop-only ([#151](https://github.com/sotashimozono/obsidian-remote-ssh/issues/151)) | First-class | Android only; no iOS | Yes (with caveats — iOS sandbox sometimes lags) | Mobile Git plugins exist but flaky | Yes (Nextcloud app) | Yes |
+| **Cost** | Self-hosted: free + your hardware/VPS | Subscription | Free | Subscription beyond free tier | Free (your git host) | Self-hosted: free + your hardware | Free (plus your storage cost) |
+| **Selective sync** | No, whole vault only | No | Per-folder share level | Some clients support it | Manual via `.gitignore` | Per-folder | Per-folder include/exclude |
+| **Version history** | None — use server-side backups instead ([[en/cookbook/backup-restore\|recipe]]) | Per-file history in UI (paid) | Optional file-versioning addon | Recycle bin / version history (paid tiers) | Native to git | Per-file history | Per-backend; not in plugin itself |
+| **Works offline** | No — needs SSH reachability | Cached locally | Local-first | Cached locally | Local-first | Cached locally | Cached locally (the local copy IS the vault) |
+| **Risk if your "cloud" disappears** | N/A — it IS your cloud | Vault inaccessible until restored | N/A — every device has it | Vault inaccessible until restored | Vault still on every clone | Self-hosted: same as us | Local copy survives |
+
+The **most important row is Topology.** Every other property follows from it.
+
+## Pick by user type
+
+### "I want it to just work, including on mobile"
+
+→ **Obsidian Sync.** It's a paid product because the productisation costs money. If your appetite for ops is "none", pay for Sync.
+
+### "I want all my files on every device, no central server"
+
+→ **Syncthing.** Peer-to-peer, no central anything, free. The downside is the conflict-resolution UX (`*-conflict-*` files) and Android-only mobile.
+
+### "I already pay for Dropbox / iCloud / OneDrive, why install anything?"
+
+→ **Use what you have.** It works fine for single-device-at-a-time editing. The classic failure is "I edited on laptop offline; iPad synced overnight; opening the file shows a `(conflict copy)` next to the real one." Live with that and move on.
+
+### "I want git-style version history of every change"
+
+→ **Obsidian Git plugin.** Every save (or every interval) becomes a commit. Great history, fragile mobile story, requires you to think in git.
+
+### "I have a homelab and want self-hosted everything"
+
+→ **Either Nextcloud or this plugin.** Nextcloud sync if you want full-replica (vault on every device) and a richer ecosystem. obsidian-remote-ssh if you want **single canonical copy** (no replicas to worry about, no per-device disk usage, edit-on-server model).
+
+### "I want this plugin's model: vault stays on the remote, no replicas"
+
+→ **obsidian-remote-ssh.** This is the niche we exist for.
+
+## When obsidian-remote-ssh is the right choice
+
+The plugin's model fits well when:
+
+- **You own a remote that's almost always reachable.** Home Pi over Tailscale, NAS, VPS, work dev box. SSH-reachable from your editing devices.
+- **You don't want N copies of your vault.** A single canonical copy on the remote is exactly what you want. No "which device has the latest" question.
+- **You're already in the SSH-keys-and-Linux mindset.** Adding another SSH host to a setup you already maintain is roughly zero ops overhead.
+- **Your privacy threshold rules out third-party cloud.** Notes never touch anyone's servers but yours.
+- **You're desktop-primary.** If mobile is a "nice to have", this works; if it's a hard requirement, see below.
+- **Big vaults (10k+ files).** The plugin lazy-fetches; you don't keep tens of thousands of files synced on every laptop.
+
+## When obsidian-remote-ssh is the wrong choice
+
+Be honest about these — using the wrong tool because of the wrong reason just hurts you:
+
+- **You need mobile editing.** Desktop only ([#151](https://github.com/sotashimozono/obsidian-remote-ssh/issues/151)). Use Obsidian Sync, or Syncthing/Nextcloud paired with the Obsidian mobile app.
+- **You're often offline.** SSH-unreachable means no editing. Replicating sync (Sync, Syncthing, Dropbox, Nextcloud) lets you edit offline; this plugin doesn't.
+- **You don't have a remote at all.** Spinning up a VPS just to run this is fine, but if "no infrastructure" is a goal, pick Sync or Syncthing.
+- **You want per-file undo from a UI.** We don't have it. Use Sync (paid) or git-based, or pair this plugin with [[en/cookbook/backup-restore|server-side restic backups]] and accept that "undo" is a CLI restore.
+- **You need real-time collaboration.** Two people editing the same file at the same instant is conflict territory in any of these tools, but it's especially abrupt in this plugin (mtime check; one side gets a conflict). For collab-doc workflows, neither this nor Sync is the right tool — look at HedgeDoc / etherpad-style.
+
+## Specific comparisons (deeper)
+
+### vs Obsidian Sync
+
+The closest peer in spirit (both are "Obsidian-aware sync"). The dividing line is **who owns the canonical store**:
+
+- Sync: Obsidian's servers. Pay a subscription, get mobile + per-file history + cross-device E2EE.
+- This plugin: your server. Free, more ops surface, no mobile yet.
+
+Obsidian Sync is a great product. If you can pay the subscription and the data-residency model is fine, it's the lower-friction choice. This plugin is for people who specifically want self-hosting.
+
+See the dedicated [[en/migration/from-obsidian-sync|migration guide]] if you're switching.
+
+### vs Syncthing
+
+Syncthing is the **opposite topology** — not "central server" but "every device has a full copy, peers gossip changes". Strengths:
+
+- No central anything; truly P2P.
+- Free, self-hosted, mature.
+- Works fully offline on every device.
+
+Where it's harder than this plugin:
+
+- **Disk pressure on every device.** A 5 GB vault eats 5 GB on every device.
+- **Conflict UX.** Two laptops editing the same file produces `*-sync-conflict-...md` files; you reconcile by hand. (We have the same problem with two clients editing the same file, but the conflict surfaces in the Obsidian UI before either save lands rather than as a sibling file.)
+- **No iOS Obsidian.** Syncthing has no iOS client at all.
+
+If you have one laptop + one phone (Android), Syncthing is great. If you have 4 devices and a phone, the disk-and-conflict story gets messier than this plugin's central-server story.
+
+### vs Dropbox / iCloud / OneDrive
+
+These work but **Obsidian explicitly warns against putting an active vault inside a sync folder.** The classic failure is `.obsidian/workspace.json` getting trampled mid-write, plugin caches racing each other, attachments syncing while you're editing them. People do it anyway because it's zero-setup. It mostly works until it doesn't.
+
+The cloud-storage path is fine if:
+
+- You only edit on one device at a time.
+- You're OK doing manual conflict-copy cleanup occasionally.
+- You're not doing heavy plugin work that writes to `.obsidian/` constantly.
+
+If those don't hold, get a real Obsidian-aware tool — Sync, this plugin, or Syncthing.
+
+### vs Obsidian Git
+
+Beautiful for "I want every save committed":
+
+- Real version history with `git log` and `git blame`.
+- Works with any git host (GitHub, GitLab, self-hosted Gitea / Forgejo).
+- Free.
+
+Costs:
+
+- **Mobile is fragile.** The mobile Git plugins exist but routinely break with auth changes, large repos, or background-sync limitations on iOS.
+- **Conflict resolution is git-flavoured.** If you can resolve a merge conflict in `vim`, this is fine. If not, it's a usability cliff.
+- **Large attachments (images, PDFs) bloat the git history.** Git LFS is the answer; setting it up correctly inside an Obsidian vault is non-trivial.
+
+Often the best fit is **this plugin + an opportunistic git mirror on the remote** (cron a `git commit -am snapshot && git push` every hour). You get this plugin's editing model + git's history, and Obsidian doesn't have to know about git at all.
+
+### vs Nextcloud (with Obsidian client)
+
+Nextcloud is the natural "I want the whole self-hosted-cloud experience" answer. The Obsidian-relevant comparison:
+
+- Nextcloud syncs files via its desktop/mobile clients into a local folder; you point Obsidian at that folder. Same shape as Dropbox, but self-hosted.
+- It has the same "vault in a sync folder" sharp edges as Dropbox, although Nextcloud's conflict story is generally cleaner.
+- **Mobile works** — Nextcloud's iOS / Android apps are mature.
+- It's a much heavier piece of software to operate (PHP stack, database, periodic upgrades, occasional storage-corruption issues). Operating Nextcloud well is a real time investment.
+
+If you already run Nextcloud, you don't need us. If you don't already run it and the only reason to install it would be "for Obsidian", this plugin is a much smaller surface area.
+
+### vs the Remotely Save plugin
+
+[Remotely Save](https://github.com/remotely-save/remotely-save) is the popular "sync your vault to S3 / Dropbox / OneDrive / WebDAV" plugin. Different model:
+
+- Remotely Save: local-first, periodic sync to a remote object store. Vault lives on every device; the cloud is a sync target.
+- This plugin: remote-first, edit-against-the-server. Vault lives only on the remote; local is a window.
+
+Pick Remotely Save when:
+
+- You want to keep the local-first model (offline editing, fast file ops).
+- Your remote of choice is an object store (S3, R2, Backblaze, OneDrive) rather than an SSH host.
+- You want mobile.
+
+Pick this plugin when:
+
+- You don't want N copies of the vault.
+- You have an SSH-reachable host.
+- You want sub-second file open over LAN/Tailscale (no "sync delay" between devices).
+
+> Trivia: this repository was originally a fork of Remotely Save before the architecture diverged hard enough to need a different name and a different project. Different goals, different tradeoffs.
+
+## "Can I run two of these?"
+
+Yes — they're not mutually exclusive:
+
+- **This plugin + Obsidian Sync (mobile-only).** Use Sync just for the mobile bridge; this plugin for desktop. Sync sees the remote vault as a set of files; the conflict surface is "did the mobile-edit and the desktop-edit collide?" which is the same problem you have with one tool.
+- **This plugin + git mirror.** As above — the remote runs an hourly `git commit && git push` cron; you get history without paying it on the editing path.
+- **This plugin + restic / borg backups.** The mandatory pairing if version history matters to you. See [[en/cookbook/backup-restore|backup recipe]].
+
+The combinations aren't great if you stack two _replicating_ tools (Sync + Syncthing on the same vault is a recipe for grief), but pairing this plugin with **non-replicating** companions (mobile bridge, history snapshots, backup) is fine and often the right answer.
+
+## See also
+
+- [[en/faq|FAQ]] — short comparison table + recurring questions
+- [[en/migration/from-obsidian-sync|Migrating from Obsidian Sync]] — if you've already picked us
+- [[en/cookbook/backup-restore|Backup & restore]] — the mandatory pairing for version-history needs
+- [[en/architecture/index|Architecture]] — how the remote-first model actually works
+- [[en/roadmap|Roadmap]] — including the mobile plan (v2.0)

--- a/docs/en/configuration/profiles.md
+++ b/docs/en/configuration/profiles.md
@@ -57,4 +57,6 @@ Click **Add jump host** under a profile. Each entry has its own Host / Port / Us
 
 If you sync your `.obsidian` directory across machines, your profile list syncs too — be aware that `Private key path` is a path that may not exist on every device.
 
+For the on-disk schema (every field, every default, hand-editing rules), see [[en/reference/data-json|data.json schema reference]].
+
 Next: [[en/configuration/this-device|This device]].

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -20,6 +20,8 @@ Recurring questions, with the shortest useful answer.
 
 The right pick depends on your trust model + ops appetite. If you already have a server you trust and do not want a third-party cloud in the loop, this plugin is for you.
 
+For an expanded breakdown that also covers Obsidian Git, Nextcloud, and the [Remotely Save](https://github.com/remotely-save/remotely-save) plugin, see [[en/comparison|the full comparison page]].
+
 ## Does it work on mobile?
 
 Not yet. Tracked under [the mobile-relay milestone](https://github.com/sotashimozono/obsidian-remote-ssh/issues?q=label%3Amobile). The current architecture spawns a daemon binary on the remote, which works fine on a desktop where Obsidian is Electron. Mobile (iOS / Android Obsidian) needs a relay component because the OS does not allow Obsidian to spawn arbitrary subprocesses.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -17,6 +17,10 @@ tags: [home]
 | Cookbook: do task X | [[en/cookbook/index\|Cookbook]] (RPi vault, SSH key, Tailscale, systemd) |
 | Look up a specific setting | [[en/configuration/profiles\|Configuration reference]] |
 | Run your own server | [[en/server/overview\|Server / deploy guide]] |
+| Run the daemon by hand (systemd, containers, debugging) | [[en/reference/daemon-cli\|Daemon CLI reference]] |
+| Hand-edit `data.json` or build it from a script | [[en/reference/data-json\|data.json schema reference]] |
+| Speed it up — "things feel slow" | [[en/operations/performance-tuning\|Performance tuning]] |
+| Decide if this plugin is the right tool vs Sync / Syncthing / Git | [[en/comparison\|Comparison vs other Obsidian sync tools]] |
 | Verify the daemon binary you downloaded | [[en/security/cosign-verify\|Cosign verification]] |
 | Build something against the protocol | [[en/api/overview\|API & protocol reference]] (and [[en/api/examples\|copy-pasteable JSON-RPC examples]]) |
 | Look up a term | [[en/glossary\|Glossary]] |
@@ -39,6 +43,7 @@ tags: [home]
 - **[[en/changelog|Changelog & releases]]** — major-milestone overview + how to find per-release notes
 - **[[en/privacy|Privacy & data handling]]** — what data this plugin handles, where it lives, what does (or does not) leave your machines
 - **[[en/migration/from-obsidian-sync|Migrating from Obsidian Sync]]** — switchover guide for users coming from Obsidian's official paid sync service
+- **[[en/comparison|Comparison]]** — full breakdown vs Obsidian Sync, Syncthing, Dropbox/iCloud, Git-based, Nextcloud, and the Remotely Save plugin
 - **[[en/faq|FAQ]]** — quick answers to recurring questions
 
 ## Release channels

--- a/docs/en/operations/performance-tuning.md
+++ b/docs/en/operations/performance-tuning.md
@@ -1,0 +1,177 @@
+---
+title: Performance tuning
+tags: [operations, performance]
+---
+
+# Performance tuning
+
+A consolidated guide to making the plugin feel snappy. Information here is scattered across `troubleshooting`, `raspberry-pi`, and `architecture/perf` — this page is the one place to start when "things feel slow".
+
+## Where time actually goes
+
+```mermaid
+flowchart LR
+  A[Obsidian action<br/>e.g. open file] --> B[Plugin issues fs.readText]
+  B --> C[JSON serialise + frame]
+  C --> D[SSH transport: laptop → remote]
+  D --> E[Daemon parses + dispatches]
+  E --> F[Remote disk I/O]
+  F --> G[Daemon serialises response]
+  G --> H[SSH transport: remote → laptop]
+  H --> I[Plugin parses + materialises]
+  I --> J[Obsidian renders]
+```
+
+For a typical small note (~5 KB):
+
+| Stage | Typical cost |
+|---|---|
+| Plugin → JSON-RPC encode | < 1 ms |
+| SSH RTT (LAN) | 0.5–2 ms |
+| SSH RTT (home WAN) | 5–30 ms |
+| SSH RTT (cross-continent) | 50–200 ms |
+| Daemon dispatch + read | 1–10 ms |
+| Plugin decode + Obsidian render | 1–5 ms |
+
+**The dominant factor is SSH RTT.** Everything below tunes around that reality.
+
+## Diagnose first
+
+Before tuning, measure. Two commands answer 90% of "why is it slow":
+
+```bash
+# 1. Network RTT to the remote
+ping -c 5 your-host
+# → look at the avg; that's your floor for every RPC
+
+# 2. Cold fs.walk time on the actual vault
+ssh user@host 'time find ~/notes -type f | wc -l'
+# → first run = cold-cache; second run = warm-cache (Linux page cache)
+# Big delta between cold and warm means disk-I/O-bound on this host
+```
+
+If `ping` is > 50 ms, that's your problem; skip to [Network section](#network). If cold `find` is > 5 seconds for a < 10k-file vault, that's disk-bound; skip to [Disk section](#disk-on-the-remote).
+
+## Network
+
+### High SSH RTT — the universal problem
+
+The plugin makes **many small RPCs** during normal Obsidian use (file open = fs.stat + fs.readText; saving = fs.write; switching folders = fs.list). At 50 ms RTT, ten ops in a flow ≈ half a second of accumulated wait.
+
+What helps:
+
+- **Use Tailscale or another mesh VPN** rather than going over the open internet. Tailscale's direct UDP path is typically 10-30 % faster than relayed TCP. See [[en/cookbook/share-via-tailscale|Tailscale recipe]].
+- **Use a closer remote** if you're on a long-haul setup. A Pi at home (5-30 ms) beats a VPS in another continent (100-200 ms) for daily editing.
+- **Don't use ssh-over-WebSocket-over-TLS** unless you must — every wrapper adds RTT.
+
+### Throughput vs latency
+
+Throughput rarely bottlenecks for note-editing — even a 10 Mbit/s link handles thousands of small RPCs per second. The exception:
+
+- **Large attachments / images** (10+ MB) — limited by raw bandwidth + base64 overhead. The plugin uses `fs.readBinaryRange` for partial reads (e.g. image previews), but the first full open of a big binary spends real bandwidth.
+- **Initial `fs.walk` on a huge vault** — recursive walk emits one entry per file in a single response. 100k files = significant payload. Mitigated by `maxEntries` cap; the plugin sets a sane default.
+
+### SSH-level tuning
+
+```
+# In ~/.ssh/config or /etc/ssh/ssh_config on the laptop
+Host your-host
+  ControlMaster auto
+  ControlPath ~/.ssh/cm-%r@%h:%p
+  ControlPersist 10m
+  TCPKeepAlive yes
+  ServerAliveInterval 60
+```
+
+`ControlMaster` reuses one TCP connection across multiple SSH invocations, which avoids the TCP+SSH-handshake cost on reconnect. Note: the plugin manages its own connection lifecycle, so this primarily helps if you also use `ssh user@host` from the terminal.
+
+## Disk on the remote
+
+### Vault on SD card vs SSD
+
+For a Raspberry Pi (or anything else with slow storage):
+
+| Storage | First fs.walk on 10k files | Subsequent (cached) |
+|---|---|---|
+| Pi SD card (Class 10) | 5-15 s | 0.2-0.5 s |
+| Pi USB-attached SATA SSD | 0.5-1.5 s | 0.1-0.3 s |
+| NVMe SSD | < 0.5 s | < 0.1 s |
+
+Cold-cache reads dominate first-time-of-day vault use. **The single biggest improvement on a Pi is moving the vault off the SD card to a USB-attached SSD.** Even a cheap $20 240 GB SATA SSD with a USB-3 enclosure is dramatic.
+
+### Filesystem choice
+
+ext4 / btrfs / xfs all work. Notes:
+
+- **ZFS on top of single-disk consumer storage** can add unexpected latency for many-small-file workloads. If you're on ZFS, set `recordsize=16K` on the dataset holding the vault.
+- **NFS mounts** as the vault root work but add a layer of latency; keep the daemon close to the actual filesystem, not over NFS to elsewhere.
+- **encrypted-at-rest filesystems** (LUKS, FileVault) have negligible per-op overhead in modern CPUs.
+
+## inotify limits (Linux remotes)
+
+The daemon uses `fsnotify` (which uses inotify on Linux) to watch the vault. Linux has a per-user limit on how many directories one process can watch, defaulting to 8192 on most distros — fine for a small vault, problematic for big trees.
+
+Symptom of hitting the limit: remote edits do not appear locally until you switch focus or trigger a manual refresh.
+
+```bash
+# Check the limit
+cat /proc/sys/fs/inotify/max_user_watches
+
+# Bump it (active until reboot)
+sudo sysctl -w fs.inotify.max_user_watches=65536
+
+# Persist across reboots
+echo 'fs.inotify.max_user_watches=65536' | \
+  sudo tee /etc/sysctl.d/99-inotify.conf
+sudo sysctl --system
+```
+
+65536 covers vaults up to ~50k directories comfortably. Bumping further has memory cost (~1 KiB per watch).
+
+## Plugin / client side
+
+### Reduce reconnect-storm thrash
+
+If your network is flaky, the reconnect manager retries up to 5 times with ×1.5 backoff (1 s, 1.5 s, 2.25 s, …). On a poor link, you might hit the cap quickly.
+
+In **Settings → Advanced**:
+- Bump **Reconnect attempts** from 5 to 10 if you genuinely have flaky connectivity (most users don't need this)
+- Disable auto-reconnect (set to 0) only if you'd rather see drops as errors than wait through retries
+
+### Daemon panel: Restart instead of Reconnect
+
+If only one operation is slow and reconnecting doesn't help, the plugin's local state may be inconsistent (e.g. stale fs.watch subscription). Settings → Daemon → **Restart** rebuilds everything cleanly. ~5 s downtime.
+
+### Telemetry to spot regressions
+
+Enable [[en/configuration/advanced|Telemetry]] when something gets newly slow. The error category counts will surface whether you're seeing more `connect.fail.timeout`, `rpc.fail.PreconditionFailed` (= conflict thrash), or general `reconnect.attempting` events. This data is local-only.
+
+## Daemon-side: thumbnail cache
+
+The daemon has a server-side thumbnail cache for `fs.thumbnail` calls (default 200 MB, under `~/.obsidian-remote/cache/thumbs/`). For an image-heavy vault, this dramatically reduces repeated-resize work. It's enabled by default; not a tuning knob you usually touch.
+
+If you see disk pressure from this cache, the cleanest mitigation is to mount `~/.obsidian-remote/cache/` on tmpfs (cache regenerates on demand):
+
+```
+# /etc/fstab fragment (Linux, optional)
+tmpfs  /home/USER/.obsidian-remote/cache  tmpfs  size=512M,mode=0700,uid=USER,gid=USER  0 0
+```
+
+## Reasonable expectations
+
+| Setup | Per-op feel |
+|---|---|
+| Pi 4 + USB SSD + LAN | Indistinguishable from local-vault Obsidian |
+| Pi 4 + SD card + LAN | Snappy after warm-up; first cold load ~5 s |
+| VPS in same continent + Tailscale | Slight lag on big-folder switches; otherwise fine |
+| VPS cross-continent + open internet | Noticeable per-op pause; livable for editing-focused use, less great for "browse everything" workflows |
+| Pi Zero 2 W + SD card | Acceptable for small vaults; struggles past ~5k files |
+
+If your feel is significantly worse than the row matching your setup, something's off — file an [issue](https://github.com/sotashimozono/obsidian-remote-ssh/issues) with the diagnostic numbers above.
+
+## See also
+
+- [[en/architecture/perf|Performance architecture]] — internals + the perf bench that gates regressions
+- [[en/operations/troubleshooting|Troubleshooting]] — the broader issue tree (this page is the perf branch)
+- [[en/server/raspberry-pi|Raspberry Pi notes]] — Pi-specific perf footnotes
+- [[en/api/watch|fs.watch]] — inotify limits in the wire-protocol context

--- a/docs/en/operations/troubleshooting.md
+++ b/docs/en/operations/troubleshooting.md
@@ -51,6 +51,8 @@ Likely culprits, in order of frequency:
 
 For deep perf debug: enable [[en/configuration/advanced|Debug logging]] and check `<plugin>/console.log` (rotated `console.log` + `.1` + `.2` + `.3`) for per-op timings.
 
+The full perf-tuning playbook (network / disk / inotify / daemon-side cache, with measurement commands) lives at [[en/operations/performance-tuning|Performance tuning]].
+
 ## How to ask for help
 
 When opening an issue, paste:

--- a/docs/en/reference/daemon-cli.md
+++ b/docs/en/reference/daemon-cli.md
@@ -1,0 +1,195 @@
+---
+title: Daemon CLI reference
+tags: [reference, daemon, cli]
+---
+
+# Daemon CLI reference
+
+Complete reference for the `obsidian-remote-server` binary. The plugin invokes this for you on every connect (see [[en/server/auto-deploy|Plugin auto-deploy]]); this page is for operators running it manually under systemd, in containers, or for debugging.
+
+## Synopsis
+
+```
+obsidian-remote-server --vault-root=<path> [--socket=<path>] [--token-file=<path>] [--verbose]
+obsidian-remote-server --version
+```
+
+## Flags
+
+### Required
+
+#### `--vault-root <path>`
+
+Absolute path of the vault directory on this host. The daemon refuses to start if:
+
+- The flag is missing or empty
+- The path does not exist
+- The path is not a directory
+
+The daemon will reject any RPC operation whose resolved path escapes this root (`PathOutsideVault` error, code `-32015`).
+
+```bash
+obsidian-remote-server --vault-root=/home/me/notes
+```
+
+Relative paths are accepted but resolved to absolute via `filepath.Abs` at startup. Symlinks in the vault root path are followed.
+
+### Optional
+
+#### `--socket <path>`
+
+Unix socket the daemon listens on. **Default: `<state-dir>/server.sock`** (state-dir is normally `~/.obsidian-remote/`).
+
+The daemon:
+1. Removes any existing file at this path (cleanup of dangling sockets from a crashed prior run)
+2. Creates the parent directory with mode `0700` if missing
+3. Binds the Unix socket
+4. Chmods the socket to `0600` so only the daemon's user can connect
+
+```bash
+obsidian-remote-server --vault-root=/srv/vault --socket=/srv/vault-state/server.sock
+```
+
+#### `--token-file <path>`
+
+Path the daemon writes its session token to at startup. **Default: `<state-dir>/token`**.
+
+The token is 32 random bytes (hex-encoded → 64 chars), generated via `crypto/rand`. The file is written with mode `0600` and removed when the daemon exits cleanly. Plugins read this file via SFTP and present it on the `auth` RPC.
+
+#### `--verbose`
+
+Enable debug-level logging to **stderr** (slog text format). Without this, logging is discarded entirely (`io.Discard`).
+
+The plugin's auto-deploy passes `--verbose` so the daemon's stderr ends up in `~/.obsidian-remote/server.log` (the spawn redirects stderr → that log file). For systemd-managed setups, decide based on whether you want noise in journalctl.
+
+#### `--version`
+
+Print the daemon version (one line) and exit `0`. Used by plugin-side diagnostics + script health checks. Bypasses all other flags.
+
+```bash
+obsidian-remote-server --version
+# → 0.1.0
+```
+
+## State directory layout
+
+When `--socket` and `--token-file` are not given, both default into `<state-dir>`. State-dir resolves to:
+
+| OS | Path |
+|---|---|
+| Linux / macOS / BSD | `$HOME/.obsidian-remote/` |
+| Windows | (daemon doesn't run on native Windows; see [[en/server/overview\|Server overview]]) |
+
+So a typical invocation with all defaults plants:
+
+```
+~/.obsidian-remote/
+    server.sock     # the Unix socket the daemon listens on (mode 0600)
+    token           # 32-byte hex token (mode 0600); auto-removed on clean exit
+```
+
+You can override either path independently — useful for multi-vault setups (one socket per vault on the same OS user; see [[en/server/multi-user|Multi-user hosting]]).
+
+## Invocation patterns
+
+### Manual smoke test
+
+```bash
+~/.obsidian-remote/server \
+  --vault-root=$HOME/notes \
+  --verbose \
+  > ~/.obsidian-remote/server.log 2>&1 &
+disown
+```
+
+After this, the plugin's reuse probe will attach without redeploying. To stop:
+
+```bash
+pkill -f obsidian-remote-server
+```
+
+### Same as the plugin's auto-deploy
+
+```bash
+nohup ~/.obsidian-remote/server \
+  --vault-root=/home/pi/notes \
+  --socket=/home/pi/.obsidian-remote/server.sock \
+  --token-file=/home/pi/.obsidian-remote/token \
+  --verbose \
+  > /home/pi/.obsidian-remote/server.log 2>&1 < /dev/null &
+```
+
+Reverse-engineered from `ServerDeployer`. The plugin uses `nohup … < /dev/null &` so the daemon survives the SSH session that spawned it.
+
+### Under systemd (per-user)
+
+See the full unit at [[en/cookbook/systemd-managed-daemon|systemd-managed daemon]]. Key fragment:
+
+```ini
+ExecStart=/usr/local/bin/obsidian-remote-server \
+  --vault-root=%h/notes \
+  --socket=%h/.obsidian-remote/server.sock \
+  --token-file=%h/.obsidian-remote/token \
+  --verbose
+```
+
+`%h` expands to the user's home; lets one unit file work for any user via `systemctl --user`.
+
+### Multi-vault on the same user
+
+Different daemons need different sockets:
+
+```bash
+# Daemon for the work vault
+~/.obsidian-remote/server \
+  --vault-root=$HOME/work-notes \
+  --socket=$HOME/.obsidian-remote/work.sock \
+  --token-file=$HOME/.obsidian-remote/work.token &
+
+# Daemon for the personal vault
+~/.obsidian-remote/server \
+  --vault-root=$HOME/personal-notes \
+  --socket=$HOME/.obsidian-remote/personal.sock \
+  --token-file=$HOME/.obsidian-remote/personal.token &
+```
+
+In the plugin profile for each, set the matching socket + token paths. See [[en/cookbook/multi-vault|multi-vault recipe]].
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean shutdown (SIGINT / SIGTERM received and listener drained, or `--version` printed) |
+| `1` | Runtime error after startup (cannot bind socket, token write failed, vault root vanished, etc.) — message goes to stderr |
+| `2` | Argument parse error (missing required flag, invalid value) — flag.ContinueOnError surfaces this |
+
+## Signal handling
+
+The daemon installs a SIGINT + SIGTERM handler that closes the listener (which unwinds `Serve`), removes the socket file + token file, then exits `0`. This is graceful shutdown.
+
+`kill -9` (SIGKILL) skips the cleanup. The next daemon start will find the stale socket file at `<socket>` and the existing handler removes it before binding fresh — so a hard kill doesn't permanently jam the path.
+
+## Environment variables
+
+The daemon does **not** read any environment variables for configuration — all config goes through CLI flags. Things that DO affect the daemon implicitly:
+
+| Env var | Effect |
+|---|---|
+| `HOME` | Determines the default state-dir (`$HOME/.obsidian-remote/`) when `--socket` / `--token-file` are not given |
+| `TZ` | Affects `slog`'s timestamp output when `--verbose` is on; otherwise irrelevant |
+
+The plugin's environment (Obsidian's `process.env`) is irrelevant to the daemon — they're separate processes on different hosts.
+
+## What the daemon does NOT do
+
+- **It does not detach from its terminal on its own.** Use `nohup … &` or run under systemd to background it. (Plugins do this for you.)
+- **It does not rotate its own log file.** When run via the plugin, stdout+stderr are piped to `~/.obsidian-remote/server.log` and that file truncates only on daemon restart. Under systemd, journalctl handles retention.
+- **It does not bind a TCP port.** Unix socket only — see [[en/server/firewall|Firewall, ports & NAT]].
+- **It does not retry-on-fail.** Process-level supervision (systemd `Restart=on-failure`, the plugin's reuse-probe-then-redeploy fallback) handles that.
+
+## See also
+
+- [[en/server/auto-deploy|Plugin auto-deploy]] — what the plugin does to invoke the daemon
+- [[en/server/systemd|systemd unit]] — production unit-file template
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — how the binary is built + signed
+- [[en/api/overview|API overview]] — the JSON-RPC the daemon speaks once it's up

--- a/docs/en/reference/data-json.md
+++ b/docs/en/reference/data-json.md
@@ -1,0 +1,189 @@
+---
+title: data.json schema reference
+tags: [reference, settings, data]
+---
+
+# `data.json` schema reference
+
+Complete schema for `<vault>/.obsidian/plugins/remote-ssh/data.json` — the file that holds your profiles, host-key trust, and plugin settings. Useful for debugging, scripted multi-machine setup, or rebuilding state by hand.
+
+> Source of truth: `plugin/src/types.ts` (`PluginSettings`, `SshProfile`, `JumpHostConfig`) plus `plugin/src/main.ts:311-326` (the `hostKeyStore` field added when serialising). If anything below disagrees with the source, the source wins.
+
+## Top-level shape
+
+```jsonc
+{
+  // PluginSettings fields (see below for each)
+  "profiles": [...],
+  "activeProfileId": "...",
+  "enableDebugLog": false,
+  "maxLogLines": 1000,
+  "reconnectMaxRetries": 5,
+  "clientId": "",
+  "userName": "",
+  "onboardingCompleted": true,
+  "telemetryEnabled": false,
+  "terminalShell": "/usr/bin/zsh -l",
+  "terminalFontSize": 12,
+  "terminalScrollback": 1000,
+
+  // Added by main.ts at save time (NOT in PluginSettings)
+  "hostKeyStore": {
+    "192.168.1.50:22": "aa:bb:cc:dd:..."
+  }
+}
+```
+
+## Top-level fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `profiles` | `SshProfile[]` | `[]` | One entry per connection target; see profile schema below |
+| `activeProfileId` | `string \| null` | `null` | Last-connected profile, restored on plugin reload |
+| `enableDebugLog` | `boolean` | `false` | Verbose logging to `console.log` (UI: Settings → Advanced) |
+| `maxLogLines` | `number` | (legacy field; the size-rotated `console.log` makes it informational) | Pre-Phase-D upper-bound; leave as default |
+| `reconnectMaxRetries` | `number` | `5` (Backoff.DEFAULT_BACKOFF.maxRetries) | 0 disables auto-reconnect; range 0-100 |
+| `clientId` | `string` | `""` (= sanitized OS hostname at runtime) | Per-device id; surfaces as `.obsidian/user/<id>/` on the remote |
+| `userName` | `string` | `""` (= OS username at runtime) | Display name only; not used for SSH auth |
+| `onboardingCompleted` | `boolean?` | `false` | First-launch flag; once true, the OnboardingModal won't auto-open |
+| `telemetryEnabled` | `boolean?` | `false` | Opt-in counters → `<plugin>/telemetry.jsonl` |
+| `terminalShell` | `string?` | (use remote `$SHELL`) | Override for the terminal pane's shell command |
+| `terminalFontSize` | `number?` | `12` | xterm.js font size, range 6-32 |
+| `terminalScrollback` | `number?` | `1000` | In-memory line buffer (not persisted across re-opens) |
+| `autoConnectProfileId` | `string?` | (unset) | Set by `ShadowVaultBootstrap` on shadow vaults; auto-connects on layout-ready. **Don't set on a regular vault.** |
+| `pendingPluginSuggestions` | `PendingPluginSuggestion[]?` | (unset) | Shadow-vault-only; suggestions for which community plugins to install on first bootstrap. Cleared once decided. |
+| `hostKeyStore` | `Record<string, string>` | `{}` | Map `host:port` → sha256-hex fingerprint. Added by `main.ts` at save. See [[en/security/host-keys\|Host-key trust]]. |
+
+## `SshProfile` schema
+
+Every entry in `profiles[]` matches:
+
+```jsonc
+{
+  "id": "abc-123-uuid",          // generated on profile creation; do not change
+  "name": "My Pi",               // display label
+
+  // Identification
+  "host": "192.168.1.50",
+  "port": 22,
+  "username": "pi",
+
+  // Authentication
+  "authMethod": "privateKey",    // "password" | "privateKey" | "agent"
+  "privateKeyPath": "~/.ssh/id_ed25519",  // for "privateKey"
+  "passphraseRef": "...",        // SecretStore handle for the passphrase
+  "agentSocket": "/path/to/sock",        // override SSH_AUTH_SOCK; rare
+  "passwordRef": "...",          // SecretStore handle if "password" auth
+
+  // Remote vault
+  "remotePath": "/home/pi/notes",
+
+  // Transport
+  "transport": "sftp",           // "sftp" (default) | "rpc"
+  "rpcSocketPath": ".obsidian-remote/server.sock",
+  "rpcTokenPath": ".obsidian-remote/token",
+
+  // SSH session tuning (sane defaults; rarely changed)
+  "connectTimeoutMs": 15000,
+  "keepaliveIntervalMs": 30000,
+  "keepaliveCountMax": 3,
+
+  // Host key (Phase 2 only — superseded by hostKeyStore for v1)
+  "hostKeyFingerprint": "...",   // legacy per-profile pin
+
+  // Optional jump host
+  "jumpHost": {
+    "host": "bastion.example.com",
+    "port": 22,
+    "username": "jump-user",
+    "authMethod": "agent",
+    "privateKeyPath": "~/.ssh/bastion_key",  // if authMethod === "privateKey"
+    "passwordRef": "..."         // if authMethod === "password"
+  }
+}
+```
+
+### Field-by-field
+
+| Field | Type | Required? | Notes |
+|---|---|:-:|---|
+| `id` | string | yes | UUID-shape; the plugin generates this on `Add profile`. **Don't edit by hand** — it keys the shadow vault directory under `~/.obsidian-remote/vaults/<id>/`. |
+| `name` | string | yes | Display only; safe to rename anytime |
+| `host` | string | yes | Hostname / IP / SSH-config alias |
+| `port` | number | yes | Defaults to 22 in the UI |
+| `username` | string | yes | Remote SSH user |
+| `authMethod` | enum | yes | One of `password`, `privateKey`, `agent` |
+| `privateKeyPath` | string | when `authMethod === 'privateKey'` | `~`-expanded at runtime |
+| `passphraseRef` | string | when key has a passphrase + you stored it | Opaque handle from SecretStore (OS keychain) |
+| `agentSocket` | string | rarely | Override of `SSH_AUTH_SOCK`; usually leave unset |
+| `passwordRef` | string | when `authMethod === 'password'` + you stored it | Same SecretStore mechanism |
+| `remotePath` | string | yes | Vault root on the remote; `~`-expanded |
+| `transport` | enum | no, default `sftp` | Switch to `rpc` to opt into the daemon |
+| `rpcSocketPath` | string | no, default `.obsidian-remote/server.sock` | Home-relative path on the remote |
+| `rpcTokenPath` | string | no, default `.obsidian-remote/token` | Home-relative path on the remote |
+| `connectTimeoutMs` | number | no | SSH handshake timeout |
+| `keepaliveIntervalMs` | number | no | SSH keepalive cadence |
+| `keepaliveCountMax` | number | no | Drop after N missed keepalives |
+| `hostKeyFingerprint` | string | no | **Legacy.** Pre-1.0 per-profile pin; superseded by the global `hostKeyStore`. New profiles don't set this. |
+| `jumpHost` | `JumpHostConfig` | no | Single jump host for now (multi-hop tracked separately) |
+
+## `JumpHostConfig` schema
+
+```jsonc
+{
+  "host": "bastion.example.com",
+  "port": 22,
+  "username": "jump-user",
+  "authMethod": "agent",          // same enum as profile
+  "privateKeyPath": "...",        // if applicable
+  "passwordRef": "..."            // if applicable
+}
+```
+
+Each jump host authenticates independently. See [[en/user-guide/jump-host|Jump hosts]] for the model.
+
+## `hostKeyStore`
+
+The plugin's own known-host store, **separate from `~/.ssh/known_hosts`**. Map of `"<host>:<port>"` → sha256-hex fingerprint:
+
+```jsonc
+{
+  "hostKeyStore": {
+    "192.168.1.50:22": "aa:bb:cc:dd:ee:ff:01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f:10:11:12:13:14:15:16:17:18:19:1a",
+    "bastion.example.com:22": "ab:cd:ef:..."
+  }
+}
+```
+
+The fingerprint format is the same colon-separated bytes shown in the host-key trust dialog (no `SHA256:` prefix). See [[en/security/host-keys|Host-key trust]] for the trust model + manual edits.
+
+## Hand-editing safely
+
+Obsidian must be **closed** when you edit `data.json` directly — the plugin saves over it on shutdown.
+
+After edits, re-open Obsidian. The plugin's load path (`main.ts:311+`) reads the file as a `Partial<PluginSettings> & { hostKeyStore? }`, so missing fields revert to defaults rather than crashing.
+
+Common safe operations:
+- Reorder `profiles[]`
+- Rename `profiles[i].name`
+- Update `profiles[i].host` / `port` / `remotePath`
+- Remove a stale `hostKeyStore` entry to force re-trust
+
+Unsafe operations (don't do these):
+- Change `profiles[i].id` (would orphan the shadow vault directory)
+- Edit `hostKeyStore` to a fingerprint you didn't actually verify (defeats the purpose)
+- Add fields not in this schema (silently dropped on next save)
+
+## What's NOT in `data.json`
+
+- **Passwords / passphrases themselves** — stored in OS keychain via SecretStore; `data.json` only has opaque handles
+- **The actual SSH private keys** — read fresh from `~/.ssh/...` on every connect
+- **Logs / telemetry** — separate files (`console.log`, `telemetry.jsonl`)
+- **The shadow vault contents** — physically separate vaults under `~/.obsidian-remote/vaults/<id>/`
+
+## See also
+
+- [[en/configuration/profiles|Profiles configuration reference]] — UI-level walkthrough of the same fields
+- [[en/security/host-keys|Host-key trust]] — `hostKeyStore` security model
+- [[en/configuration/this-device|This device]] — `clientId` / `userName` semantics
+- [[en/privacy|Privacy & data handling]] — full inventory of where the plugin writes

--- a/docs/en/server/overview.md
+++ b/docs/en/server/overview.md
@@ -49,3 +49,5 @@ See [[en/security/cosign-verify|Cosign verify]] to check a binary you downloaded
 The defaults are home-relative, so multiple OS users on one host coexist out of the box — each spawns their own daemon under their own UID. See [[en/server/multi-user|Multi-user hosting]] for the full discussion + the anti-pattern of sharing one OS user.
 
 Next: [[en/server/auto-deploy|Auto-deploy]] / [[en/server/docker|Docker]] / [[en/server/systemd|systemd]] / [[en/server/firewall|Firewall]] / [[en/server/multi-user|Multi-user]].
+
+For the binary's full flag set (running it by hand, under systemd, or in a container), see [[en/reference/daemon-cli|Daemon CLI reference]].

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.9",
+  "version": "1.0.45-beta.10",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.9",
+  "version": "1.0.45-beta.10",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.9",
+  "version": "1.0.45-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.9",
+      "version": "1.0.45-beta.10",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.9",
+  "version": "1.0.45-beta.10",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Final batch of EN docs completion before parity audit. Four reference and operational pages users have repeatedly hit blanks on.

### New pages

- **`docs/en/reference/daemon-cli.md`** — full flag set for `obsidian-remote-server` (`--vault-root` / `--socket` / `--token-file` / `--verbose` / `--version`), state-dir layout, invocation patterns (manual smoke test, plugin auto-deploy nohup form, systemd, multi-vault), exit codes, signal handling, environment variables. Verified against `server/cmd/obsidian-remote-server/main.go:44-48`.
- **`docs/en/reference/data-json.md`** — complete schema for `<vault>/.obsidian/plugins/remote-ssh/data.json`: `PluginSettings` top-level fields, `SshProfile` per-profile fields, `JumpHostConfig`, `hostKeyStore`. Hand-editing rules + the explicit inventory of what is NOT in `data.json` (passwords, private keys, logs, telemetry, shadow-vault contents). Verified against `plugin/src/types.ts` and `plugin/src/main.ts:311-326`.
- **`docs/en/operations/performance-tuning.md`** — consolidated perf playbook. Earlier docs scattered perf advice across `raspberry-pi`, `troubleshooting`, and `architecture/perf`. This is the one page to start from when "things feel slow" — Mermaid flow of where time goes, diagnose-first commands, network/disk/inotify/daemon-cache sections, reasonable-expectations table by hardware setup.
- **`docs/en/comparison.md`** — expanded standalone comparison vs Obsidian Sync, Syncthing, Dropbox/iCloud/OneDrive, Obsidian Git, Nextcloud, and the [Remotely Save](https://github.com/remotely-save/remotely-save) plugin. The FAQ already had a 6-row at-a-glance; this page covers **when this plugin is the wrong choice** and the multi-tool combinations that are sane (this plugin + git mirror, this plugin + restic, this plugin + Sync-for-mobile-only).

### Wiring

- `index.md` — 4 new "Start here" rows + a "Comparison" entry in the Sections list
- `faq.md` — pointer from the short comparison table to the full page
- `operations/troubleshooting.md` — perf section links to the new playbook
- `server/overview.md` — links to the daemon CLI reference
- `configuration/profiles.md` — links to the `data.json` schema reference

### Version

Bumps `manifest-beta.json` + `plugin/package.json` to **1.0.45-beta.10**. Next batch is the parity audit (EN ↔ docs site link-check, internal cross-link sweep), not new content.

## Test plan

- [ ] Quartz build (`docs.yml` workflow) succeeds without broken-wikilink warnings
- [ ] `version-check` passes (beta channel, version shape `1.0.45-beta.10`)
- [ ] Spot-check: comparison page renders, daemon-cli code blocks render, performance-tuning Mermaid diagram renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
