### PR TITLE
docs(ja): batch 2 — migration, security, cookbook (6 pages)

### DIFF
--- a/docs/ja/cookbook/index.md
+++ b/docs/ja/cookbook/index.md
@@ -1,0 +1,25 @@
+---
+title: Cookbook
+lang: ja
+tags: [cookbook, how-to]
+---
+
+# Cookbook
+
+ドキュメント全体のパーツを組み合わせた、目的指向のウォークスルー集です。「X したい」という質問にステップバイステップで答えるなら、ここから始めてください。
+
+## レシピ
+
+| 目的 | ページ |
+|---|---|
+| Pi を自宅 vault サーバとしてセットアップ（ゼロ → 初回接続） | [[ja/cookbook/raspberry-pi-vault\|Raspberry Pi vault from scratch]] |
+| プラグイン用の SSH 鍵を生成 | [[en/cookbook/ssh-keygen\|SSH 鍵の生成]]（英語） |
+| Pi 上の vault を Tailscale 経由で同僚と共有 | [[en/cookbook/share-via-tailscale\|Tailscale 経由で共有]]（英語） |
+| 自動デプロイされるデーモンを systemd 管理に置き換え + cosign 検証 | [[en/cookbook/systemd-managed-daemon\|systemd-managed daemon]]（英語） |
+| vault バックアップ（rsync / restic / borg）+ ディスク障害 / 誤削除からの復旧 | [[en/cookbook/backup-restore\|Backup & restore]]（英語） |
+| vault をホスト間で移行（Pi → NAS、自宅 → VPS など） | [[en/cookbook/host-migration\|Migrating between hosts]]（英語） |
+| YubiKey / TouchID / Windows Hello で SSH 接続を署名 | [[en/cookbook/hardware-key\|Hardware-key SSH auth]]（英語） |
+| Docker sshd の前段に nginx / Caddy / SSH ProxyJump | [[en/cookbook/reverse-proxy\|Reverse proxy in front of Docker sshd]]（英語） |
+| 仕事 + 個人 + 家族の vault を 1 つの Obsidian インストールから編集 | [[en/cookbook/multi-vault\|Editing multiple vaults from one Obsidian]]（英語） |
+
+このページにないレシピが欲しい場合は [discussion](https://github.com/sotashimozono/obsidian-remote-ssh/discussions) を立ててください — 共通の要望はレシピ化されます。

--- a/docs/ja/cookbook/raspberry-pi-vault.md
+++ b/docs/ja/cookbook/raspberry-pi-vault.md
@@ -1,0 +1,72 @@
+---
+title: Raspberry Pi vault from scratch
+lang: ja
+tags: [cookbook, how-to, raspberry-pi]
+---
+
+# Raspberry Pi vault — ゼロからのセットアップ
+
+ゴール: 自宅ネットワーク上の Pi に Obsidian vault をホストし、ノート PC からこのプラグイン経由で編集する。Pi OS インストール込みで約 30 分。
+
+## ハードウェア + OS
+
+- Pi 4 / Pi 5（RAM 4 GB で十分）。小規模 vault なら Pi Zero 2 W も動作
+- 32 GB+ microSD、または（推奨）USB 接続 SSD
+- Raspberry Pi OS (Bookworm) または Ubuntu Server 22.04+ for arm64
+
+[Raspberry Pi Imager](https://www.raspberrypi.com/software/) で焼く。歯車アイコンから:
+
+- ホスト名: `obsidian-vault.local`（任意。覚えやすい名前を）
+- SSH 有効化: Yes、既存の公開鍵で公開鍵認証
+- Wi-Fi 認証情報（または有線接続）
+
+Pi を起動し、約 60 秒待機。
+
+## ノート PC からの初回接続
+
+まず通常のターミナルから SSH が通ることを確認:
+```bash
+ssh pi@obsidian-vault.local
+```
+
+これが通れば Pi 側の準備は完了 — リモートにはこれ以上何も必要ありません。vault 用ディレクトリを作成:
+```bash
+ssh pi@obsidian-vault.local 'mkdir -p ~/notes'
+```
+
+## プラグインに profile を追加
+
+**Settings** → **Remote SSH** → **Add profile**:
+
+| 項目 | 値 |
+|---|---|
+| Profile name | `Pi vault` |
+| Host | `obsidian-vault.local`（または Pi の IP） |
+| Port | `22` |
+| Username | `pi` |
+| Authentication | `SSH agent`（推奨） または秘密鍵パス |
+| Remote vault path | `/home/pi/notes`（または `~/notes`） |
+| Mode | `Daemon (deploys helper on connect)`（SFTP デフォルトより低レイテンシ） |
+
+**Save** クリック後、コマンドパレットから接続: "Remote SSH: Connect" → `Pi vault` を選択。
+
+プラグインがデーモンバイナリ（約 5 MB）をアップロードして起動し、shadow vault ウィンドウを開きます。初回接続は約 5–8 秒、以降は約 1 秒。
+
+## デーモンをプラグイン再接続を超えて生存させる
+
+オプションだが、24/7 稼働の Pi なら推奨。デーモンを systemd 配下に置けばプラグイン再起動と Pi 再起動を生き延びます — [[en/cookbook/systemd-managed-daemon|systemd-managed daemon]]（英語） 参照。
+
+## 反対側からも動作確認
+
+Obsidian でノートを編集してから、Pi で:
+```bash
+ls -lt ~/notes | head
+```
+
+最新の編集が一番上に出て、新しい mtime になっているはずです。
+
+## 関連
+
+- [[en/server/raspberry-pi|Server / Raspberry Pi notes]]（英語） — Pi モデル別の性能上限とチューニング
+- [[ja/operations/troubleshooting|トラブルシューティング]] — 初回接続が失敗したときに何を確認するか
+- [[en/cookbook/ssh-keygen|SSH 鍵の生成]]（英語） — `ssh pi@obsidian-vault.local` がパスワードを要求した場合

--- a/docs/ja/getting-started/index.md
+++ b/docs/ja/getting-started/index.md
@@ -31,8 +31,8 @@ tags: [getting-started]
 
 先にリモート機をセットアップしてから戻ってきてください（以下は英語のみ）:
 
-- **[[en/cookbook/raspberry-pi-vault|Cookbook: Raspberry Pi vault from scratch]]** — Pi 用の即動レシピ
-- **[[en/cookbook/share-via-tailscale|Cookbook: Share a vault via Tailscale]]** — どこからでも到達可能な VPS / 自宅機の構成
+- **[[ja/cookbook/raspberry-pi-vault|Cookbook: Raspberry Pi vault from scratch]]** — Pi 用の即動レシピ
+- **[[en/cookbook/share-via-tailscale|Cookbook: Share a vault via Tailscale]]**（英語） — どこからでも到達可能な VPS / 自宅機の構成
 
 ## 初回接続後の次のステップ
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -17,7 +17,9 @@ tags: [home]
 | インストール先と挙動を把握したい | [[ja/getting-started/install\|インストール]] → [[ja/getting-started/first-connect\|初回接続]] |
 | よくある質問を見たい | [[ja/faq\|FAQ]] |
 | 他の同期ツールと比較して選びたい | [[ja/comparison\|比較]] |
-| Obsidian Sync から乗り換えたい | [[en/migration/from-obsidian-sync\|Migration guide]] (英語) |
+| Obsidian Sync から乗り換えたい | [[ja/migration/from-obsidian-sync\|Obsidian Sync からの移行]] |
+| セキュリティモデルを把握したい | [[ja/security/model\|脅威モデル]] |
+| Pi で自宅サーバを立てたい | [[ja/cookbook/raspberry-pi-vault\|Raspberry Pi vault from scratch]] |
 | 動かないときの対処を調べたい | [[ja/operations/troubleshooting\|トラブルシューティング]] |
 
 ## このドキュメントの言語について
@@ -27,7 +29,10 @@ tags: [home]
 ## セクション一覧
 
 - **[[ja/getting-started/index|はじめに]]** — インストール、初回接続、何が起こるか
+- **[[ja/cookbook/index|Cookbook]]** — 目的指向のレシピ集（Pi 立て上げ、SSH 鍵生成、Tailscale、systemd など）
 - **[[ja/operations/index|運用]]** — トラブルシューティング、性能チューニング、ログ、アップグレード（症状別ディスパッチャ含む）
+- **[[ja/security/index|セキュリティ]]** — 脅威モデル、ホスト鍵信頼、トークン管理、cosign 検証
+- **[[ja/migration/index|移行]]** — 既存サービスからの乗り換えガイド
 - **[[ja/comparison|比較]]** — Obsidian Sync / Syncthing / Dropbox / Git ベース / Nextcloud / Remotely Save との違い
 - **[[ja/faq|FAQ]]** — よくある質問
 

--- a/docs/ja/migration/from-obsidian-sync.md
+++ b/docs/ja/migration/from-obsidian-sync.md
@@ -1,0 +1,153 @@
+---
+title: Obsidian Sync からの移行
+lang: ja
+tags: [migration, how-to]
+---
+
+# Obsidian Sync からの移行
+
+Obsidian Sync（Obsidian 公式の有料同期サービス）から obsidian-remote-ssh への乗り換えガイドです。Sync の「Obsidian のサーバ上に vault」モデルを「**あなたの**リモートホスト上に vault」モデルに置き換えます — エンドユーザ体験は同じ、所有権の物語が違うだけ。
+
+> **スコープの正直なところ:** このページはこのプラグイン側のセットアップで検証可能な部分を扱います。Obsidian Sync 内部の挙動（履歴保持、E2EE 鍵管理、バージョン復元のセマンティクス）の正典は [Obsidian 公式の Sync ドキュメント](https://help.obsidian.md/Obsidian+Sync/Obsidian+Sync) です。本ガイド中に「Obsidian のドキュメントで確認してください」と書いてある箇所は意図的な余白で、手抜きではありません。
+
+## 残るもの、失うもの
+
+### 残るもの
+
+- **vault の中身すべて** — `.md` ファイル、添付、`.obsidian/` プラグイン設定、テーマ
+- **複数デバイスでの編集** — 両方とも対応。obsidian-remote-ssh は [[en/architecture/collab|Client ID ごとのワークスペース分離]]（英語）で並行クライアントを処理
+- **サブスクリプション解約** — Obsidian Sync は不要になる。移行検証後に解約してよい
+
+### 失うもの（と代替）
+
+| Obsidian Sync の機能 | obsidian-remote-ssh での代替 |
+|---|---|
+| **ファイルバージョン履歴**（Sync UI からファイル単位で巻き戻し） | プラグインに組み込みなし。サーバ側バックアップで代替 — [[en/cookbook/backup-restore\|restic / borg / rsync レシピ]]（英語） |
+| **E2EE**（あなたの暗号化パスワードによる） | SSH 転送が転送中暗号化を担当。**保存時暗号化はリモートホスト側の責任**（LUKS / FileVault / 暗号化 ZFS dataset）。Obsidian Sync の独立パスワードによる E2EE は再現されない |
+| **デバイス間の自動 conflict 解決** | プラグインには [[en/user-guide/conflicts\|conflict 検出]]（英語）はあるが、解決 UI は容赦なく — 拒否された側の自動バックアップなし。先にそのページを読むこと |
+| **モバイル同期** | 未対応 — このプラグインはデスクトップ専用（[[en/roadmap\|#151 で追跡]] 英語）。モバイル編集が必須なら Sync を残す |
+| **誤削除ノートのワンクリック復元** | サーバ側バックアップから復元（[[en/cookbook/backup-restore\|レシピ]] 英語） |
+| **Selective sync**（一部フォルダのみ） | 非対応。プラグインは設定された vault root 全体を同期 |
+
+これらが workflow に必須なら移行を再考、もしくは必要部分だけ Sync を残す（モバイルだけ Sync、デスクトップはこのプラグイン、など）。
+
+## 移行前チェックリスト
+
+1. **vault の置き場所を決める** — 自宅 Pi、NAS、クラウド VPS。[[ja/cookbook/raspberry-pi-vault|RPi vault ゼロから]] または [[en/cookbook/share-via-tailscale|Tailscale 共有ホスト]]（英語）参照
+2. **信頼できる Sync 履歴 snapshot を取る** — 最も最新のデバイスで Obsidian を開き、Sync が "Synced" になるのを待つ。移行ウィンドウの間は編集を止める
+3. **切替えウィンドウを計画する** — 一般的な vault で 30 分
+4. **ロールバック計画を持つ** — 新セットアップが数日きれいに動くまで Sync サブスクリプションを残しておく
+
+## 移行ステップ
+
+### 1. vault をノート PC にエクスポート
+
+Sync は正本を Obsidian のサーバに保存し、ローカルコピーは同期されたレプリカです。移行ではローカルレプリカからコピーします。
+
+最後に "Synced" になったデバイスで:
+
+```bash
+# vault のディスク上パス（Obsidian で開いているもの）
+# macOS: ~/Documents/MyVault, Linux: ~/MyVault, Windows: C:\Users\you\Documents\MyVault
+
+cp -a ~/MyVault ~/MyVault-migration-snapshot
+```
+
+`-a` でタイムスタンプと symlink を保持。この snapshot が「すべて失敗した場合の最終手段」コピーです。
+
+### 2. Sync 固有の状態を削除（任意だがクリーン）
+
+vault の `.obsidian/` ディレクトリ内に Sync が状態ファイルを書きます。残しても害はないが、削除しても害はありません:
+
+```bash
+# Sync 状態を削除（再有効化すれば Sync が再生成。こちらは無視する）
+rm -f ~/MyVault-migration-snapshot/.obsidian/sync.json
+rm -rf ~/MyVault-migration-snapshot/.obsidian/sync/   # 存在する場合のみ
+```
+
+他の `.obsidian/` ファイル（テーマ、プラグイン、ホットキー、ワークスペース状態）は触らずに連れて行く。
+
+> 注: Sync のディスク上状態ファイルの完全な目録は持っていません。上記の `sync.json` と `sync/` がよくある名前です。Obsidian の Sync ドキュメントを確認するか、`.obsidian/` ディレクトリ内で `sync*` 系で他プラグイン由来でないものを探してください。
+
+### 3. リモート vault ホストをセットアップ
+
+[[ja/cookbook/raspberry-pi-vault|Pi レシピ]] または同等の手順で:
+
+```bash
+ssh user@new-host 'mkdir -p ~/notes'
+```
+
+### 4. vault をアップロード
+
+```bash
+rsync -aHx ~/MyVault-migration-snapshot/ user@new-host:~/notes/
+```
+
+大きい vault（1+ GB）を WAN 経由で転送するのは時間がかかります。tar-pipe のほうが速いことが多い:
+
+```bash
+tar czf - -C ~/MyVault-migration-snapshot . | ssh user@new-host 'tar xzf - -C ~/notes'
+```
+
+リモート側でコピーを検証:
+
+```bash
+ssh user@new-host 'find ~/notes -type f | wc -l'    # ファイル数
+ssh user@new-host 'du -sh ~/notes'                  # 合計サイズ
+# ローカル snapshot と比較
+```
+
+### 5. Obsidian Sync を無効化
+
+Obsidian → Settings → Sync → トグル OFF。**Obsidian のサーバ上の Sync データはまだ削除しない** — それがロールバック経路。
+
+### 6. obsidian-remote-ssh をインストール
+
+[[ja/getting-started/install|標準のインストール手順]]（Community Plugins ストアか BRAT）でインストール。`user@new-host` を指す profile を追加し、vault path は `~/notes`。Connect。新しい shadow vault に vault 全部の中身が現れます。
+
+裏で何が起こっているかは [[ja/getting-started/first-connect|初回接続]] 参照。
+
+### 7. すべて動くか検証
+
+- **数件のノートを開く** — 画像 / 添付付きも含めて。正しくレンダリングされるか
+- **編集 + 保存** をしてみる。リモート側で確認: `ssh user@new-host 'ls -lt ~/notes | head -3'` — 編集が一番上にあるはず
+- **主要プラグインを確認** — Dataview / Templater / Excalidraw など。リモート vault の `.obsidian/plugins/` 配下にあるので動くはず。既知の鋭利な角は [[en/user-guide/plugin-compatibility|プラグイン互換性マトリクス]]（英語）参照
+- **テーマ + ホットキー** が反映されているか
+- **Sync を解約する前に 1 週間運用する** — 何か欠けているものを見つける時間を確保
+
+### 8. バックアップを設定（Sync 履歴の必須代替）
+
+Obsidian Sync にはファイル単位のバージョン履歴がありましたが、このプラグインにはありません。代替はサーバ側のインクリメンタルバックアップです。Sync を解約する**前に** [[en/cookbook/backup-restore|バックアップレシピ]]（英語） に従って restic か borg を設定してください — 両方を同時に失うと復旧不能。
+
+### 9. Obsidian Sync を解約
+
+クリーンに 1 週間運用 + バックアップ snapshot 検証済みになったら、Obsidian Sync サブスクリプションを解約。必要なら Obsidian のアカウント管理プロセスに従ってサーバ上の vault データの削除を要求。
+
+## 複数デバイスへの引き継ぎ
+
+Sync で複数ノート PC を同期させていたなら、各ノート PC ごとにこの手順を繰り返す:
+
+1. ノート PC B に obsidian-remote-ssh をインストール
+2. 同じ profile（host + path）を追加 — ワークスペース状態を共有したいなら同じ `Client ID`、各デバイスで独自のペインレイアウトが欲しいなら別の Client ID
+3. Connect — ノート PC B の shadow vault は、ノート PC A が編集しているのと同じリモートから再フェッチします
+
+デバイスごとのワークスペース状態は [[en/configuration/this-device|Client ID partition]]（英語）で分離されたまま。並行編集は [[en/user-guide/conflicts|conflict handling]]（英語）を経由。
+
+## ロールバック（移行が崩れた場合）
+
+Sync が Obsidian のサーバ側でまだ生きているうちなら:
+
+1. Obsidian で Sync を再有効化
+2. Sync がサーバ側コピーからローカル vault を再構築（少し時間がかかる）
+3. 何が悪かったか分かるまで obsidian-remote-ssh の使用を停止
+
+`~/MyVault-migration-snapshot` の事前 snapshot は、Sync のサーバ側コピーも壊れていた場合の二次フォールバック。
+
+## 関連
+
+- [[ja/getting-started/install|インストール]] — obsidian-remote-ssh を入れる
+- [[ja/cookbook/raspberry-pi-vault|RPi vault ゼロから]] — 新しい vault ホストとして自宅サーバを立てる
+- [[en/cookbook/backup-restore|Backup & restore]]（英語） — Sync 履歴の必須代替
+- [[en/user-guide/conflicts|Conflict handling]]（英語） — 上書き時の自動バックアップが無いという重要な文脈
+- [[ja/faq|FAQ]] — Sync / Syncthing / Dropbox との簡易比較表
+- [Obsidian Sync ドキュメント](https://help.obsidian.md/Obsidian+Sync/Obsidian+Sync) — 移行中の Sync 挙動の正典

--- a/docs/ja/migration/index.md
+++ b/docs/ja/migration/index.md
@@ -1,0 +1,33 @@
+---
+title: 移行
+lang: ja
+tags: [migration]
+---
+
+# 移行
+
+別の同期ソリューションから obsidian-remote-ssh への乗り換えガイド集です。現時点では詳細ガイドが 1 本。利用ニーズが多い順に追加していきます。
+
+## ページ一覧
+
+| ページ | 移行元 |
+|---|---|
+| [[ja/migration/from-obsidian-sync\|Obsidian Sync から]] | Obsidian の公式有料同期サービス — 精神的に最も近い相手 |
+
+## 今後追加予定（要望は issue へ）
+
+- Syncthing から
+- Dropbox / iCloud / OneDrive（vault を同期フォルダに置くパターン）から
+- Obsidian Git から
+- Nextcloud から
+- [Remotely Save](https://github.com/remotely-save/remotely-save) プラグインから
+
+## 移行する前に
+
+まず **[[ja/comparison|他の Obsidian 同期ツールとの比較]]** を読んでください。今使っているツールの方がモデル的に合っているなら、「現状維持」が正解という結論もあり得ます — それは全く問題ない結末です。
+
+## 関連
+
+- [[ja/comparison|比較]] — トレードオフの全体像
+- [[ja/getting-started/index|はじめに]] — 移行決定後のセットアップ
+- [[en/cookbook/backup-restore|Cookbook: Backup & restore]]（英語） — **旧サービスを解約する前に**設定しておくべきもの

--- a/docs/ja/security/index.md
+++ b/docs/ja/security/index.md
@@ -1,0 +1,34 @@
+---
+title: セキュリティ
+lang: ja
+tags: [security]
+---
+
+# セキュリティ
+
+脅威モデルと、それに対する防御メカニズムです。まず [[ja/security/model|脅威モデル]] を読んでください — 他のページはそれを実装する可動部品です。
+
+## ページ一覧
+
+| ページ | 内容 |
+|---|---|
+| [[ja/security/model\|脅威モデル]] | 何を防御し、何を保証し、何が明示的にスコープ外か |
+| [[en/security/host-keys\|Host-key trust]]（英語） | プラグイン独自の known-hosts ストア（`~/.ssh/known_hosts` とは別）、信頼ダイアログ、ホスト鍵ローテーション |
+| [[en/security/token\|Token handling]]（英語） | 32 バイトのデーモンセッショントークン: 生成、ディスク上のライフサイクル、漏洩時の挙動 |
+| [[en/security/cosign-verify\|Cosign verify]]（英語） | ダウンロードしたデーモンバイナリの Sigstore キーレス検証 — ワークフローが何に署名し、どう検証するか |
+
+## 読む順序
+
+1. **[[ja/security/model|脅威モデル]]** — 他のページはここを読んだ前提
+2. **[[en/security/host-keys|Host-key trust]]**（英語） — セキュリティ表面で最もユーザに近い部分
+3. **[[en/security/token|Token handling]]**（英語） + **[[en/security/cosign-verify|Cosign verify]]**（英語） — 運用者向け詳細
+
+## 関連
+
+- [[en/api/authentication|API → Authentication]]（英語） — ワイヤレベル認証ハンドシェイク（[[en/security/token|Token handling]] のトークンを使う）
+- [[en/architecture/release-pipeline|Release pipeline]]（英語） — CI でのデーモンバイナリ署名フロー
+- [[en/privacy|Privacy & data handling]]（英語） — 隣接トピック（「何を防御するか」とは別の「どんなデータがどこに流れるか」）
+
+## 脆弱性報告
+
+GitHub Security Advisories: [obsidian-remote-ssh/security/advisories/new](https://github.com/sotashimozono/obsidian-remote-ssh/security/advisories/new)。協調的開示が望ましいです。

--- a/docs/ja/security/model.md
+++ b/docs/ja/security/model.md
@@ -1,0 +1,70 @@
+---
+title: 脅威モデル
+lang: ja
+tags: [security]
+---
+
+# セキュリティ — 脅威モデル
+
+このページは obsidian-remote-ssh が**何を**防御し、**何を**防御しないかを示します。モデルが想定するより高い脅威環境にいる場合は、追加の防御を講じる必要があります。
+
+## 信頼境界
+
+```mermaid
+graph TB
+  subgraph Local["ローカルマシン (あなたのデスクトップ)"]
+    OB[Obsidian]
+    PL[Plugin]
+    KEY["~/.ssh/id_ed25519 (秘密鍵)"]
+  end
+  subgraph Wire["SSH 転送路"]
+    SSH[SSH session]
+  end
+  subgraph Remote["リモートホスト (あなたが信頼する側)"]
+    SSHD[sshd]
+    DAEM[Daemon]
+    VAULT[Vault files]
+  end
+  PL -.uses.-> KEY
+  PL --> SSH
+  SSH --> SSHD
+  SSHD --> DAEM
+  DAEM --> VAULT
+```
+
+## 防御するもの
+
+| 脅威 | 防御方法 |
+|---|---|
+| ネットワーク盗聴 | RPC + ファイル内容すべてが SSH セッション内 — `ssh` 自体と同じ暗号 |
+| 攻撃者によるリモートログイン | 標準 SSH 鍵 + あなたの sshd の堅牢化（プラグイン固有の追加サーフェスなし） |
+| 不正なホスト鍵（MITM、悪意ある DNS） | プラグインが独自の known-host ストアを保持。既知ホストでのミスマッチは明示的な override 必要 |
+| ワイヤ上での破損したデーモンバイナリ | SFTP アップロード後に SHA256 で round-trip 検証。ミスマッチは deploy 失敗 |
+| 保存時に改竄されたデーモンバイナリ（第三者ミラーから取得した場合） | [[en/security/cosign-verify\|Cosign verify]]（英語）が **このリポジトリの** リリースパイプライン由来であることを証明 |
+| 設定 vault 外のファイルをプラグインが読む | デーモンが `..` を含むパスや symlink で vault root を脱出するパスを拒否（`PathOutsideVault`） |
+| 共有ファイルシステム経由のトークン窃取 | トークンはデーモンの home 配下に mode `0600` で書かれる — そのユーザのみ読める |
+| 同時編集の衝突 | 書き込みごとに `expectedMtime` precondition。衝突は silent overwrite ではなく UI プロンプトとして表面化 |
+
+## 防御しないもの
+
+| 脅威 | 理由 |
+|---|---|
+| リモート OS が侵害された場合 | リモートが完全に乗っ取られているなら、デーモンも同様 — デーモン視点で vault を読むものはすべてフェアゲーム。防御はリモートの堅牢化（sshd、ファイアウォール、OS アップデート）に依存 |
+| ローカルマシンが侵害された場合 | ローカル OS が乗っ取られているなら、SSH 鍵 + プラグイン設定も同様。プラグインは独自の保存時暗号化を追加せず、OS のユーザアカウント分離に依存 |
+| リアルタイムで通信を傍受する悪意ある sshd | これを心配するなら、このプラグインで解決できる範囲を超えた問題があります。プラグインの host-key store は静的 MITM（証明書差し替え）を捕捉するが、検証 round trip 中に正しく応答してくる完全に共謀した sshd は捕捉しない |
+| ホスト上のサイドチャネル（他のユーザが vault ディレクトリを読む） | デーモンはあなたのユーザ権限で動く。vault ファイルパーミッションはあなたが設定したまま（典型的には 0644 / 0755）。共有ホストでは OS レベル ACL / 保存時暗号化を併用 |
+
+## 多層防御の推奨
+
+| リスク | 対策 |
+|---|---|
+| 信頼できないネットワーク | Tailscale / WireGuard / Cloudflare Tunnel をトランスポート最下層に。SSH はその中で動く |
+| ノート PC 紛失 | ディスク暗号化（FileVault、BitLocker、LUKS）— SSH 鍵 + vault shadow を保護 |
+| 長寿命の agent forwarding | プラグインは chained jump で agent forwarding を使わない — 各 hop が独立に認証。他で必要なら個別に有効化 |
+| デーモンバイナリのサプライチェーン | systemd で事前デプロイする前に cosign 検証（[[en/security/cosign-verify\|Cosign verify]]（英語） 参照）。auto-deploy 経路もアップロード後に SHA256 検証するが、cosign 検査より検証範囲は狭い |
+
+## 脆弱性報告
+
+GitHub Security Advisories: [obsidian-remote-ssh/security/advisories/new](https://github.com/sotashimozono/obsidian-remote-ssh/security/advisories/new)。協調的開示が望ましいです。「パッチリリース」が運用上どう見えるかは [[en/security/cosign-verify|Cosign verify]]（英語） 参照。
+
+次: [[en/security/cosign-verify|Cosign verify]]（英語）。

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.13",
+  "version": "1.0.45-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.45-beta.13",
+  "version": "1.0.45-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.13",
+  "version": "1.0.45-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.45-beta.13",
+      "version": "1.0.45-beta.14",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.45-beta.13",
+  "version": "1.0.45-beta.14",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Continues the JA port. Picks the next-most-leveraged pages so a JA-only visitor can: evaluate trust (security model), plan a switchover from Obsidian Sync, and follow a turn-key Pi setup recipe.

### New pages (6)

| Page | Translates from |
|---|---|
| `ja/migration/index.md` | `en/migration/index.md` |
| `ja/migration/from-obsidian-sync.md` | `en/migration/from-obsidian-sync.md` (the most-asked migration path) |
| `ja/security/index.md` | `en/security/index.md` |
| `ja/security/model.md` | `en/security/model.md` (trust boundaries Mermaid + threats-defended/not-defended tables) |
| `ja/cookbook/index.md` | `en/cookbook/index.md` |
| `ja/cookbook/raspberry-pi-vault.md` | `en/cookbook/raspberry-pi-vault.md` (turn-key Pi recipe) |

### Wiring

- `ja/index.md` Sections list: add **Cookbook / セキュリティ / 移行** entries pointing at the new section landings
- `ja/index.md` "Start here" table: add 3 new task→page rows, **re-point the Sync-migration row from EN to JA**
- `ja/getting-started/index.md`: **re-point** the "まだリモート機がない場合" RPi recipe pointer from EN to JA (Pi recipe now exists in JA)

### Translation conventions (consistent with batch 1)

- **Tone:** です/ます register
- **Kept verbatim:** proper nouns (Obsidian, Tailscale, SSH, Raspberry Pi, BRAT, Cosign, …), CLI commands, file paths, code identifiers
- **Cross-language jumps tagged "（英語）"** so readers know in advance

### Verification

```
docs link check: 0 broken wikilinks, 0 bad anchors, 0 orphan pages.
```

(Across both language trees, via the per-PR CI gate added in #311 + extended in #313.)

### Version

Bumps to **1.0.45-beta.14**.

## Test plan

- [ ] CI: `Check docs wikilinks + anchors` passes
- [ ] CI: docs build deploys to `/dev/`; spot-check `/dev/ja/security/model`, `/dev/ja/migration/from-obsidian-sync`, `/dev/ja/cookbook/raspberry-pi-vault`
- [ ] `lang: ja` frontmatter present on every new page
- [ ] Quartz Explorer renders the 3 new section landings under `/ja/`
- [ ] Quick read of the migration page — it's the longest of the batch and the most "do this" oriented; verify the bash blocks still make sense in JA context

## Next batch ideas

JA batch 3 candidates (let me know which to prioritise):
- `ja/configuration/profiles.md` (per-setting reference, high-frequency lookup)
- `ja/operations/performance-tuning.md` (the consolidated perf playbook)
- `ja/api/overview.md` (API entry point — for builders)
- `ja/security/host-keys.md` (most user-facing security topic)
- `ja/cookbook/ssh-keygen.md` (gateway to first connect for users without keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
