### PR TITLE
docs(ci): add wikilink + anchor checker as a docs-CI gate

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,13 @@ on:
     paths:
       - "docs/**"
       - "docs-site/**"
+      - "scripts/check-docs-links.mjs"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "docs-site/**"
+      - "scripts/check-docs-links.mjs"
       - ".github/workflows/docs.yml"
 
 # gh-pages deploy requires write access to contents
@@ -34,6 +41,10 @@ jobs:
       - name: Install Quartz dependencies
         working-directory: docs-site
         run: npm ci
+
+      # ── Lint: wikilinks + anchor refs (runs on PRs and pushes) ───────────
+      - name: Check docs wikilinks + anchors
+        run: node scripts/check-docs-links.mjs
 
       # ── Stable build (main → root of gh-pages) ───────────────────────────
       - name: Build docs — stable

--- a/docs/en/contributing/documentation.md
+++ b/docs/en/contributing/documentation.md
@@ -153,7 +153,7 @@ The root `index.md` should be a thin landing page with a language picker plus an
 | Diagrams | Mermaid (Quartz built-in) | Already used heavily in existing `docs/en/architecture/*.md` |
 | Maths | KaTeX (Quartz built-in) | Reserved for protocol notation if needed |
 | Spell-check | `crate-ci/typos` (CI-only) | Project name allowlist in `_typos.toml` |
-| Link-check | `lycheeverse/lychee` (CI-only) | Both internal `[[wikilinks]]` and external HTTP |
+| Link-check | `scripts/check-docs-links.mjs` (CI gate on every PR; runs locally too) | Internal `[[wikilinks]]` + `#anchor` refs. External HTTP is not currently checked. |
 | Settings/Protocol gen | `typedoc` → markdown | Output committed under `reference/` and `protocol/` so the site builds from a clean checkout |
 
 ### Browser support

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.10",
+  "version": "1.0.45-beta.11",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.10",
+  "version": "1.0.45-beta.11",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.10",
+  "version": "1.0.45-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.10",
+      "version": "1.0.45-beta.11",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.10",
+  "version": "1.0.45-beta.11",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/scripts/check-docs-links.mjs
+++ b/scripts/check-docs-links.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// Quartz/Obsidian-style wikilink checker for the docs/ tree.
+//
+// Catches:
+//   - broken [[wikilinks]] (target file does not exist)
+//   - bad anchor refs ([[page#Heading]] where the heading does not exist)
+//   - orphan pages (no inbound wikilinks; index.md is exempted)
+//
+// Resolution rules match Quartz's "shortest-path" wikilink behaviour:
+//   - [[foo/bar]]  -> resolves against docs/foo/bar.md
+//   - [[bar]]      -> resolves against any docs/**/bar.md (basename match)
+//   - [[en/foo|x]] -> alias is stripped; \| (escaped pipe in tables) handled
+//
+// Code spans (`...`) and fenced blocks (```...```) are stripped before
+// scanning so wikilink-syntax illustrations in the contributing guide
+// are not flagged as broken links.
+//
+// Exit code: 0 = clean, 1 = at least one broken wikilink or bad anchor.
+// Orphan pages are reported but do NOT fail the run by default.
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = 'docs';
+const SCAN_ROOT = path.join(ROOT, 'en');
+
+function walk(dir, files = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, files);
+    else if (e.name.endsWith('.md')) files.push(p);
+  }
+  return files;
+}
+
+const norm = (s) => s.split(path.sep).join('/');
+
+function stripCode(src) {
+  return src
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`\n]*`/g, '');
+}
+
+function slugify(s) {
+  return s
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s\-]/g, '')
+    .replace(/\s+/g, '-');
+}
+
+function parseTarget(raw) {
+  const pipeMatch = raw.match(/^(.+?)\\?\|/);
+  let target = (pipeMatch ? pipeMatch[1] : raw).trim();
+  let anchor = '';
+  const hashIdx = target.indexOf('#');
+  if (hashIdx >= 0) {
+    anchor = target.slice(hashIdx + 1).trim();
+    target = target.slice(0, hashIdx).trim();
+  }
+  return { target, anchor };
+}
+
+const allMd = walk(ROOT);
+const existingByPath = new Set(allMd.map((f) => norm(f).replace(/\.md$/, '')));
+const byBasename = new Map();
+for (const p of existingByPath) {
+  const base = p.split('/').pop();
+  if (!byBasename.has(base)) byBasename.set(base, []);
+  byBasename.get(base).push(p);
+}
+
+const headings = new Map();
+for (const file of allMd) {
+  const key = norm(file).replace(/\.md$/, '');
+  const set = new Set();
+  let inFence = false;
+  for (const line of fs.readFileSync(file, 'utf8').split(/\r?\n/)) {
+    if (/^```/.test(line)) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const m = line.match(/^#{1,6}\s+(.+?)\s*$/);
+    if (m) set.add(slugify(m[1]));
+  }
+  headings.set(key, set);
+}
+
+function resolveTarget(target, fromFile) {
+  if (!target) return norm(fromFile).replace(/\.md$/, '');
+  if (target.includes('/')) {
+    const candidate = `${ROOT}/${target}`;
+    return existingByPath.has(candidate) ? candidate : null;
+  }
+  if (byBasename.has(target)) return byBasename.get(target)[0];
+  return null;
+}
+
+const wikilinkRe = /\[\[([^\[\]]+?)\]\]/g;
+
+const broken = [];
+const badAnchors = [];
+const inbound = new Map();
+for (const p of existingByPath) inbound.set(p, 0);
+
+for (const file of walk(SCAN_ROOT)) {
+  const content = stripCode(fs.readFileSync(file, 'utf8'));
+  const fileKey = norm(file).replace(/\.md$/, '');
+  let m;
+  while ((m = wikilinkRe.exec(content)) !== null) {
+    const { target, anchor } = parseTarget(m[1]);
+    if (!target && !anchor) continue;
+    const resolved = resolveTarget(target, file);
+    if (!resolved) {
+      broken.push({ file: norm(file), link: m[0], target });
+      continue;
+    }
+    if (resolved !== fileKey) {
+      inbound.set(resolved, (inbound.get(resolved) || 0) + 1);
+    }
+    if (anchor) {
+      const slug = slugify(anchor);
+      const set = headings.get(resolved);
+      if (!set || !set.has(slug)) {
+        badAnchors.push({ file: norm(file), link: m[0], expectedSlug: slug, in: resolved });
+      }
+    }
+  }
+}
+
+const orphans = [];
+for (const [p, count] of inbound.entries()) {
+  if (!p.startsWith('docs/en/')) continue;
+  if (p === 'docs/en/index') continue;
+  if (count === 0) orphans.push(p + '.md');
+}
+orphans.sort();
+
+console.log(`docs link check: ${broken.length} broken wikilinks, ${badAnchors.length} bad anchors, ${orphans.length} orphan pages.`);
+
+if (broken.length) {
+  console.log('\n--- Broken wikilinks ---');
+  for (const b of broken) {
+    console.log(`  ${b.file}  ->  ${b.link}  (target "${b.target}" not found)`);
+  }
+}
+
+if (badAnchors.length) {
+  console.log('\n--- Bad anchor references ---');
+  for (const b of badAnchors) {
+    console.log(`  ${b.file}  ->  ${b.link}  (slug "${b.expectedSlug}" not in ${b.in}.md)`);
+  }
+}
+
+if (orphans.length) {
+  console.log('\n--- Orphan pages (no inbound wikilinks) ---');
+  for (const o of orphans) console.log(`  ${o}`);
+}
+
+process.exit(broken.length + badAnchors.length > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Batch A of the post-EN-completion plan: parity / link-check audit, promoted into a permanent CI gate.

### Audit findings (current state of EN docs, 69 pages)

| Check | Result |
|---|---|
| Broken `[[wikilinks]]` | **0** |
| Bad `[[page#anchor]]` references | **0** |
| Orphan pages (no inbound links) | 1 (`docs/en/index.md`, expected — it's the landing page) |

The link layer is in good shape after the Round 1–5 doc completion. The valuable output of this batch is therefore not the findings, but **promoting the audit into a CI gate** so future PRs can't regress the link layer between merge and deploy.

### Changes

- **`scripts/check-docs-links.mjs`** — new Quartz/Obsidian-aware wikilink resolver:
  - Shortest-path matching: `[[bar]]` resolves to `docs/**/bar.md`
  - Table-cell pipe escape handling: `[[en/foo\|alias]]`
  - Code-span and fenced-block skipping so the wikilink-syntax illustrations in `contributing/documentation.md` aren't false-positives
  - Heading anchor verification with GitHub-style slugification
  - Exit 1 on any broken link or bad anchor; orphan pages are reported but non-fatal
- **`.github/workflows/docs.yml`** — added `pull_request:` trigger (previously push-only) and a `Check docs wikilinks + anchors` step that runs before the existing build steps. PRs get lint feedback without triggering deploys (deploy steps remain gated by `if: github.ref == 'refs/heads/main'` / `'refs/heads/next'`).
- **`docs/en/contributing/documentation.md`** — the aspirational `lycheeverse/lychee` row in the tooling table is replaced with the actually-wired-up `scripts/check-docs-links.mjs`. The lychee tool was never wired up; this is now truthful.

### Why home-grown over lychee

`lychee` handles HTTP and standard Markdown links well but is weak on Obsidian-style `[[wikilinks]]` (which are non-standard and need vault-aware shortest-path resolution). The home-grown script is ~180 lines of plain Node, has no deps, and matches Quartz's actual resolution semantics. External-HTTP checking is left out of scope for now (separate concern, can be added later if needed).

### Version

Bumps to **1.0.45-beta.11**.

## Test plan

- [ ] CI: the new `Check docs wikilinks + anchors` step passes (exit 0)
- [ ] CI: full docs build still succeeds and deploys to `/dev/` on merge to `next`
- [ ] Local: `node scripts/check-docs-links.mjs` from repo root prints "0 broken / 0 bad anchors / 0 orphan pages" — try it
- [ ] Sanity: a PR that intentionally breaks a wikilink (e.g. typo a target name) should be rejected by the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
