### PR TITLE
feat(seo): hreflang alternates for EN/JA twins (1.0.47-beta.1)

### DIFF
--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -11,6 +11,7 @@ export default (() => {
     fileData,
     externalResources,
     ctx,
+    allFiles,
   }: QuartzComponentProps) => {
     const titleSuffix = cfg.pageTitleSuffix ?? ""
     const title =
@@ -53,6 +54,44 @@ export default (() => {
       fileData.slug === "404"
         ? `https://${canonicalBaseUrl}/`
         : `https://${joinSegments(canonicalBaseUrl, fileData.slug!)}`
+
+    // Hreflang alternates for EN/JA twins.
+    //
+    // Convention: pages under `docs/<lang>/<rest>` slug to `<lang>/<rest>`
+    // (e.g. `en/migration/from-obsidian-sync` and `ja/migration/from-obsidian-sync`).
+    // When both twins exist, Google needs reciprocal `rel="alternate"
+    // hreflang="..."` links on each so the right language version is
+    // surfaced for each user's locale. Without these, both twins compete
+    // as duplicates and Google may pick whichever it first crawled.
+    //
+    // Detection is convention-based: parse the slug for an `en/` or
+    // `ja/` prefix, build the twin slug by swapping the prefix, and
+    // check the in-memory `allFiles` list for the twin. If found, emit
+    // self-hreflang + twin-hreflang + x-default (pointing at EN).
+    //
+    // Pages outside the per-language subtree (e.g. `index`, `tags/*`,
+    // `404`) get no hreflang — correct, since they have no language
+    // siblings to disambiguate against.
+    const slug = fileData.slug ?? ""
+    const langTwinMatch = slug.match(/^(en|ja)\/(.+)$/)
+    const hreflangAlternates: Array<{ hrefLang: string; href: string }> = []
+    if (langTwinMatch) {
+      const [, currentLang, restPath] = langTwinMatch
+      const otherLang = currentLang === "en" ? "ja" : "en"
+      const twinSlug = `${otherLang}/${restPath}`
+      const twinExists = allFiles.some((f) => f.slug === twinSlug)
+      if (twinExists) {
+        const selfHref = canonicalUrl
+        const twinHref = `https://${joinSegments(canonicalBaseUrl, twinSlug)}`
+        const enHref = currentLang === "en" ? selfHref : twinHref
+        hreflangAlternates.push(
+          { hrefLang: currentLang, href: selfHref },
+          { hrefLang: otherLang, href: twinHref },
+          // x-default points at the EN copy by convention.
+          { hrefLang: "x-default", href: enHref },
+        )
+      }
+    }
 
     const usesCustomOgImage = ctx.cfg.plugins.emitters.some(
       (e) => e.name === CustomOgImagesEmitterName,
@@ -109,6 +148,9 @@ export default (() => {
         <meta name="description" content={description} />
         <link rel="canonical" href={canonicalUrl} />
         {isDev && <meta name="robots" content="noindex, follow" />}
+        {hreflangAlternates.map(({ hrefLang, href }) => (
+          <link rel="alternate" hrefLang={hrefLang} href={href} key={hrefLang} />
+        ))}
         <meta name="generator" content="Quartz" />
 
         {css.map((resource) => CSSResourceToStyleElement(resource, true))}

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.0",
+  "version": "1.0.47-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.0",
+  "version": "1.0.47-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.0",
+  "version": "1.0.47-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.47-beta.0",
+      "version": "1.0.47-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.0",
+  "version": "1.0.47-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO Priority 1 (cont.) — hreflang for language twins

Reciprocal `<link rel="alternate" hreflang="...">` tags between EN/JA twin pages so Google serves the right language version per user locale instead of treating them as competing duplicates.

### Problem

The JA tree shipped in 1.0.46 (PRs #313 + #314) gave us 15 twin pairs (30 pages) but no language disambiguation signal. Google's default behaviour: pick whichever was crawled first. JA-language users could land on the EN twin and bounce; EN users could land on the JA twin and bounce. Both pages competed in SERP rather than complementing each other.

### Solution

Convention-based hreflang in `Head.tsx`:

1. Parse the page's slug for an `en/` or `ja/` prefix.
2. Build the twin slug by swapping the prefix.
3. Check `allFiles` (in-memory list Quartz already passes to every component) for the twin.
4. If found, emit:
   - `<link rel="alternate" hreflang="<self-lang>" href="<self-canonical>">`
   - `<link rel="alternate" hreflang="<other-lang>" href="<twin-canonical>">`
   - `<link rel="alternate" hreflang="x-default" href="<en-canonical>">` (EN as default for unmatched locales)

No per-page frontmatter needed. As JA coverage expands, hreflang appears automatically on next build.

### Coverage

15 twin pairs = 30 pages get hreflang on this PR:

| Path | EN | JA |
|---|---|---|
| `index` | ✓ | ✓ |
| `comparison` | ✓ | ✓ |
| `faq` | ✓ | ✓ |
| `getting-started/{index,install,quickstart,first-connect}` | ✓ | ✓ |
| `operations/{index,troubleshooting}` | ✓ | ✓ |
| `cookbook/{index,raspberry-pi-vault}` | ✓ | ✓ |
| `migration/{index,from-obsidian-sync}` | ✓ | ✓ |
| `security/{index,model}` | ✓ | ✓ |

The remaining 64 EN-only pages get no hreflang — correct, no language sibling to disambiguate against.

### Where this fits in the SEO sequence

Per the plan, accumulating SEO improvements as betas on `next`, promoting all together later:

- ✓ 1.0.47-beta.0 (PR #319) — canonical, dev-noindex, description frontmatter (15 pages)
- 👉 1.0.47-beta.1 (this PR) — hreflang for EN/JA twins
- 🔲 1.0.47-beta.2 — JSON-LD structured data
- 🔲 1.0.47-beta.3 — extended description coverage
- 🔲 1.0.47-beta.4 — per-cluster OG images
- ... eventually promote to 1.0.47 stable

## Test plan

- [ ] CI green
- [ ] After dev docs deploy: view-source on `/dev/ja/migration/from-obsidian-sync/` shows 3 `<link rel="alternate" hreflang="ja|en|x-default">` tags
- [ ] EN-only page (e.g. `/dev/en/cookbook/multi-vault/`) shows no `<link rel="alternate">` tags
- [ ] After stable docs deploy (next stable promotion): same behaviour at the canonical URLs
- [ ] Google Search Console "International Targeting" report eventually surfaces the language pairs (lags ~weeks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)