### PR TITLE
feat(seo): per-page OG images via Plugin.CustomOgImages (1.0.47-beta.5)

### DIFF
--- a/docs-site/quartz.config.ts
+++ b/docs-site/quartz.config.ts
@@ -86,6 +86,12 @@ const config: QuartzConfig = {
       Plugin.Static(),
       Plugin.Favicon(),
       Plugin.NotFoundPage(),
+      // Per-page OG images. Renders a 1200x630 social card for every
+      // page using the page title + description, via Satori (HTML→SVG)
+      // + Sharp (SVG→WebP). When this emitter is active, Head.tsx
+      // detects it and stops linking the static og-image.png — every
+      // page gets its own image referenced from <meta property="og:image">.
+      Plugin.CustomOgImages(),
     ],
   },
 }

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.4",
+  "version": "1.0.47-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47-beta.4",
+  "version": "1.0.47-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.4",
+  "version": "1.0.47-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.47-beta.4",
+      "version": "1.0.47-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47-beta.4",
+  "version": "1.0.47-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO Priority 2 (cont.) — per-page OG images

Until now every page used the same static `og-image.png` for social shares — generic project icon regardless of which page was linked. This PR enables Quartz's `Plugin.CustomOgImages()` so every page gets its own 1200×630 WebP card, generated from the page title + description.

### Why this matters

Twitter / Discord / Slack / Mastodon / BlueSky all show OG image previews when pages are shared. With per-page cards, each share carries the actual page identity (title + description) — much higher CTR than the generic icon. Same applies to Open Graph + Twitter Card variants the existing Head.tsx already emits.

### Implementation

```ts
// docs-site/quartz.config.ts emitters[]:
Plugin.CustomOgImages(),
```

That's the entire change. Quartz already ships the emitter:

1. For each page, render title + description + project icon into Quartz's `defaultImage` JSX template.
2. Satori converts the JSX → SVG (1200×630).
3. Sharp converts SVG → WebP at quality 40.
4. Save under `public/static/og-images/<slug>.webp`.
5. Inject per-page `<meta property="og:image">` via the plugin's `externalResources.additionalHead`.

The existing Head.tsx already has the integration:

```ts
// Head.tsx:34-36 — already in place since before this PR
const usesCustomOgImage = ctx.cfg.plugins.emitters.some(
  (e) => e.name === CustomOgImagesEmitterName,
)
```

When the emitter is active (= now), the static `og-image.png` `<meta>` block is skipped and the per-page meta tags from `additionalHead` are rendered instead. Zero Head.tsx changes needed.

### Build-time cost

~80 pages × ~100-200 ms each = +10-15 s to the docs build. Acceptable.

### Where this fits

- 1.0.47-beta.0 — canonical, dev-noindex, description × 15 [#319] (merged)
- 1.0.47-beta.1 — hreflang for EN/JA twins [#320] (merged)
- 1.0.47-beta.2 — JSON-LD SoftwareApplication + FAQPage [#321] (merged)
- 1.0.47-beta.3 — extended description coverage (+34 pages) [#322] (merged)
- 1.0.47-beta.4 — JSON-LD Article (cookbook) + TechArticle (architecture) [#323] (merged)
- 1.0.47-beta.5 (this PR) — per-page OG images
- Next: promote `next` → `main` as 1.0.47 stable (brings the whole SEO sequence to production docs)

## Test plan

- [ ] CI green (build will be ~15 s slower with OG image generation)
- [ ] After dev docs deploy: paste `https://codes.sota-shimozono.com/obsidian-remote-ssh/dev/en/comparison/` into [Open Graph Debugger](https://www.opengraph.xyz/) — should show a 1200×630 image with "Comparison vs other Obsidian sync tools — docs" title rendered
- [ ] Different pages (e.g. `/dev/ja/migration/from-obsidian-sync/`) show different OG images with their respective titles
- [ ] Build artefact at `docs-site/public/static/og-images/` contains ~80 WebP files
- [ ] Existing static `og-image.png` is still in the static dir (used as Quartz fallback) but the rendered HTML's `<meta property="og:image">` no longer points to it

## Next: stable promotion

After this merges, the recommended next step is **promoting `next` (now at `1.0.47-beta.5`) → `main` as `1.0.47` stable** — brings the whole SEO sequence (canonical, hreflang, descriptions, JSON-LD, OG images) into production. Following the `release/X.Y.Z` branch flow from `docs/en/contributing/release-flow.md`.
