### PR TITLE
feat(seo): canonical link + dev-noindex + description frontmatter (top 15 pages)

### DIFF
--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -31,6 +31,29 @@ export default (() => {
     const socialUrl =
       fileData.slug === "404" ? url.toString() : joinSegments(url.toString(), fileData.slug!)
 
+    // Canonical + dev-noindex handling.
+    //
+    // Two builds publish from the same source: the stable site (root of
+    // gh-pages) and the dev preview (gh-pages/dev/). The dev preview
+    // must not compete with stable in SERPs — it's a staging surface,
+    // not authoritative content. Two-step defence:
+    //
+    //   1. <link rel="canonical"> always points at the stable URL, with
+    //      any "/dev" suffix stripped from baseUrl. So even if a dev
+    //      page gets crawled, the search engine is told the real
+    //      authority lives at the stable URL.
+    //   2. On dev builds we additionally emit <meta robots noindex,
+    //      follow> so crawlers skip indexing dev pages entirely while
+    //      still propagating internal-link equity to anything we link.
+    const isDev = (cfg.baseUrl ?? "").includes("/dev")
+    const canonicalBaseUrl = isDev
+      ? (cfg.baseUrl ?? "").replace(/\/dev\/?$/, "")
+      : (cfg.baseUrl ?? "")
+    const canonicalUrl =
+      fileData.slug === "404"
+        ? `https://${canonicalBaseUrl}/`
+        : `https://${joinSegments(canonicalBaseUrl, fileData.slug!)}`
+
     const usesCustomOgImage = ctx.cfg.plugins.emitters.some(
       (e) => e.name === CustomOgImagesEmitterName,
     )
@@ -84,6 +107,8 @@ export default (() => {
 
         <link rel="icon" href={iconPath} />
         <meta name="description" content={description} />
+        <link rel="canonical" href={canonicalUrl} />
+        {isDev && <meta name="robots" content="noindex, follow" />}
         <meta name="generator" content="Quartz" />
 
         {css.map((resource) => CSSResourceToStyleElement(resource, true))}

--- a/docs/en/architecture/shadow-vault.md
+++ b/docs/en/architecture/shadow-vault.md
@@ -1,3 +1,9 @@
+---
+title: "Architecture: Shadow Vault Approach"
+tags: [architecture, shadow-vault]
+description: "How obsidian-remote-ssh's shadow vault architecture works: separate Obsidian vault per profile, lazy fetch from the remote, why monkey-patching the adapter was retired."
+---
+
 # Architecture: Shadow Vault Approach
 
 **Status:** Shipped. The shadow-vault model has been the production architecture since v0.4.14 (Phases 0–6A) and is the basis for the v1.0 release line.

--- a/docs/en/comparison.md
+++ b/docs/en/comparison.md
@@ -1,6 +1,7 @@
 ---
 title: Comparison vs other Obsidian sync tools
 tags: [comparison, overview]
+description: "obsidian-remote-ssh vs Obsidian Sync, Syncthing, Dropbox, iCloud, Obsidian Git, Nextcloud, Remotely Save — picking the right vault sync tool by topology and trade-offs."
 ---
 
 # Comparison vs other Obsidian sync tools

--- a/docs/en/cookbook/backup-restore.md
+++ b/docs/en/cookbook/backup-restore.md
@@ -1,6 +1,7 @@
 ---
 title: Backup & restore
 tags: [cookbook, how-to, backup, ops]
+description: "Back up and restore your remote Obsidian vault with rsync, restic, or borg. Covers daily snapshots, off-site replication, single-note recovery, full disaster restore."
 ---
 
 # Backup & restore

--- a/docs/en/cookbook/raspberry-pi-vault.md
+++ b/docs/en/cookbook/raspberry-pi-vault.md
@@ -1,6 +1,7 @@
 ---
 title: Raspberry Pi vault from scratch
 tags: [cookbook, how-to, raspberry-pi]
+description: "Set up a Raspberry Pi as your home Obsidian vault server from scratch — OS install, SSH key, vault directory, network access, and the matching plugin profile."
 ---
 
 # Raspberry Pi vault from scratch

--- a/docs/en/cookbook/share-via-tailscale.md
+++ b/docs/en/cookbook/share-via-tailscale.md
@@ -1,6 +1,7 @@
 ---
 title: Share a vault via Tailscale
 tags: [cookbook, how-to, tailscale]
+description: "Run obsidian-remote-ssh over Tailscale: zero router config, encrypted in-transit traffic, works across NAT, reachable from your laptop and (later) your phone."
 ---
 
 # Share a vault via Tailscale

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -1,6 +1,7 @@
 ---
 title: FAQ
 tags: [faq]
+description: "Common questions about obsidian-remote-ssh: works offline?, mobile support, conflict handling, daemon safety, comparison vs Sync, troubleshooting first steps."
 ---
 
 # FAQ

--- a/docs/en/getting-started/first-connect.md
+++ b/docs/en/getting-started/first-connect.md
@@ -1,6 +1,7 @@
 ---
 title: First connect
 tags: [getting-started]
+description: "What happens when you click Connect: SSH handshake, daemon auto-deploy with cosign-signed binary, vault fetch, shadow vault opens. Step-by-step explanation."
 ---
 
 # First connect — what's actually happening

--- a/docs/en/getting-started/install.md
+++ b/docs/en/getting-started/install.md
@@ -1,6 +1,7 @@
 ---
 title: Install
 tags: [getting-started, install]
+description: "Install obsidian-remote-ssh from the Obsidian Community Plugins store, BRAT (beta channel), or manually from a release tag. Desktop only; Obsidian 1.5+."
 ---
 
 # Install obsidian-remote-ssh

--- a/docs/en/getting-started/quickstart.md
+++ b/docs/en/getting-started/quickstart.md
@@ -1,6 +1,7 @@
 ---
 title: Quickstart
 tags: [getting-started, quickstart]
+description: "Five-minute walkthrough: connect to a remote vault over SSH from Obsidian, see your notes appear, edit them, and verify the round-trip works end to end."
 ---
 
 # 5-minute quickstart

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,6 +1,7 @@
 ---
 title: obsidian-remote-ssh
 tags: [home]
+description: "Edit Obsidian vaults stored on a remote SSH host — no local copies, no third-party cloud. Install guide, architecture, JSON-RPC protocol, and operations docs."
 ---
 
 > **Edit remote Obsidian vaults over SSH/SFTP** — like VS Code Remote-SSH, but for Obsidian.

--- a/docs/en/migration/from-obsidian-sync.md
+++ b/docs/en/migration/from-obsidian-sync.md
@@ -1,6 +1,7 @@
 ---
 title: Migrating from Obsidian Sync
 tags: [migration, how-to]
+description: "Switch your vault from Obsidian's paid Sync service to obsidian-remote-ssh. Step-by-step migration with rollback plan, replacement features, and known gaps."
 ---
 
 # Migrating from Obsidian Sync

--- a/docs/en/operations/troubleshooting.md
+++ b/docs/en/operations/troubleshooting.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshooting
 tags: [operations]
+description: "Diagnosing common obsidian-remote-ssh issues: connection failures, host-key mismatches, daemon-deploy errors, conflict surfaces, slow sync — symptoms and fixes."
 ---
 
 # Troubleshooting

--- a/docs/en/security/model.md
+++ b/docs/en/security/model.md
@@ -1,6 +1,7 @@
 ---
 title: Threat model
 tags: [security]
+description: "obsidian-remote-ssh security model: SSH transport, daemon-side token auth, host-key TOFU store, cosign-signed binaries, vault-root path-escape enforcement, threat model."
 ---
 
 # Security — threat model

--- a/docs/en/tutorial.md
+++ b/docs/en/tutorial.md
@@ -1,6 +1,7 @@
 ---
 title: Tutorial — zero to a working vault
 tags: [tutorial, getting-started]
+description: "Long-form walkthrough from a fresh laptop and a Pi to a working remote vault. Setup, SSH key, profile, first connect, verification, what to do when things break."
 ---
 
 # Tutorial — zero to a working vault

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -2,6 +2,7 @@
 title: obsidian-remote-ssh
 lang: ja
 tags: [home]
+description: "Obsidian の vault を SSH/SFTP 経由でリモート編集できるプラグインの日本語ガイドです。Raspberry Pi や NAS、VPS の vault に Obsidian から直接アクセス。"
 ---
 
 > **Obsidian の vault を SSH/SFTP 経由でリモート編集できるプラグインです** — VS Code Remote-SSH の Obsidian 版だと思ってください。

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.46",
+  "version": "1.0.47-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.46",
+  "version": "1.0.47-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.46",
+  "version": "1.0.47-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.46",
+      "version": "1.0.47-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.46",
+  "version": "1.0.47-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO Priority 1 — quick wins

Three focused improvements for the docs site, all low-touch, all immediately effective:

### 1. `<link rel=\"canonical\">` always emitted

The same source builds two sites: stable (`codes.sota-shimozono.com/obsidian-remote-ssh/`) and dev preview (`…/dev/`). Without a canonical, search engines treat both as candidates for the authoritative copy and the more-recently-crawled version often wins — typically dev, which dilutes stable's SERP position.

`Head.tsx` now always emits `<link rel=\"canonical\" href=\"...\">` pointing at the **stable** URL (with any \`/dev\` suffix stripped from \`cfg.baseUrl\` if present). Dev pages explicitly say \"the real authority is at the stable URL\".

### 2. `<meta name=\"robots\" content=\"noindex, follow\">` on dev builds only

For dev pages we additionally tell crawlers to skip indexing entirely. \`follow\` so internal-link signals still propagate. Detection: \`cfg.baseUrl.includes(\"/dev\")\` — works because the existing \`docs.yml\` workflow sets \`QUARTZ_BASE_URL\` per environment, no new config field needed.

### 3. Hand-curated `description:` frontmatter for 15 entry pages

Quartz already supports `description:` frontmatter — when present it becomes \`<meta name=\"description\">\`, og:description, and the Twitter Card variants. Without it, Quartz auto-extracts from leading prose, producing variable-quality SERP snippets.

Curated descriptions (~150-160 chars) added to:

| Cluster | Pages |
|---|---|
| EN landing | `en/index.md`, `en/comparison.md`, `en/faq.md`, `en/tutorial.md` |
| Getting started | `getting-started/install.md`, `quickstart.md`, `first-connect.md` |
| Conversion intent | `migration/from-obsidian-sync.md` |
| Cookbook | `cookbook/raspberry-pi-vault.md`, `backup-restore.md`, `share-via-tailscale.md` |
| Trust + ops | `operations/troubleshooting.md`, `architecture/shadow-vault.md`, `security/model.md` |
| JA landing | `ja/index.md` |

Note: `shadow-vault.md` previously had no frontmatter at all — the H1 was its de-facto title. Adding minimal frontmatter (title matches the H1 verbatim, plus tags + description). Slug, rendered title, and headings unchanged.

The remaining 50+ pages keep Quartz's auto-extracted descriptions for now. We can extend coverage once Search Console data shows which queries actually drive traffic.

### What's NOT in this PR (deferred)

- **`hreflang`** for EN/JA twins — needs ~30 frontmatter additions or a Head.tsx-level convention; designing as a separate PR
- **JSON-LD structured data** (`SoftwareApplication`, `FAQPage`, `HowTo`) — separate PR
- **Per-page OG images** — separate PR
- **Search Console + Bing Webmaster registration** — manual user-side work, not code

### Version bump

`next` was at plain `1.0.46` after PR #318's post-promotion sync. Per `docs/en/contributing/release-flow.md`, the first PR after a stable promotion runs `bump:beta:start` to enter the new cycle: `1.0.46 → 1.0.47-beta.0`. Doing it correctly here (PRs #310-314 had used `bump:beta` and stayed in `1.0.45.*-beta.N`, which produced the messy 1.0.46 jump).

## Test plan

- [ ] CI green — version-check should pass (BETA channel: head `1.0.47-beta.0` > base `1.0.46`, root manifest unchanged)
- [ ] After merge: BRAT users see `1.0.47-beta.0` as the next prerelease
- [ ] After dev docs deploy: view-source on a `/dev/...` page should show:
  - `<link rel=\"canonical\" href=\"https://codes.sota-shimozono.com/obsidian-remote-ssh/...\">`  (no `/dev`)
  - `<meta name=\"robots\" content=\"noindex, follow\">`
- [ ] After stable docs deploy (next stable promotion): `<link rel=\"canonical\">` matches the page's own URL, no robots noindex meta
- [ ] After deploy: SERP snippets for landing / install / comparison reflect the new descriptions (will take a few crawl cycles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)