### PR TITLE
feat(seo): JSON-LD structured data — SoftwareApplication + FAQPage (1.0.47-beta.2)

### DIFF
--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -55,6 +55,62 @@ export default (() => {
         ? `https://${canonicalBaseUrl}/`
         : `https://${joinSegments(canonicalBaseUrl, fileData.slug!)}`
 
+    // JSON-LD structured data (schema.org).
+    //
+    // Selected via `schema:` frontmatter field. Currently supported:
+    //
+    //   - "SoftwareApplication" — for the project's home/landing pages.
+    //     Auto-fills name, description, url from page metadata; the
+    //     remaining fields (category, OS, offer, download URL) are
+    //     static project facts.
+    //
+    //   - "FAQPage" — requires a `faq:` array of {q, a} objects in
+    //     frontmatter. Each becomes a Question/Answer pair in the
+    //     mainEntity. Google uses this to render People-Also-Ask
+    //     boxes in SERPs.
+    //
+    // Other types (HowTo for cookbooks, TechArticle for architecture
+    // pages) can be added here as we extend coverage.
+    const schemaType = fileData.frontmatter?.schema as string | undefined
+    let jsonLdBlob: Record<string, unknown> | null = null
+
+    if (schemaType === "SoftwareApplication") {
+      jsonLdBlob = {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        name: cfg.pageTitle ?? "obsidian-remote-ssh",
+        description,
+        url: canonicalUrl,
+        applicationCategory: "ProductivityApplication",
+        operatingSystem: "Linux, macOS, Windows",
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+        downloadUrl:
+          "https://github.com/sotashimozono/obsidian-remote-ssh/releases/latest",
+      }
+    } else if (schemaType === "FAQPage") {
+      const faqItems = fileData.frontmatter?.faq as
+        | Array<{ q: string; a: string }>
+        | undefined
+      if (faqItems && faqItems.length > 0) {
+        jsonLdBlob = {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ q, a }) => ({
+            "@type": "Question",
+            name: q,
+            acceptedAnswer: {
+              "@type": "Answer",
+              text: a,
+            },
+          })),
+        }
+      }
+    }
+
     // Hreflang alternates for EN/JA twins.
     //
     // Convention: pages under `docs/<lang>/<rest>` slug to `<lang>/<rest>`
@@ -151,6 +207,12 @@ export default (() => {
         {hreflangAlternates.map(({ hrefLang, href }) => (
           <link rel="alternate" hrefLang={hrefLang} href={href} key={hrefLang} />
         ))}
+        {jsonLdBlob && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLdBlob) }}
+          />
+        )}
         <meta name="generator" content="Quartz" />
 
         {css.map((resource) => CSSResourceToStyleElement(resource, true))}

--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -2,6 +2,22 @@
 title: FAQ
 tags: [faq]
 description: "Common questions about obsidian-remote-ssh: works offline?, mobile support, conflict handling, daemon safety, comparison vs Sync, troubleshooting first steps."
+schema: FAQPage
+faq:
+  - q: "How is this different from Obsidian Sync, Syncthing, or Dropbox?"
+    a: "obsidian-remote-ssh keeps a single canonical vault on YOUR remote SSH host (no third-party cloud, no replicated copies). Obsidian Sync stores in Obsidian's cloud; Syncthing and Dropbox replicate the vault across all devices. Pick by trust model and ops appetite — see the comparison page for the full breakdown."
+  - q: "Does it work on mobile?"
+    a: "Not yet. The current architecture spawns a daemon binary on the remote, which works on desktop Obsidian (Electron). iOS / Android Obsidian need a relay component because the OS doesn't allow Obsidian to spawn subprocesses. Tracked under the mobile-relay milestone."
+  - q: "Can I use this with multiple clients editing the same vault?"
+    a: "Yes — designed for it. Each client gets its own shadow vault and its own daemon session. Conflicts surface in the conflict-handling flow rather than as sibling files. Workspace state (open tabs, pane sizes) is partitioned per-client under .obsidian/user/<client-id>/."
+  - q: "Does it support Windows as the remote host?"
+    a: "Not currently. The daemon ships for Linux (amd64 / arm64) and macOS (Intel / Apple Silicon). Windows + WSL works — treat WSL as the remote so the daemon runs in its Linux environment. Native Windows + OpenSSH server is on the roadmap but not started."
+  - q: "Can I use it without the daemon (SFTP-only)?"
+    a: "Yes — set the profile Mode to sftp. No daemon deployment, slower per-operation latency (about 50-100 ms vs 5-10 ms), and no fs.watch push notifications (the plugin polls for changes instead). Useful for locked-down remote hosts where deploying a binary isn't feasible."
+  - q: "Does the plugin upload anything to a third party?"
+    a: "No. All traffic flows over your SSH connection to your host. Telemetry counters are opt-in, off by default, and local-only — there is no phone-home path in the codebase. Verify by reading the source under plugin/src/."
+  - q: "Does the plugin re-deploy the daemon every time I connect?"
+    a: "No — it tries to reuse a running daemon first. The plugin probes the remote socket and validates the cached token. If reuse succeeds, no upload happens. The daemon binary is only redeployed when reuse fails (no daemon, version mismatch, or invalid token)."
 ---
 
 # FAQ

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -2,6 +2,7 @@
 title: obsidian-remote-ssh
 tags: [home]
 description: "Edit Obsidian vaults stored on a remote SSH host — no local copies, no third-party cloud. Install guide, architecture, JSON-RPC protocol, and operations docs."
+schema: SoftwareApplication
 ---
 
 > **Edit remote Obsidian vaults over SSH/SFTP** — like VS Code Remote-SSH, but for Obsidian.

--- a/docs/ja/faq.md
+++ b/docs/ja/faq.md
@@ -2,6 +2,22 @@
 title: FAQ
 lang: ja
 tags: [faq]
+schema: FAQPage
+faq:
+  - q: "Obsidian Sync / Syncthing / Dropbox との違いは?"
+    a: "obsidian-remote-ssh はあなたのリモート SSH ホスト上に正本を 1 つ持ちます (第三者クラウドなし、レプリカもなし)。Obsidian Sync は Obsidian のクラウドに保存、Syncthing と Dropbox は全デバイスに複製。信頼モデルと運用負荷で選んでください。比較ページに全比較表があります。"
+  - q: "モバイルで動きますか?"
+    a: "現在は未対応です。現アーキテクチャはリモートで daemon バイナリを起動するため、デスクトップ Obsidian (Electron) では動作しますが、iOS / Android では OS がサブプロセスの起動を許可しません。モバイルリレー実装はマイルストーンで追跡中です。"
+  - q: "同じ vault を複数クライアントから編集できますか?"
+    a: "はい — 設計上対応しています。各クライアントが独自のシャドウボールトと daemon セッションを持ちます。競合は競合ハンドリングフローで surface し、兄弟ファイルとして残りません。ワークスペース状態 (タブ、ペイン) は .obsidian/user/<client-id>/ 配下で per-client 分離。"
+  - q: "リモートホストが Windows でも動きますか?"
+    a: "現在は非対応です。daemon は Linux (amd64 / arm64) と macOS (Intel / Apple Silicon) 用にビルドされます。Windows + WSL は WSL を remote として扱えば動作 (daemon は Linux 環境で起動)。ネイティブ Windows + OpenSSH サーバはロードマップにありますが未着手です。"
+  - q: "デーモンなし (SFTP のみ) で使えますか?"
+    a: "はい — プロフィールの Mode を sftp に設定してください。daemon デプロイなし、操作あたりレイテンシは大きく (約 50-100 ms vs 5-10 ms)、fs.watch によるプッシュ通知もなし (代わりに polling)。バイナリ配置できないロックダウンされたリモートホストで有用です。"
+  - q: "このプラグインは第三者にデータを送りますか?"
+    a: "いいえ。全トラフィックはあなたのホストへの SSH 接続上です。テレメトリカウンタは opt-in で既定 off、local-only — phone-home 経路はコードベースに存在しません。plugin/src/ 配下のソースで確認できます。"
+  - q: "接続のたびにデーモンを再デプロイしますか?"
+    a: "いいえ — まず実行中の daemon を再利用しようとします。リモートソケットをプローブし、キャッシュ済みトークンを検証。再利用成功ならアップロードなし。再利用失敗 (daemon 未起動、バージョン不一致、トークン無効) のときのみバイナリを再デプロイします。"
 ---
 
 # FAQ

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -3,6 +3,7 @@ title: obsidian-remote-ssh
 lang: ja
 tags: [home]
 description: "Obsidian の vault を SSH/SFTP 経由でリモート編集できるプラグインの日本語ガイドです。Raspberry Pi や NAS、VPS の vault に Obsidian から直接アクセス。"
+schema: SoftwareApplication
 ---
 
 > **Obsidian の vault を SSH/SFTP 経由でリモート編集できるプラグインです** — VS Code Remote-SSH の Obsidian 版だと思ってください。

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.1",
+  "version": "1.0.47-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.1",
+  "version": "1.0.47-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.1",
+  "version": "1.0.47-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.47-beta.1",
+      "version": "1.0.47-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.1",
+  "version": "1.0.47-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO Priority 2 — structured data (JSON-LD)

Adds schema.org structured-data markers so Google can render rich SERP results:

- **`SoftwareApplication`** on `docs/en/index.md` + `docs/ja/index.md` → "software card" enrichment for the project's home page
- **`FAQPage`** on `docs/en/faq.md` + `docs/ja/faq.md` (with curated 7-item `faq:` array) → People-Also-Ask boxes in Google SERP

### Implementation

`Head.tsx` now dispatches on a new `schema:` frontmatter field. Pages without it emit nothing extra (the vast majority of pages); pages with a supported value emit a single `<script type="application/ld+json">` block.

Currently supported:

```yaml
schema: SoftwareApplication
```
Auto-fills `name` from `cfg.pageTitle`, `description` from frontmatter, `url` from canonical. Static project facts (free, ProductivityApplication, Linux/macOS/Windows desktop, GitHub releases/latest) are hard-coded.

```yaml
schema: FAQPage
faq:
  - q: "..."
    a: "..."
```
Each Q&A pair becomes a Question/Answer entity under `mainEntity`. Plain-text only (Google strips markup from FAQPage answers).

Designed so adding `HowTo` (for cookbook recipes) or `TechArticle` (for architecture pages) in the same dispatch is a small follow-up — just extend the switch and tag the relevant pages.

### FAQ Q&A selection

Picked 7 of the 12 existing FAQ items based on search-intent fit:

1. How is this different from Obsidian Sync, Syncthing, or Dropbox?
2. Does it work on mobile?
3. Can I use this with multiple clients editing the same vault?
4. Does it support Windows as the remote host?
5. Can I use it without the daemon (SFTP-only)?
6. Does the plugin upload anything to a third party?
7. Does the plugin re-deploy the daemon every time I connect?

The 5 we skipped (LOCAL OS, separate known_hosts rationale, uninstall, security reporting, feature requests) are operational/process questions — useful on the page but lower SERP value.

JA versions are full translations of the EN answers, in the same order.

### Where this fits

Accumulating SEO improvements as betas on `next`:

- 1.0.47-beta.0 — canonical, dev-noindex, description frontmatter (15 pages) [#319] (merged)
- 1.0.47-beta.1 — hreflang for EN/JA twins [#320] (merged)
- 1.0.47-beta.2 (this PR) — JSON-LD SoftwareApplication + FAQPage
- 1.0.47-beta.3 — extend description coverage to more pages
- 1.0.47-beta.4 — per-cluster OG images
- 1.0.47-beta.5 — JSON-LD HowTo (cookbook) + TechArticle (architecture)
- ... eventually promote to 1.0.47 stable

## Test plan

- [ ] CI green
- [ ] After dev docs deploy: view-source on `/dev/en/` shows `<script type="application/ld+json">` with the SoftwareApplication blob
- [ ] view-source on `/dev/en/faq/` shows the FAQPage blob with all 7 Q&A pairs
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) confirms valid SoftwareApplication and FAQPage parsing
- [ ] After stable promotion: same on production URLs
- [ ] Eventually (~weeks after Search Console submission): "Software" / "FAQ" enrichments appear in actual SERP
