### PR TITLE
ci: unblock Dependabot PRs (version-check skip + Dockerfile mkdir -p)

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -38,31 +38,31 @@ jobs:
     # Branch protection lists this as a required check, and a
     # job-level `if:` would cause GitHub to omit the check entirely
     # ("expected but missing" → merge blocked). We instead skip at
-    # the STEP level for sync-shape PRs: no real work happens, but
-    # the empty job still reports green.
+    # the STEP level for auto-generated PRs: no real work happens,
+    # but the empty job still reports green.
     #
-    # Two PR shapes count as "sync" for the skip:
+    # Three PR shapes are skipped:
     #   1. head_ref == 'main' — the auto-opened main → next sync PR
     #      from sync-main-to-next.yml.
     #   2. head_ref starts with 'chore/sync-main-to-next' — a manual
-    #      conflict-resolution PR opened when (1) hits conflicts that
-    #      can't be resolved on the main head ref. Same purpose, same
-    #      semantics; the version-check rules don't apply because the
-    #      whole point is to pull main's version state into next.
+    #      conflict-resolution PR opened when (1) hits conflicts.
+    #   3. actor == 'dependabot[bot]' — dependency-bump PRs carry no
+    #      plugin version change by design.
     steps:
-      - name: Detect sync-shape PR
+      - name: Detect auto-generated PR (sync or Dependabot)
         id: sync_check
         run: |
           if [[ "${{ github.head_ref }}" == "main" ]] \
-            || [[ "${{ github.head_ref }}" == chore/sync-main-to-next* ]]; then
+            || [[ "${{ github.head_ref }}" == chore/sync-main-to-next* ]] \
+            || [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
             echo "is_sync=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_sync=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Skip note (sync PRs only)
+      - name: Skip note (auto-generated PRs)
         if: steps.sync_check.outputs.is_sync == 'true'
-        run: echo "Sync-shape PR (head=${{ github.head_ref }}) — version-check is a no-op."
+        run: echo "Auto-generated PR (actor=${{ github.actor }}, head=${{ github.head_ref }}) — version-check is a no-op."
 
       - if: steps.sync_check.outputs.is_sync != 'true'
         uses: actions/checkout@v6
@@ -152,7 +152,7 @@ jobs:
           fi
 
       - name: STABLE channel (PR → main) — head version must be plain X.Y.Z
-        if: github.base_ref == 'main'
+        if: github.base_ref == 'main' && steps.sync_check.outputs.is_sync != 'true'
         run: |
           head="${{ steps.versions.outputs.head_manifest }}"
           if [[ "$head" == *-beta.* ]]; then

--- a/docker/test-sshd/Dockerfile
+++ b/docker/test-sshd/Dockerfile
@@ -12,8 +12,8 @@ FROM ubuntu:24.04
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openssh-server iproute2 \
  && rm -rf /var/lib/apt/lists/* \
- && mkdir /var/run/sshd \
- # Ubuntu 24.04 ships with a pre-created `ubuntu` user at UID 1000;
+ && mkdir -p /var/run/sshd \
+ # Ubuntu 24.04+ ships with a pre-created `ubuntu` user at UID 1000;
  # remove it so the well-known `tester` UID stays available. Older
  # bases (22.04) don't have this user — `|| true` keeps the build
  # green if dependabot ever pulls us back.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.48-beta.0",
+  "version": "1.0.48-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.48-beta.0",
+  "version": "1.0.48-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.48-beta.0",
+  "version": "1.0.48-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.48-beta.0",
+      "version": "1.0.48-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.48-beta.0",
+  "version": "1.0.48-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- **version-check.yml**: extend the auto-PR skip logic to include `dependabot[bot]`. Dependency-bump PRs don't carry a plugin version change by design; the job still runs and reports green (required check stays satisfied) but no actual version assertions execute.
- **docker/test-sshd/Dockerfile**: change `mkdir /var/run/sshd` to `mkdir -p /var/run/sshd`. On Ubuntu 26.04 (Resolute) the `openssh-server` post-install script may pre-create the directory, causing the bare `mkdir` to fail with exit 1 and breaking the SSH integration test.

## Why now

Dependabot opened 5 PRs (#332-#336). Four of them (#332, #333, #334, #335) are safe patch/minor bumps that are blocked only by `version-check` failing. This PR fixes both blockers so those four can merge cleanly. PR #336 (xterm 5 to 6) is a separate story -- bundle-size exceeds the 800 KB limit and needs its own investigation.

## Test plan

- [ ] CI passes on this PR (version-check reports green for a non-Dependabot PR -- no regressions)
- [ ] After merge to `next`, trigger re-run on Dependabot PRs #332, #333, #334, #335 and confirm all required checks pass
- [ ] SSH integration test passes on #334 (Ubuntu 26.04) after this merges

Generated with Claude Code