### PR TITLE
chore(build): raise bundle-size cap to 900 KB and prefer ESM xterm build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - run: npm ci
       - name: Production build
         run: node esbuild.config.mjs production
-      - name: Bundle size guard (< 800 KB)
+      - name: Bundle size guard (< 900 KB)
         # Use Node for stat so the script works identically on
         # ubuntu/macos/windows (GNU `stat -c%s` and BSD `stat -f%z`
         # diverge; PowerShell's `Get-Item` is a third dialect). Inline
@@ -161,8 +161,10 @@ jobs:
         # the printed strings don't confuse the YAML parser.
         #
         # Cap raised 600 → 800 KB in #149 to absorb the bundled
-        # xterm.js + addon-fit (~300 KB combined). Mirror of
-        # `release.yml`'s same-named guard — both must agree.
+        # xterm.js + addon-fit (~300 KB combined). Raised 800 → 900 KB
+        # for xterm 6: even after switching to the smaller ESM build via
+        # `mainFields: ['module', 'main']`, xterm 6 adds ~55 KB over 5.x.
+        # Mirror of `release.yml`'s same-named guard — both must agree.
         shell: bash
         run: |
           node -e '
@@ -170,8 +172,8 @@ jobs:
           const size = fs.statSync("main.js").size;
           const kb = Math.round(size / 1024);
           console.log("Bundle: " + kb + " KB");
-          if (size > 819200) {
-            console.error("::error::Bundle " + kb + " KB exceeds 800 KB limit — check for unwanted large deps");
+          if (size > 921600) {
+            console.error("::error::Bundle " + kb + " KB exceeds 900 KB limit — check for unwanted large deps");
             process.exit(1);
           }'
       - name: Upload build artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,19 +256,22 @@ jobs:
       - name: Verify bundle size
         working-directory: plugin
         # Cap raised 600 → 800 KB in #149 to absorb the bundled
-        # xterm.js + addon-fit (~300 KB combined). esbuild code-
-        # splitting requires `format: 'esm'`, which Obsidian plugins
-        # don't support, so the terminal deps land in the same main.js
-        # along with everything else. 800 KB is still standard for an
-        # Obsidian plugin (Excalidraw 5.9 MB / Templater 4.2 MB /
-        # Dataview 4.1 MB) — flag here if a future feature pushes us
-        # higher and we need to revisit on-demand loading.
+        # xterm.js + addon-fit (~300 KB combined). Raised 800 → 900 KB
+        # for xterm 6: its CJS build is ~40% larger than 5.x, and even
+        # after preferring the ESM build via esbuild `mainFields`, the
+        # plugin gains ~55 KB. esbuild code-splitting requires
+        # `format: 'esm'`, which Obsidian plugins don't support, so the
+        # terminal deps land in the same main.js along with everything
+        # else. 900 KB is still standard for an Obsidian plugin
+        # (Excalidraw 5.9 MB / Templater 4.2 MB / Dataview 4.1 MB) —
+        # flag here if a future feature pushes us higher and we need
+        # to revisit on-demand loading.
         run: |
           SIZE=$(stat -c%s main.js)
           KB=$(( SIZE / 1024 ))
           echo "Bundle: ${KB} KB"
-          if [ $SIZE -gt 819200 ]; then
-            echo "::error::Bundle ${KB} KB exceeds 800 KB limit"
+          if [ $SIZE -gt 921600 ]; then
+            echo "::error::Bundle ${KB} KB exceeds 900 KB limit"
             exit 1
           fi
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.48-beta.1",
+  "version": "1.0.48-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/esbuild.config.mjs
+++ b/plugin/esbuild.config.mjs
@@ -30,6 +30,12 @@ esbuild.build({
   format: 'cjs',
   platform: 'node',
   target: 'node18',
+  // Prefer the `module` field (ESM build) over `main` (CJS build) when a
+  // package ships both. xterm 6 ships a CJS bundle (~488 KB) that's ~40%
+  // larger than its ESM equivalent (~345 KB); picking the ESM variant
+  // keeps the plugin bundle under the 800 KB guard. esbuild still wraps
+  // the result in our CJS output format, so Obsidian can `require()` it.
+  mainFields: ['module', 'main'],
   sourcemap: prod ? false : 'inline',
   minify: prod,
   outfile: 'main.js',

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.48-beta.1",
+  "version": "1.0.48-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.48-beta.1",
+  "version": "1.0.48-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.48-beta.1",
+      "version": "1.0.48-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.48-beta.1",
+  "version": "1.0.48-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Prepare for Dependabot PR #336 (`@xterm/xterm` 5.5.0 -> 6.0.0) by:

1. **esbuild.config.mjs**: add `mainFields: ['module', 'main']` so xterm 6's smaller ESM build (~345 KB) is picked over its CJS build (~488 KB). No effect on xterm 5 or any other CJS-only dep.

2. **ci.yml + release.yml**: raise the bundle-size guard 800 -> 900 KB. Even with the ESM preference, xterm 6 adds ~55 KB over 5.x.

## Why

xterm 6 ballooned its CJS build by ~199 KB (5.x: 289 KB -> 6.x: 488 KB). esbuild on `platform: 'node'` resolves to `main` by default, picking the bloated CJS. The ESM build (`lib/xterm.mjs`) is only +56 KB over 5.x.

Bundle measurements (local, production build):
- Current (xterm 5, CJS): **771 KB**
- xterm 6 + CJS default: **966 KB** (over the 800 KB cap by 166 KB)
- xterm 6 + ESM via mainFields: **825 KB** (only 25 KB over the 800 KB cap)

900 KB cap accommodates xterm 6 ESM with ~75 KB of headroom. Still small for an Obsidian plugin (Excalidraw 5.9 MB / Templater 4.2 MB / Dataview 4.1 MB).

## Test plan

- [ ] CI passes — production build is < 900 KB on `next` (no xterm 6 yet)
- [ ] After merge, rebase Dependabot PR #336 and verify it builds under 900 KB

Generated with Claude Code