### PR TITLE
docs(en): batch B — section landing pages for 10 sections

### DIFF
--- a/docs/en/api/index.md
+++ b/docs/en/api/index.md
@@ -1,0 +1,40 @@
+---
+title: API & protocol
+tags: [api, reference]
+---
+
+# API & protocol
+
+The wire-level reference for the JSON-RPC protocol the plugin and daemon speak. Useful if you're building something against the daemon (a non-Obsidian client, a load test, a port to a different host) or debugging an unexpected error in a normal session.
+
+> **Stability promise:** the protocol is **frozen at version 1**. Method additions are non-breaking; breaking changes ship as new methods. See [[en/api/protocol-evolution|Protocol evolution]].
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [[en/api/overview\|Overview]] | The shape of every RPC: framing, versioning, capabilities, the auth handshake, and the method namespace |
+| [[en/api/authentication\|Authentication]] | The `auth` and `server.info` handshake methods + protocol-version check |
+| [[en/api/filesystem\|Filesystem]] | `fs.*` methods: read / write / list / walk / stat / mkdir / remove / rename / thumbnail |
+| [[en/api/watch\|fs.watch]] | The push-notification subscription model + inotify caveats |
+| [[en/api/errors\|Errors]] | Standard JSON-RPC error codes + the project's domain-specific code range |
+| [[en/api/protocol-evolution\|Protocol evolution]] | How the v1 contract evolves; what counts as a breaking change |
+| [[en/api/examples\|Examples]] | Copy-pasteable JSON-RPC requests for every method, ready for `nc -U` against a Unix socket |
+
+## Reading order
+
+If you're new to the protocol:
+
+1. **[[en/api/overview|Overview]]** for the big picture (framing + handshake + namespace).
+2. **[[en/api/authentication|Authentication]]** to understand what every connection does first.
+3. **[[en/api/filesystem|Filesystem]]** for the methods you'll actually call.
+4. **[[en/api/errors|Errors]]** when something goes wrong.
+5. **[[en/api/examples|Examples]]** for copy-paste recipes.
+
+If you're porting to a new client, also read [[en/api/protocol-evolution|Protocol evolution]] before relying on any specific method's shape.
+
+## See also
+
+- [[en/architecture/index|Architecture]] — the why behind the wire-level decisions
+- [[en/reference/daemon-cli|Daemon CLI reference]] — flag set for the binary that speaks this protocol
+- [[en/security/model|Security model]] — what the authentication actually defends against

--- a/docs/en/configuration/index.md
+++ b/docs/en/configuration/index.md
@@ -1,0 +1,31 @@
+---
+title: Configuration
+tags: [configuration, reference]
+---
+
+# Configuration
+
+Every plugin setting, documented. The pages here mirror the structure of **Settings → Remote SSH** inside Obsidian.
+
+## Pages
+
+| Page | Mirrors UI section |
+|---|---|
+| [[en/configuration/profiles\|Profiles]] | **Settings → Remote SSH → SSH profiles** — per-profile host / port / auth / vault path / mode / jump host |
+| [[en/configuration/this-device\|This device]] | **Settings → Remote SSH → This device** — `Client ID`, `User name`, the per-client workspace partition |
+| [[en/configuration/advanced\|Advanced]] | **Settings → Remote SSH → Advanced** — debug log toggle, reconnect retries, edge-case knobs |
+| [[en/configuration/terminal\|Terminal]] | xterm.js panel: shell command, font size, scrollback |
+
+## Where settings live
+
+```
+<vault>/.obsidian/plugins/remote-ssh/data.json
+```
+
+The on-disk schema is documented at **[[en/reference/data-json|data.json schema reference]]** — read that page if you want to script multi-machine setup or edit the file by hand.
+
+## See also
+
+- [[en/reference/data-json|data.json schema reference]] — the on-disk format behind the UI
+- [[en/security/host-keys|Host-key trust]] — the `hostKeyStore` field is added at save time, separate from per-profile settings
+- [[en/getting-started/first-connect|First connect]] — when each setting first matters

--- a/docs/en/contributing/index.md
+++ b/docs/en/contributing/index.md
@@ -1,0 +1,38 @@
+---
+title: Contributing
+tags: [contributing]
+---
+
+# Contributing
+
+How to set up a dev environment, run tests, get a release out, and add docs. The four pages here are everything you need to make and ship a change.
+
+## Pages
+
+| Page | Read when |
+|---|---|
+| [[en/contributing/development-setup\|Development setup]] | Before your first PR — toolchain, repo layout, common workflows |
+| [[en/contributing/testing-strategy\|Testing strategy]] | Before adding tests — what each test layer (unit / integration / E2E) is for |
+| [[en/contributing/release-flow\|Release flow]] | When you want to know how your merged PR becomes a published release |
+| [[en/contributing/documentation\|Documentation guide]] | When adding or editing pages on this docs site |
+
+## Reading order
+
+For a first-time contributor:
+
+1. **[[en/contributing/development-setup|Development setup]]** — get the build green locally.
+2. **[[en/contributing/testing-strategy|Testing strategy]]** — write the right kind of test for your change.
+3. Open the PR. The CI on `next` does the rest.
+4. **[[en/contributing/release-flow|Release flow]]** — read this once so you know how betas and stable releases differ.
+
+For a docs-only PR, skip straight to **[[en/contributing/documentation|Documentation guide]]**.
+
+## Branching model in one paragraph
+
+`next` is the integration branch — every merge produces a `X.Y.Z-beta.N` release on the BRAT channel. `main` is the stable branch — promotion via a `release/X.Y.Z` PR cuts a stable release on the Obsidian Community Plugins channel. Conventional Commits are enforced; non-conformant PRs are rejected by `commitlint`. Full details in [`CONTRIBUTING.md`](https://github.com/sotashimozono/obsidian-remote-ssh/blob/next/CONTRIBUTING.md) and [[en/contributing/release-flow|Release flow]].
+
+## See also
+
+- [`CONTRIBUTING.md`](https://github.com/sotashimozono/obsidian-remote-ssh/blob/next/CONTRIBUTING.md) — canonical short-form contributor reference (kept in sync with these pages)
+- [[en/architecture/release-pipeline|Release & deploy pipeline]] — system view of what CI does behind the release flow
+- [[en/api/protocol-evolution|Protocol evolution]] — the rules a wire-protocol change must follow

--- a/docs/en/getting-started/index.md
+++ b/docs/en/getting-started/index.md
@@ -1,0 +1,45 @@
+---
+title: Getting started
+tags: [getting-started]
+---
+
+# Getting started
+
+The shortest path from "never used this plugin" to "editing a remote vault from Obsidian". Three pages, in order.
+
+## Pages
+
+| # | Page | Time |
+|---|---|---|
+| 1 | [[en/getting-started/install\|Install]] | ~2 min |
+| 2 | [[en/getting-started/first-connect\|First connect]] | ~5 min |
+| 3 | [[en/getting-started/quickstart\|Quickstart]] (alternative entry point) | ~5 min total |
+
+## Two paths through
+
+**If you have an SSH-reachable host already** (Pi, NAS, VPS, work box):
+1. **[[en/getting-started/quickstart|Quickstart]]** — the 5-minute version, skips the deep explanations.
+
+**If you want to know what's happening at each step:**
+1. **[[en/getting-started/install|Install]]** — what you're installing, how the channels work.
+2. **[[en/getting-started/first-connect|First connect]]** — what happens behind the scenes when you click Connect for the first time (binary upload, daemon spawn, shadow vault materialisation).
+
+Both paths converge on the same working state. Pick by appetite for explanation.
+
+## What if I don't have a remote yet?
+
+Set one up first, then come back:
+
+- **[[en/cookbook/raspberry-pi-vault|Cookbook: Raspberry Pi vault from scratch]]** — turn-key Pi recipe.
+- **[[en/cookbook/share-via-tailscale|Cookbook: Share a vault via Tailscale]]** — VPS or home box reachable from anywhere.
+
+## Next, after first connect
+
+- **[[en/user-guide/index|User guide]]** — feature walkthroughs you'll want during normal use.
+- **[[en/configuration/profiles|Configuration → Profiles]]** — every per-profile setting documented.
+- **[[en/operations/troubleshooting|Operations → Troubleshooting]]** — for when something doesn't work.
+
+## See also
+
+- **[[en/tutorial|Tutorial]]** — long-form walkthrough from zero to verified setup, more thorough than Quickstart.
+- **[[en/comparison|Comparison]]** — if you're not yet sure this plugin is the right tool.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -28,21 +28,23 @@ tags: [home]
 
 ## Sections
 
-- **[[en/getting-started/install|Getting started]]** — install, first connect, what to expect
+- **[[en/getting-started/index|Getting started]]** — install, first connect, what to expect
 - **[[en/tutorial|Tutorial]]** — long-form walkthrough from zero to verified setup
 - **[[en/cookbook/index|Cookbook]]** — task-oriented how-tos (RPi vault, SSH keygen, Tailscale, systemd)
-- **[[en/user-guide/ssh-config|User guide]]** — SSH config import, jump hosts, host keys, conflict handling, terminal pane, plugin compatibility
-- **[[en/configuration/profiles|Configuration reference]]** — every plugin setting documented
-- **[[en/server/overview|Server / deploy]]** — Docker, systemd, Raspberry Pi, auto-deploy
-- **[[en/api/overview|API & protocol]]** — RPC methods, error codes, payload shapes, copy-pasteable [[en/api/examples|examples]]
-- **[[en/security/model|Security]]** — threat model, signing, token handling, host-key trust
-- **[[en/operations/troubleshooting|Operations]]** — logs, daemon panel, reconnect, upgrading, uninstalling, common failures
+- **[[en/user-guide/index|User guide]]** — SSH config import, jump hosts, host keys, conflict handling, terminal pane, plugin compatibility
+- **[[en/configuration/index|Configuration reference]]** — every plugin setting documented
+- **[[en/server/index|Server / deploy]]** — Docker, systemd, Raspberry Pi, auto-deploy
+- **[[en/api/index|API & protocol]]** — RPC methods, error codes, payload shapes, copy-pasteable [[en/api/examples|examples]]
+- **[[en/security/index|Security]]** — threat model, signing, token handling, host-key trust
+- **[[en/operations/index|Operations]]** — logs, daemon panel, reconnect, upgrading, uninstalling, common failures
+- **[[en/reference/index|Reference]]** — daemon CLI flags, `data.json` schema
 - **[[en/architecture/index|Architecture]]** — shadow vault design, sync internals, performance
+- **[[en/contributing/index|Contributing]]** — dev setup, testing, release flow, docs guide
 - **[[en/glossary|Glossary]]** — terms used across the docs, defined once
 - **[[en/roadmap|Roadmap]]** — what's left before v1.0 + v2 mobile plan
 - **[[en/changelog|Changelog & releases]]** — major-milestone overview + how to find per-release notes
 - **[[en/privacy|Privacy & data handling]]** — what data this plugin handles, where it lives, what does (or does not) leave your machines
-- **[[en/migration/from-obsidian-sync|Migrating from Obsidian Sync]]** — switchover guide for users coming from Obsidian's official paid sync service
+- **[[en/migration/index|Migration]]** — switchover guides (currently from Obsidian Sync; more planned)
 - **[[en/comparison|Comparison]]** — full breakdown vs Obsidian Sync, Syncthing, Dropbox/iCloud, Git-based, Nextcloud, and the Remotely Save plugin
 - **[[en/faq|FAQ]]** — quick answers to recurring questions
 

--- a/docs/en/migration/index.md
+++ b/docs/en/migration/index.md
@@ -1,0 +1,32 @@
+---
+title: Migration
+tags: [migration]
+---
+
+# Migration
+
+Switching to obsidian-remote-ssh from another sync solution. Currently one detailed guide; more will land as users hit them.
+
+## Pages
+
+| Page | Coming from |
+|---|---|
+| [[en/migration/from-obsidian-sync\|From Obsidian Sync]] | Obsidian's official paid sync service — the closest peer in spirit |
+
+## Coming later (open an issue if you want one prioritised)
+
+- From Syncthing
+- From Dropbox / iCloud / OneDrive (vault-in-sync-folder pattern)
+- From Obsidian Git
+- From Nextcloud
+- From the [Remotely Save](https://github.com/remotely-save/remotely-save) plugin
+
+## Before you migrate
+
+Read **[[en/comparison|Comparison vs other Obsidian sync tools]]** first. If your model fits the tool you're already using better than it fits this plugin, the right answer might be "stay where you are" — that's a fine outcome.
+
+## See also
+
+- [[en/comparison|Comparison]] — full breakdown of the tradeoffs
+- [[en/getting-started/index|Getting started]] — what to do once you've decided to migrate
+- [[en/cookbook/backup-restore|Cookbook: Backup & restore]] — set this up **before** you cancel your old service

--- a/docs/en/operations/index.md
+++ b/docs/en/operations/index.md
@@ -1,0 +1,30 @@
+---
+title: Operations
+tags: [operations]
+---
+
+# Operations
+
+What to do when the plugin is running and you need to *operate* it: read its logs, diagnose a problem, tune for speed, upgrade, or uninstall. Symptom → fix.
+
+## Pages
+
+| Page | When to read |
+|---|---|
+| [[en/operations/troubleshooting\|Troubleshooting]] | Something doesn't work. The symptom-to-cause-to-fix map. **Start here for any "it's broken" question.** |
+| [[en/operations/performance-tuning\|Performance tuning]] | "It works but feels slow." Network / disk / inotify / daemon-cache playbook. |
+| [[en/operations/reconnect\|Reconnect behaviour]] | What the plugin does when the SSH link drops + how to tune the retries |
+| [[en/operations/daemon-panel\|Daemon panel]] | The Settings → Daemon UI: status badge, log viewer, restart button |
+| [[en/operations/logs\|Logs]] | Where every log lives (plugin `console.log`, daemon `server.log`), rotation, sensitive content |
+| [[en/operations/upgrading\|Upgrading]] | How a new plugin version arrives + when the daemon gets re-deployed |
+| [[en/operations/uninstalling\|Uninstalling]] | Clean removal — both local plugin state and remote daemon files |
+
+## Reading order
+
+There isn't one — operations docs are reached by symptom, not sequentially. The closest to "read me first" is [[en/operations/troubleshooting|Troubleshooting]] because it's the dispatcher to the others.
+
+## See also
+
+- [[en/api/errors|Error codes]] — what error names mean when they show up in logs
+- [[en/security/model|Security model]] — what the daemon is allowed to touch
+- [[en/contributing/release-flow|Release flow]] — how new versions are produced (helps when you want to know what's in the upgrade you just got)

--- a/docs/en/reference/index.md
+++ b/docs/en/reference/index.md
@@ -1,0 +1,29 @@
+---
+title: Reference
+tags: [reference]
+---
+
+# Reference
+
+Mechanical reference material — flag sets, schemas, the things you look up rather than read end-to-end.
+
+## Pages
+
+| Page | When to use |
+|---|---|
+| [[en/reference/daemon-cli\|Daemon CLI reference]] | Running `obsidian-remote-server` by hand: full flag set, state-dir layout, exit codes, signal handling |
+| [[en/reference/data-json\|data.json schema reference]] | Editing the plugin's `data.json` directly or scripting multi-machine setup: `PluginSettings`, `SshProfile`, `JumpHostConfig`, `hostKeyStore` |
+
+## What's NOT here
+
+- **API/protocol reference** lives at **[[en/api/index|API & protocol]]** — separate section because it has its own structure.
+- **Per-setting UI walkthroughs** live at **[[en/configuration/index|Configuration]]** — same fields, but documented from the UI's POV.
+- **Error code list** lives at **[[en/api/errors|API → Errors]]** alongside the rest of the protocol docs.
+
+This section exists for the things that don't fit those — currently the daemon binary's CLI surface and the on-disk settings file.
+
+## See also
+
+- [[en/api/index|API & protocol]] — the JSON-RPC reference
+- [[en/configuration/index|Configuration]] — UI walkthroughs of the same data the schema describes
+- [[en/server/index|Server / deploy]] — the operator-facing pages that invoke `obsidian-remote-server`

--- a/docs/en/security/index.md
+++ b/docs/en/security/index.md
@@ -1,0 +1,33 @@
+---
+title: Security
+tags: [security]
+---
+
+# Security
+
+The threat model and the mechanisms that defend against it. Read [[en/security/model|the threat model]] first — the other pages are the moving parts that implement it.
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [[en/security/model\|Threat model]] | Who we defend against, what guarantees we make, what is explicitly out of scope |
+| [[en/security/host-keys\|Host-key trust]] | The plugin's own known-hosts store (separate from `~/.ssh/known_hosts`), the trust dialog, and host-key rotation |
+| [[en/security/token\|Token handling]] | The 32-byte daemon session token: generation, on-disk lifecycle, what happens on a leak |
+| [[en/security/cosign-verify\|Cosign verify]] | Sigstore keyless verification of the daemon binary you downloaded — what the workflow signs, how to check it |
+
+## Reading order
+
+1. **[[en/security/model|Threat model]]** — every other page assumes you've read this.
+2. **[[en/security/host-keys|Host-key trust]]** — the most user-facing part of the security surface.
+3. **[[en/security/token|Token handling]]** + **[[en/security/cosign-verify|Cosign verify]]** — operator-facing details that complete the picture.
+
+## See also
+
+- [[en/api/authentication|API → Authentication]] — the wire-level auth handshake (uses the token from [[en/security/token|Token handling]])
+- [[en/architecture/release-pipeline|Release pipeline]] — how the daemon binary gets signed in CI
+- [[en/privacy|Privacy & data handling]] — adjacent topic; what data flows where, separate from "what the system defends against"
+
+## Reporting a vulnerability
+
+GitHub Security Advisories: [obsidian-remote-ssh/security/advisories/new](https://github.com/sotashimozono/obsidian-remote-ssh/security/advisories/new). Coordinated disclosure preferred.

--- a/docs/en/server/index.md
+++ b/docs/en/server/index.md
@@ -1,0 +1,46 @@
+---
+title: Server / deploy
+tags: [server, deploy]
+---
+
+# Server / deploy
+
+How the daemon side gets onto your remote host and stays running. **Most users don't need any of this** — the plugin auto-deploys the daemon on connect. Reach for these pages when you want to manage the daemon yourself (systemd, containers, multiple users on one host, restricted networks).
+
+> **Start with [[en/server/overview|the Server overview]]** — it covers what the daemon is, what it needs from the host, and what it does NOT do. The other pages are the deployment options.
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [[en/server/overview\|Overview]] | What the daemon is, what it needs, what it does not do |
+| [[en/server/auto-deploy\|Plugin auto-deploy]] | The default — what happens when you click Connect |
+| [[en/server/docker\|Docker]] | Run the daemon inside an sshd container; turn-key compose file |
+| [[en/server/systemd\|systemd]] | Per-user systemd unit; production-grade lifecycle management |
+| [[en/server/raspberry-pi\|Raspberry Pi]] | Pi-specific notes — SD card vs USB SSD, ARM binary, expectations |
+| [[en/server/multi-user\|Multi-user hosting]] | One host, many SSH users; the per-user-state model + the anti-pattern of sharing one OS user |
+| [[en/server/firewall\|Firewall, ports & NAT]] | Why the daemon needs no public ports + how Tailscale/wireguard fit in |
+| [[en/server/signing\|Signing]] | Operator-side: what the cosign signatures cover, when to verify, who signs |
+
+## Reading order
+
+For "I just want it to work":
+- Read **[[en/server/overview|Overview]]** to understand what gets deployed.
+- That's it. The plugin handles everything else.
+
+For "I want to run my own daemon under systemd":
+1. **[[en/server/overview|Overview]]** for context.
+2. **[[en/server/systemd|systemd]]** for the unit file.
+3. **[[en/reference/daemon-cli|Daemon CLI reference]]** for the flag set the unit invokes.
+
+For "I'm setting up a multi-user host":
+1. **[[en/server/overview|Overview]]**.
+2. **[[en/server/multi-user|Multi-user hosting]]** — read carefully; the wrong setup leaks state between users.
+3. **[[en/server/firewall|Firewall, ports & NAT]]** if the host is internet-facing.
+
+## See also
+
+- [[en/reference/daemon-cli|Daemon CLI reference]] — every flag the binary accepts
+- [[en/security/cosign-verify|Cosign verify]] — verify the binary you downloaded before deploying it manually
+- [[en/architecture/release-pipeline|Release pipeline]] — how the binary is built + signed
+- [[en/cookbook/systemd-managed-daemon|Cookbook: systemd-managed daemon]] — full walkthrough recipe

--- a/docs/en/user-guide/index.md
+++ b/docs/en/user-guide/index.md
@@ -1,0 +1,29 @@
+---
+title: User guide
+tags: [user-guide]
+---
+
+# User guide
+
+Feature-by-feature walkthroughs for things you'll use during normal day-to-day editing — once you're past the [[en/getting-started/install|install]] and [[en/getting-started/first-connect|first connect]] steps.
+
+## Pages
+
+| Page | What it covers |
+|---|---|
+| [[en/user-guide/ssh-config\|SSH config import]] | Auto-populate a profile from an existing `~/.ssh/config Host` block |
+| [[en/user-guide/jump-host\|Jump hosts]] | Single jump-host config (multi-hop tracked separately) |
+| [[en/user-guide/host-keys\|Host-key trust UI]] | The first-connect trust dialog + how to handle a changed host key |
+| [[en/user-guide/conflicts\|Conflict handling]] | mtime-precondition writes, what happens when two clients race, **and the missing automatic backup-on-overwrite caveat** |
+| [[en/user-guide/terminal-pane\|Terminal pane]] | The xterm.js panel for opening a shell on the remote host |
+| [[en/user-guide/plugin-compatibility\|Plugin compatibility]] | Which Obsidian community plugins work cleanly + the known sharp edges (Dataview, Templater, Excalidraw…) |
+
+## Reading order
+
+There's no required order. Read as you encounter the feature. The one page worth reading **before** you need it is **[[en/user-guide/conflicts|Conflict handling]]** — it documents an unforgiving UX surface (no automatic backup of the rejected side) that's better understood in advance than discovered mid-edit.
+
+## See also
+
+- [[en/configuration/profiles|Configuration → Profiles]] — every per-profile field documented (SSH config import populates this UI)
+- [[en/security/host-keys|Security → Host-key trust]] — the security model behind the trust dialog
+- [[en/operations/troubleshooting|Operations → Troubleshooting]] — when a feature isn't behaving

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.11",
+  "version": "1.0.45-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.11",
+  "version": "1.0.45-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.11",
+  "version": "1.0.45-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.11",
+      "version": "1.0.45-beta.12",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.11",
+  "version": "1.0.45-beta.12",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Batch B of the post-EN-completion plan: section landing pages for the 10 sections that lacked one.

### The problem

Quartz routes folder URLs (`/en/api/`, `/en/operations/`, etc.) to the folder's `index.md` if present. Without one, visitors see a bare directory listing rather than a curated entry point. Only `architecture/` and `cookbook/` had landings; the other 10 sections did not.

### Pages added

| Section | Landing approach |
|---|---|
| `api/` | Protocol stability promise + reading order for new vs porting users |
| `operations/` | Symptom → page dispatcher; troubleshooting first |
| `security/` | Threat-model-first reading order |
| `server/` | Defers to existing `overview.md` (the de facto content); reading orders by use case |
| `user-guide/` | Feature table; flags `conflicts.md` as **read before you need it** |
| `configuration/` | Mirrors `Settings → Remote SSH`; points at `reference/data-json` for on-disk schema |
| `getting-started/` | Two-path layout (Quickstart vs Install → First-connect) |
| `contributing/` | First-time contributor reading order + branching-model summary |
| `reference/` | Explains what is and isn't in this section (vs `api/`, `configuration/`, `server/`) |
| `migration/` | Single page so far; lists planned coming-from sources; points at `comparison` and `backup-restore` |

### Wiring

`docs/en/index.md` Sections list updated to point at the new `index.md` files instead of arbitrary inner pages (e.g. `Configuration → en/configuration/profiles` becomes `→ en/configuration/index`). Added entries for the two sections that previously had no row at all: `reference/` and `contributing/`.

### Verification

The wikilink/anchor checker added in #311 now runs as a pre-build CI step. Local run on this branch:

```
docs link check: 0 broken wikilinks, 0 bad anchors, 0 orphan pages.
```

(Orphan count went to 0 because every section's `index.md` is now reached from the root index's Sections list — previously some inner pages had no inbound link.)

### Version

Bumps to **1.0.45-beta.12**.

## Test plan

- [ ] CI: `Check docs wikilinks + anchors` passes (the new gate from #311)
- [ ] CI: dev docs build deploys to `codes.sota-shimozono.com/obsidian-remote-ssh/dev/` after merge
- [ ] Spot-check the live site: `/dev/en/api/`, `/dev/en/operations/`, `/dev/en/security/` etc. each show the new landing instead of a directory listing
- [ ] Reading-order suggestions on each landing make sense for someone landing cold

## Next batch

C — start the JA port (top 10 high-value pages first). Will branch from `next` after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
