### PR TITLE
feat(seo): JSON-LD Article + TechArticle for cookbook & architecture (1.0.47-beta.4)

### DIFF
--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -91,6 +91,40 @@ export default (() => {
         downloadUrl:
           "https://github.com/sotashimozono/obsidian-remote-ssh/releases/latest",
       }
+    } else if (schemaType === "Article" || schemaType === "TechArticle") {
+      // Article + TechArticle share most of the same shape. We auto-fill
+      // headline/description/url/dates/inLanguage from page metadata so
+      // the per-page frontmatter only has to carry `schema: Article` (or
+      // `schema: TechArticle`) — no other fields required.
+      const dates = (fileData.dates ?? {}) as {
+        published?: Date
+        modified?: Date
+        created?: Date
+      }
+      const headline = (fileData.frontmatter?.title ?? "") as string
+      const lang = (fileData.frontmatter?.lang as string | undefined) ?? "en"
+      const articleBlob: Record<string, unknown> = {
+        "@context": "https://schema.org",
+        "@type": schemaType,
+        headline,
+        description,
+        url: canonicalUrl,
+        inLanguage: lang,
+        isPartOf: {
+          "@type": "WebSite",
+          name: cfg.pageTitle ?? "obsidian-remote-ssh",
+          url: `https://${canonicalBaseUrl}/`,
+        },
+      }
+      if (dates.published) {
+        articleBlob.datePublished = dates.published.toISOString()
+      } else if (dates.created) {
+        articleBlob.datePublished = dates.created.toISOString()
+      }
+      if (dates.modified) {
+        articleBlob.dateModified = dates.modified.toISOString()
+      }
+      jsonLdBlob = articleBlob
     } else if (schemaType === "FAQPage") {
       const faqItems = fileData.frontmatter?.faq as
         | Array<{ q: string; a: string }>

--- a/docs/en/architecture/collab.md
+++ b/docs/en/architecture/collab.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture: collab safety epic (E2)"
+tags: [architecture, collab, conflicts]
+schema: TechArticle
+description: "Design record for obsidian-remote-ssh's collab + offline-resilience epic: conflict surface design, write preconditions, queue-on-disconnect, watcher resubscription."
+---
+
 # Architecture: collab safety epic (E2)
 
 This doc records the design for the conflict + offline-resilience

--- a/docs/en/architecture/perf.md
+++ b/docs/en/architecture/perf.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture: performance epic (E1)"
+tags: [architecture, performance]
+schema: TechArticle
+description: "Design record for obsidian-remote-ssh's performance epic: SSH RTT amortisation, daemon thumbnail cache, fs.walk + fs.thumbnail design, batched RPC, profiling results."
+---
+
 # Architecture: performance epic (E1)
 
 This doc is the design record for the performance epic that lands in

--- a/docs/en/architecture/release-pipeline.md
+++ b/docs/en/architecture/release-pipeline.md
@@ -1,6 +1,7 @@
 ---
 title: Release & deploy pipeline
 tags: [architecture, release, ci, deploy]
+schema: TechArticle
 ---
 
 # Release & deploy pipeline

--- a/docs/en/architecture/shadow-vault.md
+++ b/docs/en/architecture/shadow-vault.md
@@ -2,6 +2,7 @@
 title: "Architecture: Shadow Vault Approach"
 tags: [architecture, shadow-vault]
 description: "How obsidian-remote-ssh's shadow vault architecture works: separate Obsidian vault per profile, lazy fetch from the remote, why monkey-patching the adapter was retired."
+schema: TechArticle
 ---
 
 # Architecture: Shadow Vault Approach

--- a/docs/en/cookbook/backup-restore.md
+++ b/docs/en/cookbook/backup-restore.md
@@ -2,6 +2,7 @@
 title: Backup & restore
 tags: [cookbook, how-to, backup, ops]
 description: "Back up and restore your remote Obsidian vault with rsync, restic, or borg. Covers daily snapshots, off-site replication, single-note recovery, full disaster restore."
+schema: Article
 ---
 
 # Backup & restore

--- a/docs/en/cookbook/hardware-key.md
+++ b/docs/en/cookbook/hardware-key.md
@@ -2,6 +2,7 @@
 title: Hardware-key SSH auth (YubiKey, TouchID, Secure Enclave)
 tags: [cookbook, how-to, ssh, security, hardware]
 description: "Use a YubiKey, Nitrokey, macOS Secure Enclave, or Windows Hello to sign SSH connections to your Obsidian vault. FIDO2 ed25519-sk + Apple keychain + TPM recipes."
+schema: Article
 ---
 
 # Hardware-key SSH auth

--- a/docs/en/cookbook/host-migration.md
+++ b/docs/en/cookbook/host-migration.md
@@ -2,6 +2,7 @@
 title: Migrating between hosts
 tags: [cookbook, how-to, ops, migration]
 description: "Move your Obsidian vault from one remote host to another (Pi to NAS, home to VPS) with rsync, profile re-target, and host-key trust handoff. Zero-data-loss recipe."
+schema: Article
 ---
 
 # Migrating between hosts

--- a/docs/en/cookbook/multi-vault.md
+++ b/docs/en/cookbook/multi-vault.md
@@ -2,6 +2,7 @@
 title: Editing multiple vaults from one Obsidian
 tags: [cookbook, how-to, multi-vault]
 description: "Edit work, personal, and family Obsidian vaults from a single Obsidian install. Multiple SSH profiles, separate shadow vaults, shared launcher vault."
+schema: Article
 ---
 
 # Editing multiple vaults from one Obsidian

--- a/docs/en/cookbook/raspberry-pi-vault.md
+++ b/docs/en/cookbook/raspberry-pi-vault.md
@@ -2,6 +2,7 @@
 title: Raspberry Pi vault from scratch
 tags: [cookbook, how-to, raspberry-pi]
 description: "Set up a Raspberry Pi as your home Obsidian vault server from scratch — OS install, SSH key, vault directory, network access, and the matching plugin profile."
+schema: Article
 ---
 
 # Raspberry Pi vault from scratch

--- a/docs/en/cookbook/reverse-proxy.md
+++ b/docs/en/cookbook/reverse-proxy.md
@@ -2,6 +2,7 @@
 title: Reverse proxy in front of Docker sshd
 tags: [cookbook, how-to, docker, reverse-proxy, deploy]
 description: "Front the obsidian-remote-ssh sshd container with nginx / Caddy / SSH ProxyJump. TLS termination, multi-tenant routing, hostname-based vault selection."
+schema: Article
 ---
 
 # Reverse proxy in front of Docker sshd

--- a/docs/en/cookbook/share-via-tailscale.md
+++ b/docs/en/cookbook/share-via-tailscale.md
@@ -2,6 +2,7 @@
 title: Share a vault via Tailscale
 tags: [cookbook, how-to, tailscale]
 description: "Run obsidian-remote-ssh over Tailscale: zero router config, encrypted in-transit traffic, works across NAT, reachable from your laptop and (later) your phone."
+schema: Article
 ---
 
 # Share a vault via Tailscale

--- a/docs/en/cookbook/ssh-keygen.md
+++ b/docs/en/cookbook/ssh-keygen.md
@@ -2,6 +2,7 @@
 title: Generating an SSH key
 tags: [cookbook, how-to, ssh]
 description: "Generate an SSH key the obsidian-remote-ssh plugin can use: ed25519 vs ed25519-sk vs RSA, passphrase choice, ssh-agent integration, where to put the public key."
+schema: Article
 ---
 
 # Generating an SSH key

--- a/docs/en/cookbook/systemd-managed-daemon.md
+++ b/docs/en/cookbook/systemd-managed-daemon.md
@@ -2,6 +2,7 @@
 title: systemd-managed daemon
 tags: [cookbook, how-to, systemd, security]
 description: "Replace the auto-deployed daemon with a systemd-managed one: cosign-verify the binary first, install as a user unit, enable lingering, monitor with journalctl."
+schema: Article
 ---
 
 # systemd-managed daemon (with cosign verification)

--- a/docs/ja/cookbook/raspberry-pi-vault.md
+++ b/docs/ja/cookbook/raspberry-pi-vault.md
@@ -3,6 +3,7 @@ title: Raspberry Pi vault from scratch
 lang: ja
 tags: [cookbook, how-to, raspberry-pi]
 description: "Raspberry Pi をホーム vault サーバとしてゼロからセットアップ: OS インストール、SSH 鍵、vault ディレクトリ、ネットワークアクセス、対応するプラグインプロファイル。"
+schema: Article
 ---
 
 # Raspberry Pi vault — ゼロからのセットアップ

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.3",
+  "version": "1.0.47-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.3",
+  "version": "1.0.47-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.3",
+  "version": "1.0.47-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.47-beta.3",
+      "version": "1.0.47-beta.4",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.3",
+  "version": "1.0.47-beta.4",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO Priority 2 (cont.) — Article + TechArticle JSON-LD

Extends the schema-dispatch from beta.2 (SoftwareApplication + FAQPage) to cover the two largest content clusters:

- **`Article`** — applied to 10 cookbook recipes (9 EN + 1 JA twin)
- **`TechArticle`** — applied to 4 architecture design records

After this PR: 14 more pages emit valid schema.org structured data, on top of the 4 from beta.2.

### Implementation

`Head.tsx` gets one new branch in the schema dispatch that handles both Article and TechArticle (they share most of the same shape):

```ts
} else if (schemaType === "Article" || schemaType === "TechArticle") {
  // auto-fills: headline, description, url, inLanguage, isPartOf,
  // datePublished, dateModified — all from existing page metadata
  // and Quartz's CreatedModifiedDate plugin.
}
```

The dates field plumbs through naturally because `quartz.config.ts:57-59` already runs `Plugin.CreatedModifiedDate({priority: ["frontmatter", "git", "filesystem"]})`.

Per-page frontmatter only needs `schema: Article` or `schema: TechArticle` — every other field is auto-filled. Pages without the flag emit nothing extra.

### Why Article instead of HowTo for cookbook?

Google deprecated **HowTo SERP rich results in late 2023** — adding the more-complex HowTo schema today gives no SERP visibility benefit. Plain Article still provides the metadata Google uses for "improved page understanding" without requiring the structured `step:` arrays HowTo demanded.

### Coverage

| Cluster | Schema | Pages |
|---|---|---|
| Architecture | TechArticle | shadow-vault, release-pipeline, collab, perf |
| Cookbook (EN) | Article | raspberry-pi-vault, ssh-keygen, share-via-tailscale, systemd-managed-daemon, backup-restore, host-migration, hardware-key, reverse-proxy, multi-vault |
| Cookbook (JA twin) | Article | raspberry-pi-vault |

### Special cases

`architecture/collab.md` and `architecture/perf.md` previously had no frontmatter at all — H1 was the de-facto title. Adding minimal frontmatter (title matches H1, plus tags, schema, description). Slug, rendered title, and headings unchanged.

### Where this fits

- 1.0.47-beta.0 — canonical, dev-noindex, description × 15 [#319] (merged)
- 1.0.47-beta.1 — hreflang for EN/JA twins [#320] (merged)
- 1.0.47-beta.2 — JSON-LD SoftwareApplication + FAQPage [#321] (merged)
- 1.0.47-beta.3 — extended description coverage (+34 pages) [#322] (merged)
- 1.0.47-beta.4 (this PR) — JSON-LD Article (cookbook) + TechArticle (architecture)
- 1.0.47-beta.5 — per-cluster OG images
- ... eventually promote to 1.0.47 stable

## Test plan

- [ ] CI green (link checker clean — verified locally)
- [ ] After dev docs deploy: view-source on `/dev/en/cookbook/raspberry-pi-vault/` shows `<script type="application/ld+json">` with `"@type": "Article"`
- [ ] view-source on `/dev/en/architecture/shadow-vault/` shows `"@type": "TechArticle"`
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) confirms valid Article + TechArticle parsing on a sample of 3 pages
- [ ] After stable promotion: same on production URLs
