### PR TITLE
feat(seo): BreadcrumbList + WebSite JSON-LD (1.0.48-beta.0)

### DIFF
--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -165,6 +165,90 @@ export default (() => {
       }
     }
 
+    // BreadcrumbList — emit for any page two or more segments deep so
+    // Google can render the breadcrumb trail in SERPs (Home › cookbook
+    // › Raspberry Pi vault). Higher CTR vs the bare URL.
+    //
+    // Segments come from the slug; intermediate folder URLs work because
+    // Quartz emits an index.html for each section landing (en/cookbook/,
+    // en/architecture/, etc.). Slug-to-readable conversion uses a small
+    // table of common abbreviations + title-case fallback.
+    const SEGMENT_NAMES: Record<string, string> = {
+      en: "English",
+      ja: "Japanese",
+      api: "API",
+      faq: "FAQ",
+      ssh: "SSH",
+      sftp: "SFTP",
+      cli: "CLI",
+    }
+    const segmentName = (s: string): string =>
+      SEGMENT_NAMES[s] ??
+      s
+        .split("-")
+        .map((w) => (w ? w.charAt(0).toUpperCase() + w.slice(1) : ""))
+        .join(" ")
+
+    const slugSegments = slug.split("/").filter(Boolean)
+    let breadcrumbBlob: Record<string, unknown> | null = null
+    if (slugSegments.length >= 2 && slug !== "404") {
+      const items: Array<Record<string, unknown>> = [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Home",
+          item: `https://${canonicalBaseUrl}/`,
+        },
+      ]
+      let cumulative = ""
+      for (let i = 0; i < slugSegments.length - 1; i++) {
+        cumulative += "/" + slugSegments[i]
+        items.push({
+          "@type": "ListItem",
+          position: i + 2,
+          name: segmentName(slugSegments[i]),
+          item: `https://${canonicalBaseUrl}${cumulative}/`,
+        })
+      }
+      // Final segment: use the frontmatter title (richer than slug) for
+      // the page name; the URL is the page's canonical.
+      items.push({
+        "@type": "ListItem",
+        position: slugSegments.length + 1,
+        name:
+          (fileData.frontmatter?.title as string | undefined) ??
+          segmentName(slugSegments[slugSegments.length - 1]),
+        item: canonicalUrl,
+      })
+      breadcrumbBlob = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        itemListElement: items,
+      }
+    }
+
+    // WebSite — emit on the root landing pages (en/index, ja/index, and
+    // the top-level docs/index). Tells Google the canonical name + URL
+    // of the site as a whole; pairs with the SoftwareApplication on the
+    // same pages without duplication (different @types).
+    //
+    // SearchAction deliberately omitted: Quartz's built-in search is
+    // keyboard-driven, not URL-driven, so we have no urlTemplate Google
+    // would actually be able to follow. Adding a fake one is worse than
+    // omitting — Google's validator can reject it as broken.
+    let websiteBlob: Record<string, unknown> | null = null
+    if (slug === "en/index" || slug === "ja/index" || slug === "index") {
+      websiteBlob = {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        url: `https://${canonicalBaseUrl}/`,
+        name: cfg.pageTitle ?? "obsidian-remote-ssh",
+        description,
+        inLanguage: (fileData.frontmatter?.lang as string | undefined) ?? "en",
+        publisher: projectAuthor,
+      }
+    }
+
     // Hreflang alternates for EN/JA twins.
     //
     // Convention: pages under `docs/<lang>/<rest>` slug to `<lang>/<rest>`
@@ -272,6 +356,22 @@ export default (() => {
               // FAQ answer, etc.) cannot break out of the surrounding
               // <script> element. JSON.stringify itself does not do this.
               __html: JSON.stringify(jsonLdBlob).replace(/</g, "\\u003c"),
+            }}
+          />
+        )}
+        {breadcrumbBlob && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(breadcrumbBlob).replace(/</g, "\\u003c"),
+            }}
+          />
+        )}
+        {websiteBlob && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(websiteBlob).replace(/</g, "\\u003c"),
             }}
           />
         )}

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47",
+  "version": "1.0.48-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.47",
+  "version": "1.0.48-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47",
+  "version": "1.0.48-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.47",
+      "version": "1.0.48-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.47",
+  "version": "1.0.48-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## SEO follow-up — BreadcrumbList + WebSite JSON-LD (1.0.48-beta.0)

Two more schema.org types in `Head.tsx`. First PR of the 1.0.48 beta cycle, starting on the freshly-synced `next` (at plain `1.0.47` from the post-promotion sync).

### What this adds

**BreadcrumbList** (every page 2+ slug segments deep)

Generates the navigation trail Google can render in SERPs:

```
Home › cookbook › Raspberry Pi vault from scratch
```

vs the bare URL. Higher CTR. Position-indexed `ListItem` entries; the leaf uses the frontmatter `title` (richer than slug-derived). Intermediate folder URLs resolve because Quartz emits `index.html` for each section landing (`en/cookbook/`, `en/architecture/`, etc.).

Slug-to-readable conversion uses a small abbreviation lookup (`en` → "English", `ja` → "Japanese", `api` → "API", `faq` → "FAQ", `ssh` → "SSH", `sftp` → "SFTP", `cli` → "CLI") plus title-case fallback for the rest.

**WebSite** (root landing pages only — `en/index`, `ja/index`, `index`)

Tells Google the canonical name + URL of the site as a whole. Pairs cleanly with the existing `SoftwareApplication` schema on the same pages (different `@type` values, no duplication).

### What this deliberately omits

**SearchAction** is NOT emitted. Quartz's built-in search is keyboard-driven (Ctrl+K), not URL-driven — there's no `urlTemplate` Google could actually follow. Adding a fake `urlTemplate` is worse than omitting: Google's structured-data validator can reject the entire `WebSite` if SearchAction is broken. If we ever wire up URL-driven search (e.g. `?q=foo` triggering the search bar), drop in the SearchAction then.

### Coverage

| Schema | Pages |
|---|---|
| BreadcrumbList | ~75 pages (every page 2+ segments deep) |
| WebSite | 3 pages (`en/index`, `ja/index`, `index`) |

Combined with previous SEO PRs, the docs site now emits up to 3 separate JSON-LD blocks per page: a page-type schema (SoftwareApplication / FAQPage / Article / TechArticle), the BreadcrumbList, and WebSite on the roots.

### Where this fits in the broader SEO sequence

Today's Quick-wins + 1.0.48-beta.0 batch:

- GitHub repo: `homepage` set, topics expanded from 6 to 13 (added `self-hosted`, `note-taking`, `pkm`, `raspberry-pi`, `typescript`, `golang`, `remote-vault`)
- `robots.txt` PR opened on `sotashimozono.github.io` to declare the obsidian-remote-ssh sitemap alongside the personal site's
- This PR: BreadcrumbList + WebSite JSON-LD

Next planned beta improvements (separate PRs to keep review surface small):

- Lighthouse / Core Web Vitals audit + fixes (LCP / CLS / INP)
- Custom GitHub social preview image (repo settings)
- Additional content-side description expansion as Search Console data accrues

## Test plan

- [ ] CI green
- [ ] After dev docs deploy: view-source on `/dev/en/cookbook/raspberry-pi-vault` shows 3 `<script type="application/ld+json">` blocks — the existing Article + new BreadcrumbList (+ no WebSite since not a root)
- [ ] view-source on `/dev/en/` shows SoftwareApplication + WebSite (+ no BreadcrumbList since 1 segment)
- [ ] [Google Rich Results Test](https://search.google.com/test/rich-results) on a cookbook page recognises the BreadcrumbList
- [ ] After stable promotion: same on production URLs
