### PR TITLE
fix(sync): writer self-reflect (#341) + shared-config round-trip (#342)

### DIFF
--- a/plugin/src/adapter/AdapterManager.ts
+++ b/plugin/src/adapter/AdapterManager.ts
@@ -239,37 +239,58 @@ export class AdapterManager {
 
     // Live-update subscription is only meaningful on the RPC transport;
     // the SFTP fallback has no notification channel.
-    //
-    // The two transports get *different* writer-side reflect paths
-    // (#341):
-    //
-    //  - RPC: the daemon's fs.watch echoes our own writes back, and
-    //    FsChangeListener already turns those into vault.trigger(...)
-    //    via its own VaultModelBuilder. Wiring a writer reflector too
-    //    would double-fire every event. Leave the reflector null and
-    //    keep relying on the echo (de-duping the echo so the reflect
-    //    is immediate is tracked separately — see the RPC self-reflect
-    //    suite, still red by design).
-    //
-    //  - SFTP: no daemon, no echo, no recovery channel — the writer's
-    //    vault model never learns about its own mutations. Wire a
-    //    VaultModelBuilder as the reflector so adapter.write/rename/
-    //    remove/mkdir mirror straight into vault.fileMap + the trigger
-    //    bus. VaultModelBuilder is stateless (it only mutates the live
-    //    Vault), so a single instance for the patched lifetime is fine.
     if (this.conn.rpcConnection) {
       void this.fsChangeListener.subscribe({
         rpcConnection: this.conn.rpcConnection,
         dataAdapter: this._dataAdapter,
         pathMapper: mapper,
       });
-    } else {
-      this._dataAdapter.setWriterReflector(
-        new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
-      );
     }
+    this.applyWriterReflectPolicy();
 
     return true;
+  }
+
+  /**
+   * Pick the writer-side reflect strategy for the *currently active*
+   * transport (#341). Called at `patch()` time and again after every
+   * transport swap, because a reconnect can flip SFTP↔RPC and the
+   * adapter object outlives the swap.
+   *
+   *  - RPC: the daemon's `fs.watch` echoes our own writes back and
+   *    `FsChangeListener` already turns those into `vault.trigger(...)`
+   *    via its own `VaultModelBuilder`. A writer reflector on top
+   *    would double-fire every event, so it's cleared to null.
+   *  - SFTP: no daemon, no echo, no recovery channel — the writer's
+   *    vault model never learns about its own mutations. Wire a
+   *    `VaultModelBuilder` reflector so adapter write/rename/remove/
+   *    mkdir mirror straight into `vault.fileMap` + the trigger bus.
+   *    `VaultModelBuilder` is stateless (only mutates the live
+   *    `Vault`), so a fresh instance per (re)wire is fine.
+   *
+   * `this.conn.rpcConnection` is authoritative here: on reconnect it
+   * is (re)established before the `swapClient` hook fires (see
+   * `ConnectionManager.reconnect`), so reading it from
+   * `afterSwapClient` reflects the post-swap transport.
+   */
+  private applyWriterReflectPolicy(): void {
+    if (!this._dataAdapter) return;
+    this._dataAdapter.setWriterReflector(
+      this.conn.rpcConnection
+        ? null
+        : new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
+    );
+  }
+
+  /**
+   * Re-evaluate the writer-reflect policy after the reconnect loop
+   * swapped the adapter's transport. Must be called from the
+   * `swapClient` reconnect hook; without it a SFTP→RPC reconnect
+   * keeps a now-double-firing reflector, and RPC→SFTP loses the
+   * reflector entirely (silent #341 regression).
+   */
+  afterSwapClient(): void {
+    this.applyWriterReflectPolicy();
   }
 
   /**

--- a/plugin/src/adapter/AdapterManager.ts
+++ b/plugin/src/adapter/AdapterManager.ts
@@ -1,5 +1,6 @@
 import type { App, PluginManifest } from 'obsidian';
-import { FileSystemAdapter, Notice } from 'obsidian';
+import { FileSystemAdapter, Notice, TFile, TFolder } from 'obsidian';
+import { VaultModelBuilder } from '../vault/VaultModelBuilder';
 import type { PluginSettings } from '../types';
 import { ReadCache } from '../cache/ReadCache';
 import { DirCache } from '../cache/DirCache';
@@ -238,12 +239,34 @@ export class AdapterManager {
 
     // Live-update subscription is only meaningful on the RPC transport;
     // the SFTP fallback has no notification channel.
+    //
+    // The two transports get *different* writer-side reflect paths
+    // (#341):
+    //
+    //  - RPC: the daemon's fs.watch echoes our own writes back, and
+    //    FsChangeListener already turns those into vault.trigger(...)
+    //    via its own VaultModelBuilder. Wiring a writer reflector too
+    //    would double-fire every event. Leave the reflector null and
+    //    keep relying on the echo (de-duping the echo so the reflect
+    //    is immediate is tracked separately — see the RPC self-reflect
+    //    suite, still red by design).
+    //
+    //  - SFTP: no daemon, no echo, no recovery channel — the writer's
+    //    vault model never learns about its own mutations. Wire a
+    //    VaultModelBuilder as the reflector so adapter.write/rename/
+    //    remove/mkdir mirror straight into vault.fileMap + the trigger
+    //    bus. VaultModelBuilder is stateless (it only mutates the live
+    //    Vault), so a single instance for the patched lifetime is fine.
     if (this.conn.rpcConnection) {
       void this.fsChangeListener.subscribe({
         rpcConnection: this.conn.rpcConnection,
         dataAdapter: this._dataAdapter,
         pathMapper: mapper,
       });
+    } else {
+      this._dataAdapter.setWriterReflector(
+        new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
+      );
     }
 
     return true;

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -222,10 +222,17 @@ export class SftpDataAdapter {
   /**
    * Run a writer-side reflect, swallowing + logging any throw. By the
    * time this runs the remote op has already succeeded; a reflector
-   * fault (or a vault listener that throws despite Obsidian's
-   * per-handler isolation) must not surface to the editor as a write
-   * failure and provoke a spurious retry / duplicate remote write.
-   * Centralising the guard also keeps the call sites to one line.
+   * fault (or a vault listener that throws — Obsidian wraps each
+   * `Events.trigger` handler in its own try/catch, but a fault inside
+   * `VaultModelBuilder` itself would still land here) must not surface
+   * to the editor as a write failure and provoke a spurious retry /
+   * duplicate remote write. Centralising the guard also keeps the
+   * call sites to one line.
+   *
+   * The log includes the error's class name so a systematic bug
+   * (`TypeError` from a model-builder defect) is distinguishable in
+   * the log stream from a transient listener fault — the two need
+   * very different triage.
    */
   private reflect(run: (r: WriterReflector) => void): void {
     const r = this.writerReflector;
@@ -233,7 +240,10 @@ export class SftpDataAdapter {
     try {
       run(r);
     } catch (e) {
-      logger.warn(`SftpDataAdapter: writer reflect failed: ${errorMessage(e)}`);
+      const kind = e instanceof Error ? e.name : typeof e;
+      logger.warn(
+        `SftpDataAdapter: writer reflect failed [${kind}]: ${errorMessage(e)}`,
+      );
     }
   }
 

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -200,21 +200,41 @@ export class SftpDataAdapter {
 
   /**
    * Writer-side vault-model reflector (#341). When wired, every
-   * successful local mutation is mirrored into the writer's own
-   * `vault.fileMap` + `vault.trigger(...)` bus so File Explorer,
-   * MetadataCache and open editor tabs follow a title-bar rename
-   * (etc.) instead of staying bound to the stale `TFile`.
+   * mutation that actually lands on the remote is mirrored into the
+   * writer's own `vault.fileMap` + `vault.trigger(...)` bus so File
+   * Explorer, MetadataCache and open editor tabs follow a title-bar
+   * rename (etc.) instead of staying bound to the stale `TFile`.
    *
-   * Null by default: the model builder needs the live `Vault`, which
-   * only exists once the shadow window opens, so it's wired via
-   * `setWriterReflector` after construction rather than as a
-   * constructor arg. When null, every reflect call is a no-op — the
+   * Null by default and wired via `setWriterReflector` rather than a
+   * constructor arg: the adapter is constructed before
+   * `AdapterManager` knows which transport is active, and the
+   * reflector is only meaningful for the SFTP transport (RPC recovers
+   * via the `FsChangeListener` daemon echo, so wiring both would
+   * double-fire). When null, every reflect call is a no-op — the
    * legacy behaviour, so non-shadow callers are unaffected.
    */
   private writerReflector: WriterReflector | null = null;
 
   setWriterReflector(reflector: WriterReflector | null): void {
     this.writerReflector = reflector;
+  }
+
+  /**
+   * Run a writer-side reflect, swallowing + logging any throw. By the
+   * time this runs the remote op has already succeeded; a reflector
+   * fault (or a vault listener that throws despite Obsidian's
+   * per-handler isolation) must not surface to the editor as a write
+   * failure and provoke a spurious retry / duplicate remote write.
+   * Centralising the guard also keeps the call sites to one line.
+   */
+  private reflect(run: (r: WriterReflector) => void): void {
+    const r = this.writerReflector;
+    if (!r) return;
+    try {
+      run(r);
+    } catch (e) {
+      logger.warn(`SftpDataAdapter: writer reflect failed: ${errorMessage(e)}`);
+    }
   }
 
   // ─── DataAdapter (read-side) ─────────────────────────────────────────────
@@ -379,7 +399,7 @@ export class SftpDataAdapter {
         const cached = this.readCache.peek(this.toRemote(normalizedPath));
         this.ancestorTracker.remember(normalizedPath, data, cached?.mtime ?? 0);
       }
-      this.writerReflector?.reflectWrite(normalizedPath);
+      this.reflect(r => r.reflectWrite(normalizedPath));
     } finally {
       perfTracer.end(__t1, { op: 'write', path: normalizedPath, bytes: data.length });
     }
@@ -393,7 +413,7 @@ export class SftpDataAdapter {
         return;
       }
       await this.writeBuffer(normalizedPath, Buffer.from(data), false);
-      this.writerReflector?.reflectWrite(normalizedPath);
+      this.reflect(r => r.reflectWrite(normalizedPath));
     } finally {
       perfTracer.end(__t1, { op: 'writeBinary', path: normalizedPath, bytes: data.byteLength });
     }
@@ -438,6 +458,10 @@ export class SftpDataAdapter {
       catch { existing = Buffer.alloc(0); }
       const merged = Buffer.concat([existing, Buffer.from(data)]);
       await this.writeBuffer(normalizedPath, merged, false);
+      // appendBinary writes through writeBuffer directly (not via
+      // this.write/writeBinary), so it must reflect itself or the
+      // writer's model misses binary appends (#341).
+      this.reflect(r => r.reflectWrite(normalizedPath));
       void options;
     } finally {
       perfTracer.end(__t1, { op: 'appendBinary', path: normalizedPath, bytes: data.byteLength });
@@ -479,7 +503,7 @@ export class SftpDataAdapter {
     const remote = this.toRemote(normalizedPath);
     await this.client.mkdirp(remote);
     this.dirCache.invalidate(parentDirRemote(remote));
-    this.writerReflector?.reflectMkdir(normalizedPath);
+    this.reflect(r => r.reflectMkdir(normalizedPath));
   }
 
   async remove(normalizedPath: string): Promise<void> {
@@ -493,7 +517,13 @@ export class SftpDataAdapter {
       }
       this.invalidatePath(remote);
       this.ancestorTracker?.invalidate(normalizedPath);
-      this.writerReflector?.reflectRemove(normalizedPath);
+      // Reflect only when the delete actually hit the remote. While
+      // reconnecting the op is merely queued; mirroring the model now
+      // would drop the entry locally even though the file still
+      // exists remotely, and a failed replay would leave them
+      // permanently diverged (the QueueReplayer path does not
+      // re-reflect).
+      if (!this.reconnecting) this.reflect(r => r.reflectRemove(normalizedPath));
     } finally {
       perfTracer.end(__t1, { op: 'remove', path: normalizedPath });
     }
@@ -511,7 +541,8 @@ export class SftpDataAdapter {
       // them out. Cheap to add later if it ever matters.
     }
     this.invalidateTree(remote);
-    this.writerReflector?.reflectRemove(normalizedPath);
+    // See `remove`: only mirror once the rmdir actually applied.
+    if (!this.reconnecting) this.reflect(r => r.reflectRemove(normalizedPath));
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
@@ -532,7 +563,8 @@ export class SftpDataAdapter {
       // whatever they last read at that path, regardless of how the
       // file got there.
       this.ancestorTracker?.invalidate(oldPath);
-      this.writerReflector?.reflectRename(oldPath, newPath);
+      // See `remove`: only mirror once the rename actually applied.
+      if (!this.reconnecting) this.reflect(r => r.reflectRename(oldPath, newPath));
     } finally {
       perfTracer.end(__t1, { op: 'rename', path: oldPath, newPath });
     }

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -22,6 +22,7 @@ function isThumbnailEligible(vaultPath: string): boolean {
   return THUMBNAIL_EXTENSIONS.has(vaultPath.slice(dot + 1).toLowerCase());
 }
 import type { RemoteFsClient } from './RemoteFsClient';
+import type { WriterReflector } from './WriterReflector';
 import type { ReadCache } from '../cache/ReadCache';
 import type { DirCache } from '../cache/DirCache';
 import type { PathMapper } from '../path/PathMapper';
@@ -197,6 +198,25 @@ export class SftpDataAdapter {
     return this.reconnecting;
   }
 
+  /**
+   * Writer-side vault-model reflector (#341). When wired, every
+   * successful local mutation is mirrored into the writer's own
+   * `vault.fileMap` + `vault.trigger(...)` bus so File Explorer,
+   * MetadataCache and open editor tabs follow a title-bar rename
+   * (etc.) instead of staying bound to the stale `TFile`.
+   *
+   * Null by default: the model builder needs the live `Vault`, which
+   * only exists once the shadow window opens, so it's wired via
+   * `setWriterReflector` after construction rather than as a
+   * constructor arg. When null, every reflect call is a no-op — the
+   * legacy behaviour, so non-shadow callers are unaffected.
+   */
+  private writerReflector: WriterReflector | null = null;
+
+  setWriterReflector(reflector: WriterReflector | null): void {
+    this.writerReflector = reflector;
+  }
+
   // ─── DataAdapter (read-side) ─────────────────────────────────────────────
 
   getName(): string {
@@ -359,6 +379,7 @@ export class SftpDataAdapter {
         const cached = this.readCache.peek(this.toRemote(normalizedPath));
         this.ancestorTracker.remember(normalizedPath, data, cached?.mtime ?? 0);
       }
+      this.writerReflector?.reflectWrite(normalizedPath);
     } finally {
       perfTracer.end(__t1, { op: 'write', path: normalizedPath, bytes: data.length });
     }
@@ -372,6 +393,7 @@ export class SftpDataAdapter {
         return;
       }
       await this.writeBuffer(normalizedPath, Buffer.from(data), false);
+      this.writerReflector?.reflectWrite(normalizedPath);
     } finally {
       perfTracer.end(__t1, { op: 'writeBinary', path: normalizedPath, bytes: data.byteLength });
     }
@@ -457,6 +479,7 @@ export class SftpDataAdapter {
     const remote = this.toRemote(normalizedPath);
     await this.client.mkdirp(remote);
     this.dirCache.invalidate(parentDirRemote(remote));
+    this.writerReflector?.reflectMkdir(normalizedPath);
   }
 
   async remove(normalizedPath: string): Promise<void> {
@@ -470,6 +493,7 @@ export class SftpDataAdapter {
       }
       this.invalidatePath(remote);
       this.ancestorTracker?.invalidate(normalizedPath);
+      this.writerReflector?.reflectRemove(normalizedPath);
     } finally {
       perfTracer.end(__t1, { op: 'remove', path: normalizedPath });
     }
@@ -487,6 +511,7 @@ export class SftpDataAdapter {
       // them out. Cheap to add later if it ever matters.
     }
     this.invalidateTree(remote);
+    this.writerReflector?.reflectRemove(normalizedPath);
   }
 
   async rename(oldPath: string, newPath: string): Promise<void> {
@@ -507,6 +532,7 @@ export class SftpDataAdapter {
       // whatever they last read at that path, regardless of how the
       // file got there.
       this.ancestorTracker?.invalidate(oldPath);
+      this.writerReflector?.reflectRename(oldPath, newPath);
     } finally {
       perfTracer.end(__t1, { op: 'rename', path: oldPath, newPath });
     }

--- a/plugin/src/adapter/WriterReflector.ts
+++ b/plugin/src/adapter/WriterReflector.ts
@@ -1,0 +1,47 @@
+/**
+ * Callback surface the `SftpDataAdapter` invokes after a
+ * local-originated mutation succeeds, so the writer's own in-memory
+ * vault model — `vault.fileMap` plus the `vault.trigger(...)` event
+ * bus that File Explorer, MetadataCache and open editor tabs all
+ * subscribe to — reflects the change without waiting for a
+ * remote-driven echo.
+ *
+ * Issue #341: a title-bar rename calls `adapter.rename(old, new)`,
+ * the remote op succeeds, but nothing fires `vault.trigger('rename')`
+ * on the writer side, so the open editor tab stays bound to the
+ * stale `TFile` and the next save targets a path that no longer
+ * exists. On the SFTP transport there is no daemon `fs.watch` push
+ * to recover from, so the divergence is permanent.
+ *
+ * `VaultModelBuilder` already maintains exactly this model for
+ * remote-originated changes (driven by `FsChangeListener`); it
+ * structurally satisfies this interface, so the writer path reuses
+ * it. The interface lives in `adapter/` and is referenced only
+ * structurally from `vault/`, so wiring it introduces no
+ * adapter → vault import edge.
+ */
+export interface WriterReflector {
+  /**
+   * After `write` / `writeBinary`: insert the `TFile` and fire
+   * `create` when the path is new, otherwise fire `modify`.
+   */
+  reflectWrite(path: string): void;
+
+  /**
+   * After `rename`: move the entry between `fileMap` keys and fire
+   * `vault.trigger('rename', file, oldPath)`.
+   */
+  reflectRename(oldPath: string, newPath: string): void;
+
+  /**
+   * After `remove` / `rmdir`: drop the entry (and descendants, for a
+   * folder) and fire `vault.trigger('delete', file)`.
+   */
+  reflectRemove(path: string): void;
+
+  /**
+   * After `mkdir`: insert the `TFolder` when absent and fire
+   * `vault.trigger('create', folder)`.
+   */
+  reflectMkdir(path: string): void;
+}

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -541,7 +541,13 @@ export default class RemoteSshPlugin extends Plugin {
       setAdapterReconnecting: (on) => this.adapterMgr.dataAdapter?.setReconnecting(on),
       onState: (s) => this.onReconnectStateChange(s),
       hooks: {
-        swapClient: (c) => this.adapterMgr.dataAdapter?.swapClient(c),
+        swapClient: (c) => {
+          this.adapterMgr.dataAdapter?.swapClient(c);
+          // The reconnect may have flipped SFTP↔RPC; re-pick the
+          // writer-reflect policy so we don't double-fire (RPC) or
+          // silently lose self-reflect (SFTP) — #341.
+          this.adapterMgr.afterSwapClient();
+        },
         prepareListenerForReconnect: () => this.fsChangeListener.prepareForReconnect(),
         resumeListenerAfterReconnect: async (rpc) => {
           const da = this.adapterMgr.dataAdapter;

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -478,6 +478,28 @@ export default class RemoteSshPlugin extends Plugin {
       return;
     }
 
+    // Pull the shared Obsidian config (app.json / appearance.json /
+    // core-plugins.json / hotkeys.json) from the remote onto the
+    // local shadow disk *before* the populate, so the next time this
+    // window restarts Obsidian reads fresh settings instead of the
+    // stale local copy (#342). Best-effort: a failure here must not
+    // block rendering the vault.
+    const da = this.adapterMgr.dataAdapter;
+    const hostAdapter = this.app.vault.adapter;
+    if (da && hostAdapter instanceof FileSystemAdapter) {
+      try {
+        await ShadowVaultBootstrap.pullSharedObsidianConfig(
+          da,
+          this.app.vault.configDir,
+          path.join(hostAdapter.getBasePath(), this.app.vault.configDir),
+        );
+      } catch (e) {
+        logger.warn(
+          `runAutoConnect(${tag}): shared-config pull failed: ${errorMessage(e)}`,
+        );
+      }
+    }
+
     // Adapter is patched; build the file model so File Explorer
     // renders the remote tree.
     let summary: string;

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -488,11 +488,23 @@ export default class RemoteSshPlugin extends Plugin {
     const hostAdapter = this.app.vault.adapter;
     if (da && hostAdapter instanceof FileSystemAdapter) {
       try {
-        await ShadowVaultBootstrap.pullSharedObsidianConfig(
+        const cfg = await ShadowVaultBootstrap.pullSharedObsidianConfig(
           da,
           this.app.vault.configDir,
           path.join(hostAdapter.getBasePath(), this.app.vault.configDir),
         );
+        if (cfg.errored.length > 0) {
+          // The connection is up but some shared-config files the
+          // remote *had* couldn't be pulled (transient SSH error /
+          // corrupt file). Without a signal the user would just see
+          // settings silently not update — the #342 symptom. Absent
+          // files are not errored, so a fresh vault stays quiet.
+          new Notice(
+            `Remote SSH: ${cfg.errored.length} shared-config file` +
+            `${cfg.errored.length === 1 ? '' : 's'} (${cfg.errored.join(', ')}) ` +
+            'could not be synced — settings may be stale until the next connect',
+          );
+        }
       } catch (e) {
         logger.warn(
           `runAutoConnect(${tag}): shared-config pull failed: ${errorMessage(e)}`,

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -183,21 +183,28 @@ export class ShadowVaultBootstrap {
    * `workspace.json` is deliberately NOT here — it's per-client UI
    * state that `PathMapper` already redirects into a private subtree.
    */
-  static readonly SHARED_OBSIDIAN_CONFIG_FILES: readonly string[] = [
+  static readonly SHARED_OBSIDIAN_CONFIG_FILES = [
     'app.json',
     'appearance.json',
     'core-plugins.json',
     'hotkeys.json',
-  ];
+  ] as const satisfies readonly string[];
 
   /**
    * Pull the shared-config allowlist from the remote into the local
    * shadow vault's config dir, closing the #342 round-trip gap.
    *
-   * Bytes are copied verbatim — no JSON parse/re-serialise — so key
-   * order and formatting survive exactly as Obsidian wrote them.
-   * A file absent on the remote is skipped, not treated as an error
-   * (a fresh remote vault legitimately has none of these yet).
+   * The remote bytes are written **verbatim** (no re-serialise, so
+   * key order / formatting survive), but only after `JSON.parse`
+   * confirms they're well-formed: a truncated or half-written remote
+   * file must not clobber a healthy local copy and leave Obsidian
+   * unable to read its own settings on next start (which is the very
+   * #342 symptom this method exists to fix). The write is atomic
+   * (tmp + rename) so an interrupted pull can't tear the local file.
+   *
+   * A file absent on the remote is skipped, not an error (a fresh
+   * remote vault legitimately has none yet). A present-but-corrupt
+   * file is skipped too, leaving the prior local copy intact.
    *
    * Static because both call sites (the connect flow in `main.ts`
    * and the Layer-2 test helper) have a reader + paths but not
@@ -223,7 +230,22 @@ export class ShadowVaultBootstrap {
           continue;
         }
         const content = await reader.read(remoteRel);
-        fs.writeFileSync(path.join(localConfigDir, basename), content, 'utf-8');
+        try {
+          JSON.parse(content);
+        } catch {
+          // Corrupt/partial remote file — do NOT overwrite the
+          // (possibly healthy) local copy with broken JSON.
+          logger.warn(
+            `pullSharedObsidianConfig: ${basename} on remote is not valid JSON; ` +
+            'keeping the local copy untouched',
+          );
+          skipped.push(basename);
+          continue;
+        }
+        const dest = path.join(localConfigDir, basename);
+        const tmp = `${dest}.${process.pid}.tmp`;
+        fs.writeFileSync(tmp, content, 'utf-8');
+        fs.renameSync(tmp, dest);
         pulled.push(basename);
       } catch (e) {
         // Best-effort: a single unreadable file must not abort the

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -30,6 +30,18 @@ export interface BootstrapResult {
 }
 
 /**
+ * The narrow read surface `pullSharedObsidianConfig` needs from the
+ * remote. `SftpDataAdapter` satisfies this structurally (it has both
+ * `exists` and a string-returning `read`), so the connect flow and
+ * the Layer-2 test helper pass the patched adapter directly. Kept
+ * minimal so `shadow/` gains no dependency on `adapter/`.
+ */
+export interface SharedConfigReader {
+  exists(normalizedPath: string): Promise<boolean>;
+  read(normalizedPath: string): Promise<string>;
+}
+
+/**
  * Materialises the on-disk shadow vault for a profile so a separate
  * Obsidian window can open it as if it were any other local vault.
  *
@@ -155,6 +167,80 @@ export class ShadowVaultBootstrap {
     const pluginDir = path.join(configDir, 'plugins', 'remote-ssh');
     const pluginDataFile = path.join(pluginDir, 'data.json');
     return { vaultDir, configDir, pluginDir, pluginDataFile };
+  }
+
+  // ─── shared-config round-trip (#342) ────────────────────────────────────
+
+  /**
+   * Shared (non per-client) Obsidian config files. `PathMapper`
+   * leaves these unmapped on purpose so every machine on the vault
+   * sees the same `app.json` / theme / enabled-core-plugins /
+   * hotkeys. The sharing was one-way though: edits in one session
+   * push to the remote, but the local shadow disk never pulled them
+   * back, so the *next* Obsidian startup read a stale local copy and
+   * the settings appeared to evaporate (#342).
+   *
+   * `workspace.json` is deliberately NOT here — it's per-client UI
+   * state that `PathMapper` already redirects into a private subtree.
+   */
+  static readonly SHARED_OBSIDIAN_CONFIG_FILES: readonly string[] = [
+    'app.json',
+    'appearance.json',
+    'core-plugins.json',
+    'hotkeys.json',
+  ];
+
+  /**
+   * Pull the shared-config allowlist from the remote into the local
+   * shadow vault's config dir, closing the #342 round-trip gap.
+   *
+   * Bytes are copied verbatim — no JSON parse/re-serialise — so key
+   * order and formatting survive exactly as Obsidian wrote them.
+   * A file absent on the remote is skipped, not treated as an error
+   * (a fresh remote vault legitimately has none of these yet).
+   *
+   * Static because both call sites (the connect flow in `main.ts`
+   * and the Layer-2 test helper) have a reader + paths but not
+   * necessarily a constructed `ShadowVaultBootstrap` to hand.
+   */
+  static async pullSharedObsidianConfig(
+    reader: SharedConfigReader,
+    /** Vault-relative config dir, e.g. `.obsidian` (`app.vault.configDir`). */
+    remoteConfigDir: string,
+    /** Absolute local config dir, i.e. `ShadowVaultLayout.configDir`. */
+    localConfigDir: string,
+  ): Promise<{ pulled: string[]; skipped: string[] }> {
+    const pulled: string[] = [];
+    const skipped: string[] = [];
+
+    fs.mkdirSync(localConfigDir, { recursive: true });
+
+    for (const basename of ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES) {
+      const remoteRel = `${remoteConfigDir}/${basename}`;
+      try {
+        if (!(await reader.exists(remoteRel))) {
+          skipped.push(basename);
+          continue;
+        }
+        const content = await reader.read(remoteRel);
+        fs.writeFileSync(path.join(localConfigDir, basename), content, 'utf-8');
+        pulled.push(basename);
+      } catch (e) {
+        // Best-effort: a single unreadable file must not abort the
+        // others or fail the connect. The stale local copy (if any)
+        // stays; logged so it's diagnosable.
+        logger.warn(
+          `pullSharedObsidianConfig: ${basename} skipped (${errorMessage(e)})`,
+        );
+        skipped.push(basename);
+      }
+    }
+
+    logger.info(
+      `pullSharedObsidianConfig: pulled [${pulled.join(', ')}], ` +
+      `skipped [${skipped.join(', ')}]`,
+    );
+    return { pulled, skipped };
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -202,9 +202,16 @@ export class ShadowVaultBootstrap {
    * #342 symptom this method exists to fix). The write is atomic
    * (tmp + rename) so an interrupted pull can't tear the local file.
    *
-   * A file absent on the remote is skipped, not an error (a fresh
-   * remote vault legitimately has none yet). A present-but-corrupt
-   * file is skipped too, leaving the prior local copy intact.
+   * The result distinguishes two kinds of non-pull:
+   *  - `skipped`: every basename not pulled (absent OR errored) — the
+   *    superset, kept for back-compat / logging.
+   *  - `errored`: the subset where the remote *had* the file but it
+   *    couldn't be pulled (read/exists threw, corrupt JSON, write or
+   *    rename failed). A file absent on the remote is NOT errored (a
+   *    fresh remote vault legitimately has none yet). The connect flow
+   *    surfaces a Notice when `errored` is non-empty so a transient
+   *    SSH hiccup doesn't silently leave settings stale — the #342
+   *    symptom this method exists to prevent.
    *
    * Static because both call sites (the connect flow in `main.ts`
    * and the Layer-2 test helper) have a reader + paths but not
@@ -216,9 +223,10 @@ export class ShadowVaultBootstrap {
     remoteConfigDir: string,
     /** Absolute local config dir, i.e. `ShadowVaultLayout.configDir`. */
     localConfigDir: string,
-  ): Promise<{ pulled: string[]; skipped: string[] }> {
+  ): Promise<{ pulled: string[]; skipped: string[]; errored: string[] }> {
     const pulled: string[] = [];
     const skipped: string[] = [];
+    const errored: string[] = [];
 
     fs.mkdirSync(localConfigDir, { recursive: true });
 
@@ -240,29 +248,41 @@ export class ShadowVaultBootstrap {
             'keeping the local copy untouched',
           );
           skipped.push(basename);
+          errored.push(basename);
           continue;
         }
         const dest = path.join(localConfigDir, basename);
         const tmp = `${dest}.${process.pid}.tmp`;
         fs.writeFileSync(tmp, content, 'utf-8');
-        fs.renameSync(tmp, dest);
+        try {
+          fs.renameSync(tmp, dest);
+        } catch (renameErr) {
+          // rename failed (perms / cross-device) — drop the orphan
+          // tmp so it can't accumulate or be mistaken for real data,
+          // then rethrow into the outer catch for the skip+error path.
+          try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+          throw renameErr;
+        }
         pulled.push(basename);
       } catch (e) {
         // Best-effort: a single unreadable file must not abort the
         // others or fail the connect. The stale local copy (if any)
-        // stays; logged so it's diagnosable.
+        // stays; logged so it's diagnosable. The remote *had* the
+        // file (exists() passed or threw) so this counts as errored,
+        // not a benign absence.
         logger.warn(
           `pullSharedObsidianConfig: ${basename} skipped (${errorMessage(e)})`,
         );
         skipped.push(basename);
+        errored.push(basename);
       }
     }
 
     logger.info(
       `pullSharedObsidianConfig: pulled [${pulled.join(', ')}], ` +
-      `skipped [${skipped.join(', ')}]`,
+      `skipped [${skipped.join(', ')}], errored [${errored.join(', ')}]`,
     );
-    return { pulled, skipped };
+    return { pulled, skipped, errored };
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -419,10 +419,19 @@ export class VaultModelBuilder {
       }
       return;
     }
-    this.insertOne(
+    if (!this.insertOne(
       { path, isDirectory: false, ctime: 0, mtime: Date.now(), size: 0 },
       { ensureParents: true },
-    );
+    )) {
+      // insertOne returns null when even ensureParents couldn't
+      // synthesise the chain (catastrophic — root missing). The new
+      // file exists on the remote but not in the writer's model:
+      // File Explorer won't show it until the next full populate.
+      logger.warn(
+        `VaultModelBuilder.reflectWrite: insertOne("${path}") no-op; ` +
+        'new file not reflected into the writer model',
+      );
+    }
   }
 
   /** Reflect a writer-side `adapter.rename`. */
@@ -451,10 +460,15 @@ export class VaultModelBuilder {
   /** Reflect a writer-side `adapter.mkdir` (idempotent if modelled). */
   reflectMkdir(path: string): void {
     if (this.vault.getAbstractFileByPath(path)) return;
-    this.insertOne(
+    if (!this.insertOne(
       { path, isDirectory: true, ctime: 0, mtime: Date.now(), size: 0 },
       { ensureParents: true },
-    );
+    )) {
+      logger.warn(
+        `VaultModelBuilder.reflectMkdir: insertOne("${path}") no-op; ` +
+        'new folder not reflected into the writer model',
+      );
+    }
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -1,4 +1,5 @@
 import type { TAbstractFile, TFile, TFolder, Vault } from 'obsidian';
+import type { WriterReflector } from '../adapter/WriterReflector';
 import { logger } from '../util/logger';
 import { perfTracer } from '../util/PerfTracer';
 import { errorMessage } from "../util/errorMessage";
@@ -375,8 +376,19 @@ export class VaultModelBuilder {
   // `SftpDataAdapter` calls them after a local-originated mutation so
   // the writer's own vault model stays in sync without waiting for a
   // remote `FsChangeListener` echo (which never arrives on the SFTP
-  // transport — no daemon). No `implements` clause: matching by shape
-  // keeps the dependency edge adapter → (structural) → vault only.
+  // transport — no daemon). There is no `implements WriterReflector`
+  // clause: that would force a runtime `vault → adapter` import for a
+  // value the class never references. Conformance is instead pinned
+  // at build time by the type-only `satisfies`-style anchor at the
+  // bottom of this file (tsconfig compiles only `src/**`, so the test
+  // wiring is *not* a typecheck — without the anchor a `reflect*`
+  // signature drift would ship green).
+  //
+  // The underlying `*One` mutators return `false` when the model
+  // couldn't be updated (path not modelled, destination parent
+  // missing). For a writer reflect that `false` means the writer's
+  // own vault model just diverged from the remote — the exact #341
+  // symptom — so it is logged rather than silently dropped.
 
   /**
    * Reflect a writer-side `adapter.write` / `writeBinary`. Inserts the
@@ -387,10 +399,24 @@ export class VaultModelBuilder {
   reflectWrite(path: string): void {
     const existing = this.vault.getAbstractFileByPath(path);
     if (existing) {
-      // A folder already occupying the path is pathological (the
-      // adapter wrote a file there); leave the model alone rather
-      // than firing a misleading `modify` for a TFolder.
-      if (!isFolder(existing)) this.modifyOne(path);
+      if (isFolder(existing)) {
+        // A folder occupies the path the adapter just wrote a file
+        // to (a folder→file swap raced our model). Firing `modify`
+        // for a TFolder would mislead File Explorer; not firing
+        // leaves the model wrong. Neither is recoverable here — log
+        // so the divergence is diagnosable.
+        logger.warn(
+          `VaultModelBuilder.reflectWrite: "${path}" is modelled as a folder; ` +
+          'model diverged from remote (file written over a folder)',
+        );
+        return;
+      }
+      if (!this.modifyOne(path)) {
+        logger.warn(
+          `VaultModelBuilder.reflectWrite: modifyOne("${path}") no-op; ` +
+          'writer model may be stale for this path',
+        );
+      }
       return;
     }
     this.insertOne(
@@ -401,10 +427,23 @@ export class VaultModelBuilder {
 
   /** Reflect a writer-side `adapter.rename`. */
   reflectRename(oldPath: string, newPath: string): void {
-    this.renameOne(oldPath, newPath);
+    if (!this.renameOne(oldPath, newPath)) {
+      // The open editor tab stays bound to the stale TFile — this is
+      // the core #341 failure. renameOne already warns with the
+      // specific cause; add the reflect context.
+      logger.warn(
+        `VaultModelBuilder.reflectRename: "${oldPath}" → "${newPath}" not reflected; ` +
+        'writer vault model is stale (editor may still point at the old path)',
+      );
+    }
   }
 
-  /** Reflect a writer-side `adapter.remove` / `rmdir`. */
+  /**
+   * Reflect a writer-side `adapter.remove` / `rmdir`. A `false` from
+   * `removeOne` (path was never modelled) is benign for a delete —
+   * the desired end state (absent) already holds — so it is not
+   * logged.
+   */
   reflectRemove(path: string): void {
     this.removeOne(path);
   }
@@ -517,3 +556,16 @@ function insertIntoFileMap(vault: Vault, path: string, entry: TAbstractFile): vo
   const map = (vault as unknown as { fileMap: Record<string, TAbstractFile> }).fileMap;
   map[path] = entry;
 }
+
+// Build-time proof that VaultModelBuilder structurally satisfies
+// WriterReflector. `tsconfig.json` compiles only `src/**`, so the
+// test wiring (`adapter.setWriterReflector(builder)`) is never
+// typechecked — without this anchor a `reflect*` rename or signature
+// drift would ship green and silently no-op behind the adapter's
+// optional chaining. Type-only: zero runtime, no `vault → adapter`
+// import edge. `Exact extends true` forces a compile error the moment
+// conformance breaks.
+type _Assert<T extends true> = T;
+type _WriterReflectorConformance = _Assert<
+  VaultModelBuilder extends WriterReflector ? true : false
+>;

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -369,6 +369,55 @@ export class VaultModelBuilder {
     return true;
   }
 
+  // ─── writer self-reflect (#341) ─────────────────────────────────────────
+  //
+  // These four methods structurally satisfy `adapter/WriterReflector`.
+  // `SftpDataAdapter` calls them after a local-originated mutation so
+  // the writer's own vault model stays in sync without waiting for a
+  // remote `FsChangeListener` echo (which never arrives on the SFTP
+  // transport — no daemon). No `implements` clause: matching by shape
+  // keeps the dependency edge adapter → (structural) → vault only.
+
+  /**
+   * Reflect a writer-side `adapter.write` / `writeBinary`. Inserts the
+   * file (firing `create`) when the path is new, otherwise bumps it
+   * (firing `modify`). Missing parent folders are synthesised so a
+   * write into a not-yet-modelled subtree still lands.
+   */
+  reflectWrite(path: string): void {
+    const existing = this.vault.getAbstractFileByPath(path);
+    if (existing) {
+      // A folder already occupying the path is pathological (the
+      // adapter wrote a file there); leave the model alone rather
+      // than firing a misleading `modify` for a TFolder.
+      if (!isFolder(existing)) this.modifyOne(path);
+      return;
+    }
+    this.insertOne(
+      { path, isDirectory: false, ctime: 0, mtime: Date.now(), size: 0 },
+      { ensureParents: true },
+    );
+  }
+
+  /** Reflect a writer-side `adapter.rename`. */
+  reflectRename(oldPath: string, newPath: string): void {
+    this.renameOne(oldPath, newPath);
+  }
+
+  /** Reflect a writer-side `adapter.remove` / `rmdir`. */
+  reflectRemove(path: string): void {
+    this.removeOne(path);
+  }
+
+  /** Reflect a writer-side `adapter.mkdir` (idempotent if modelled). */
+  reflectMkdir(path: string): void {
+    if (this.vault.getAbstractFileByPath(path)) return;
+    this.insertOne(
+      { path, isDirectory: true, ctime: 0, mtime: Date.now(), size: 0 },
+      { ensureParents: true },
+    );
+  }
+
   // ─── internals ──────────────────────────────────────────────────────────
 
   private insertFile(entry: RemoteEntry, parent: TFolder): TFile {

--- a/plugin/tests/AdapterManager.test.ts
+++ b/plugin/tests/AdapterManager.test.ts
@@ -13,12 +13,18 @@ import type { PluginSettings } from '../src/types';
  * mocks only need the methods that are called on a fresh (un-patched)
  * instance: FsChangeListener.unsubscribe() and ConnectionManager.rpcConnection.
  */
-function makeManager(opts: { transferTracker?: { clear: () => void } } = {}) {
+function makeManager(opts: {
+  transferTracker?: { clear: () => void };
+  rpcConnection?: unknown;
+} = {}) {
   const unsubscribeSpy = vi.fn();
   const mgr = new AdapterManager(
-    {} as App,
+    { vault: {} } as unknown as App,
     { id: 'remote-ssh' } as unknown as PluginManifest,
-    { rpcConnection: null, activeRemoteBasePath: null } as unknown as ConnectionManager,
+    {
+      rpcConnection: opts.rpcConnection ?? null,
+      activeRemoteBasePath: null,
+    } as unknown as ConnectionManager,
     { subscribe: vi.fn(), unsubscribe: unsubscribeSpy } as unknown as FsChangeListener,
     { startPolling: vi.fn() } as unknown as PendingEditsBar,
     () => ({}) as unknown as PluginSettings,
@@ -135,5 +141,40 @@ describe('AdapterManager.restore()', () => {
     const { mgr } = makeManager({ transferTracker: { clear: clearSpy } });
     mgr.restore();
     expect(clearSpy).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── afterSwapClient — writer-reflect policy (#341) ────────────────────────
+
+describe('AdapterManager.afterSwapClient() — transport reflect policy', () => {
+  /** Inject a fake patched adapter so we can observe setWriterReflector. */
+  function withFakeAdapter(mgr: AdapterManager) {
+    const setWriterReflector = vi.fn();
+    (mgr as unknown as { _dataAdapter: unknown })._dataAdapter = { setWriterReflector };
+    return setWriterReflector;
+  }
+
+  it('SFTP transport wires a (non-null) writer reflector', () => {
+    const { mgr } = makeManager({ rpcConnection: null });
+    const setWriterReflector = withFakeAdapter(mgr);
+
+    mgr.afterSwapClient();
+
+    expect(setWriterReflector).toHaveBeenCalledTimes(1);
+    expect(setWriterReflector.mock.calls[0][0]).not.toBeNull();
+  });
+
+  it('RPC transport clears the reflector to null (no double-fire with FsChangeListener)', () => {
+    const { mgr } = makeManager({ rpcConnection: { info: {} } });
+    const setWriterReflector = withFakeAdapter(mgr);
+
+    mgr.afterSwapClient();
+
+    expect(setWriterReflector).toHaveBeenCalledWith(null);
+  });
+
+  it('is a no-op (no throw) when no adapter is patched', () => {
+    const { mgr } = makeManager();
+    expect(() => mgr.afterSwapClient()).not.toThrow();
   });
 });

--- a/plugin/tests/AdapterManager.test.ts
+++ b/plugin/tests/AdapterManager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { AdapterManager, PATCHED_METHODS } from '../src/adapter/AdapterManager';
+import { VaultModelBuilder } from '../src/vault/VaultModelBuilder';
 import type { App, PluginManifest } from 'obsidian';
 import type { ConnectionManager } from '../src/ConnectionManager';
 import type { FsChangeListener } from '../src/vault/FsChangeListener';
@@ -161,7 +162,9 @@ describe('AdapterManager.afterSwapClient() — transport reflect policy', () => 
     mgr.afterSwapClient();
 
     expect(setWriterReflector).toHaveBeenCalledTimes(1);
-    expect(setWriterReflector.mock.calls[0][0]).not.toBeNull();
+    // Must be an actual VaultModelBuilder, not merely non-null — a
+    // no-op stub passing here would silently break self-reflect.
+    expect(setWriterReflector.mock.calls[0][0]).toBeInstanceOf(VaultModelBuilder);
   });
 
   it('RPC transport clears the reflector to null (no double-fire with FsChangeListener)', () => {

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -1351,3 +1351,109 @@ describe('SftpDataAdapter: readBuffer stat-after-read failure', () => {
     expect(cached?.mtime).toBe(0);
   });
 });
+
+// ─── writer reflect wiring (#341) ────────────────────────────────────────────
+
+describe('SftpDataAdapter — writer reflect (#341)', () => {
+  let readCache: ReadCache;
+  let dirCache: DirCache;
+
+  beforeEach(() => {
+    readCache = new ReadCache();
+    dirCache = new DirCache();
+  });
+
+  function makeReflector() {
+    return {
+      reflectWrite:  vi.fn(),
+      reflectRename: vi.fn(),
+      reflectRemove: vi.fn(),
+      reflectMkdir:  vi.fn(),
+    };
+  }
+
+  it('write / writeBinary / appendBinary call reflectWrite with the vault path', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    const r = makeReflector();
+    adapter.setWriterReflector(r);
+
+    await adapter.write('note.md', 'hello');
+    await adapter.writeBinary('blob.bin', new ArrayBuffer(2));
+    await adapter.appendBinary('log.bin', new ArrayBuffer(1));
+
+    expect(r.reflectWrite.mock.calls.map(c => c[0]))
+      .toEqual(['note.md', 'blob.bin', 'log.bin']);
+  });
+
+  it('mkdir → reflectMkdir, remove → reflectRemove, rmdir → reflectRemove', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    const r = makeReflector();
+    adapter.setWriterReflector(r);
+
+    await adapter.mkdir('dir');
+    await adapter.write('dir/f.md', 'x');
+    await adapter.remove('dir/f.md');
+    await adapter.rmdir('dir', true);
+
+    expect(r.reflectMkdir).toHaveBeenCalledWith('dir');
+    expect(r.reflectRemove.mock.calls.map(c => c[0])).toEqual(['dir/f.md', 'dir']);
+  });
+
+  it('rename calls reflectRename(old, new); copy reflects nothing', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    const r = makeReflector();
+    adapter.setWriterReflector(r);
+
+    await adapter.write('a.md', 'x');
+    await adapter.rename('a.md', 'b.md');
+    await adapter.copy('b.md', 'c.md');
+
+    expect(r.reflectRename).toHaveBeenCalledWith('a.md', 'b.md');
+    // copy has no writer-reflect by design — none of the hooks fire for it.
+    expect(r.reflectRename).toHaveBeenCalledTimes(1);
+    expect(r.reflectWrite).toHaveBeenCalledTimes(1); // only the seed write
+  });
+
+  it('a throwing reflector does not surface as a write failure', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    adapter.setWriterReflector({
+      reflectWrite:  () => { throw new Error('listener blew up'); },
+      reflectRename: vi.fn(),
+      reflectRemove: vi.fn(),
+      reflectMkdir:  vi.fn(),
+    });
+
+    await expect(adapter.write('note.md', 'hello')).resolves.toBeUndefined();
+    // The remote write still happened despite the reflect throw.
+    expect(fake.files['/v/note.md'].data.toString('utf8')).toBe('hello');
+  });
+
+  it('a null reflector is a safe no-op', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    adapter.setWriterReflector(null);
+    await expect(adapter.write('note.md', 'hi')).resolves.toBeUndefined();
+  });
+
+  it('does NOT reflect a remove that was only queued while reconnecting (#C1)', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remote-ssh-reflect-q-'));
+    const queue = await OfflineQueue.open(tmpDir);
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(
+      fake.client, '/v', readCache, dirCache, 'v',
+      null, null, null, new AncestorTracker(), queue,
+    );
+    const r = makeReflector();
+    adapter.setWriterReflector(r);
+
+    adapter.setReconnecting(true);
+    await adapter.remove('note.md'); // queued, NOT applied to remote
+
+    expect(r.reflectRemove).not.toHaveBeenCalled();
+    expect(queue.pending().map(e => e.op.kind)).toContain('remove');
+  });
+});

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -1456,4 +1456,43 @@ describe('SftpDataAdapter — writer reflect (#341)', () => {
     expect(r.reflectRemove).not.toHaveBeenCalled();
     expect(queue.pending().map(e => e.op.kind)).toContain('remove');
   });
+
+  it('does NOT reflect rmdir / rename that were only queued while reconnecting (#C1)', async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'remote-ssh-reflect-q2-'));
+    const queue = await OfflineQueue.open(tmpDir);
+    const fake = makeFakeClient({ dirs: { '/v': [], '/v/d': [] } });
+    const adapter = new SftpDataAdapter(
+      fake.client, '/v', readCache, dirCache, 'v',
+      null, null, null, new AncestorTracker(), queue,
+    );
+    const r = makeReflector();
+    adapter.setWriterReflector(r);
+
+    adapter.setReconnecting(true);
+    await adapter.rmdir('d', true);          // queued, not applied
+    await adapter.rename('a.md', 'b.md');    // queued, not applied
+
+    expect(r.reflectRemove).not.toHaveBeenCalled();
+    expect(r.reflectRename).not.toHaveBeenCalled();
+    const kinds = queue.pending().map(e => e.op.kind);
+    expect(kinds).toContain('rmdir');
+    expect(kinds).toContain('rename');
+  });
+
+  it('a throwing reflector on rename does not surface as a rename failure', async () => {
+    const fake = makeFakeClient({ dirs: { '/v': [] } });
+    const adapter = new SftpDataAdapter(fake.client, '/v', readCache, dirCache, 'v');
+    await adapter.write('a.md', 'x');
+    adapter.setWriterReflector({
+      reflectWrite:  vi.fn(),
+      reflectRename: () => { throw new Error('listener blew up'); },
+      reflectRemove: vi.fn(),
+      reflectMkdir:  vi.fn(),
+    });
+
+    await expect(adapter.rename('a.md', 'b.md')).resolves.toBeUndefined();
+    // The remote rename still happened despite the reflect throw.
+    expect(fake.files['/v/b.md']).toBeDefined();
+    expect(fake.files['/v/a.md']).toBeUndefined();
+  });
 });

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -600,3 +600,101 @@ describe('ShadowVaultBootstrap: installPlugin symlink fallback', () => {
     expect(fs.existsSync(path.join(result.layout.pluginDir, 'manifest.json'))).toBe(true);
   });
 });
+
+// ─── pullSharedObsidianConfig (#342 shared-config round-trip) ─────────────────
+
+describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
+  let localConfigDir: string;
+
+  beforeEach(() => {
+    localConfigDir = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-pull-')),
+      '.obsidian',
+    );
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(path.dirname(localConfigDir), { recursive: true, force: true }); }
+    catch { /* best effort */ }
+  });
+
+  /**
+   * Build a fake SharedConfigReader from a per-basename spec.
+   * `content` → readable & valid; `'throw'` → read rejects;
+   * `'invalid'` → readable but not JSON; absent key → exists()=false.
+   */
+  function makeReader(spec: Record<string, string | 'throw' | 'invalid'>) {
+    const resolve = (p: string) => p.slice(p.lastIndexOf('/') + 1);
+    return {
+      exists: vi.fn(async (p: string) => resolve(p) in spec),
+      read: vi.fn(async (p: string) => {
+        const v = spec[resolve(p)];
+        if (v === 'throw') throw new Error('SSH read failed');
+        if (v === 'invalid') return '{ not json';
+        return v;
+      }),
+    };
+  }
+
+  it('pulls every present & valid file verbatim and reports them', async () => {
+    const reader = makeReader({
+      'app.json':          JSON.stringify({ useMarkdownLinks: false }),
+      'appearance.json':   JSON.stringify({ theme: 'obsidian' }),
+      'core-plugins.json': JSON.stringify(['file-explorer', 'search']),
+      'hotkeys.json':      JSON.stringify({ 'editor:toggle-bold': [] }),
+    });
+
+    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+      reader, '.obsidian', localConfigDir,
+    );
+
+    expect(pulled.sort()).toEqual(
+      [...ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES].sort(),
+    );
+    expect(skipped).toEqual([]);
+    expect(JSON.parse(fs.readFileSync(path.join(localConfigDir, 'app.json'), 'utf-8')))
+      .toEqual({ useMarkdownLinks: false });
+    // Atomic write must not leave a .tmp sibling behind.
+    expect(fs.readdirSync(localConfigDir).some(f => f.endsWith('.tmp'))).toBe(false);
+  });
+
+  it('creates localConfigDir when it does not exist yet', async () => {
+    expect(fs.existsSync(localConfigDir)).toBe(false);
+    await ShadowVaultBootstrap.pullSharedObsidianConfig(
+      makeReader({ 'app.json': '{}' }), '.obsidian', localConfigDir,
+    );
+    expect(fs.existsSync(localConfigDir)).toBe(true);
+  });
+
+  it('skips a file that is absent on the remote without writing it', async () => {
+    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+      makeReader({ 'appearance.json': '{}' }), '.obsidian', localConfigDir,
+    );
+    expect(pulled).toEqual(['appearance.json']);
+    expect(skipped).toContain('app.json');
+    expect(fs.existsSync(path.join(localConfigDir, 'app.json'))).toBe(false);
+  });
+
+  it('skips a file whose read throws but still processes the rest', async () => {
+    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+      makeReader({ 'app.json': 'throw', 'hotkeys.json': '{}' }),
+      '.obsidian', localConfigDir,
+    );
+    expect(skipped).toContain('app.json');
+    expect(pulled).toContain('hotkeys.json'); // loop didn't abort
+  });
+
+  it('skips a corrupt remote file and leaves the prior local copy intact', async () => {
+    fs.mkdirSync(localConfigDir, { recursive: true });
+    const healthy = JSON.stringify({ theme: 'keepme' });
+    fs.writeFileSync(path.join(localConfigDir, 'app.json'), healthy, 'utf-8');
+
+    const { skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+      makeReader({ 'app.json': 'invalid' }), '.obsidian', localConfigDir,
+    );
+
+    expect(skipped).toContain('app.json');
+    expect(fs.readFileSync(path.join(localConfigDir, 'app.json'), 'utf-8'))
+      .toBe(healthy); // NOT clobbered with broken JSON
+  });
+});

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -644,7 +644,7 @@ describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
       'hotkeys.json':      JSON.stringify({ 'editor:toggle-bold': [] }),
     });
 
-    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+    const { pulled, skipped, errored } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
       reader, '.obsidian', localConfigDir,
     );
 
@@ -652,6 +652,7 @@ describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
       [...ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES].sort(),
     );
     expect(skipped).toEqual([]);
+    expect(errored).toEqual([]);
     expect(JSON.parse(fs.readFileSync(path.join(localConfigDir, 'app.json'), 'utf-8')))
       .toEqual({ useMarkdownLinks: false });
     // Atomic write must not leave a .tmp sibling behind.
@@ -667,20 +668,23 @@ describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
   });
 
   it('skips a file that is absent on the remote without writing it', async () => {
-    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+    const { pulled, skipped, errored } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
       makeReader({ 'appearance.json': '{}' }), '.obsidian', localConfigDir,
     );
     expect(pulled).toEqual(['appearance.json']);
     expect(skipped).toContain('app.json');
+    // Absent-on-remote is a benign skip, NOT an error (no Notice).
+    expect(errored).not.toContain('app.json');
     expect(fs.existsSync(path.join(localConfigDir, 'app.json'))).toBe(false);
   });
 
   it('skips a file whose read throws but still processes the rest', async () => {
-    const { pulled, skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+    const { pulled, skipped, errored } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
       makeReader({ 'app.json': 'throw', 'hotkeys.json': '{}' }),
       '.obsidian', localConfigDir,
     );
     expect(skipped).toContain('app.json');
+    expect(errored).toContain('app.json'); // a read throw is an error, surfaces a Notice
     expect(pulled).toContain('hotkeys.json'); // loop didn't abort
   });
 
@@ -689,11 +693,12 @@ describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
     const healthy = JSON.stringify({ theme: 'keepme' });
     fs.writeFileSync(path.join(localConfigDir, 'app.json'), healthy, 'utf-8');
 
-    const { skipped } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
+    const { skipped, errored } = await ShadowVaultBootstrap.pullSharedObsidianConfig(
       makeReader({ 'app.json': 'invalid' }), '.obsidian', localConfigDir,
     );
 
     expect(skipped).toContain('app.json');
+    expect(errored).toContain('app.json'); // corrupt remote → surfaces a Notice
     expect(fs.readFileSync(path.join(localConfigDir, 'app.json'), 'utf-8'))
       .toBe(healthy); // NOT clobbered with broken JSON
   });

--- a/plugin/tests/VaultModelBuilder.test.ts
+++ b/plugin/tests/VaultModelBuilder.test.ts
@@ -522,3 +522,96 @@ describe('VaultModelBuilder.renameOne', () => {
     expect(triggers).toEqual([]);
   });
 });
+
+// ─── writer self-reflect (#341) ──────────────────────────────────────────────
+
+describe('VaultModelBuilder.reflect* (#341 writer self-reflect)', () => {
+  it('reflectWrite on a new path inserts a file and fires create', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectWrite('Notes.md');
+
+    expect(fileMap['Notes.md']).toBeInstanceOf(FakeTFile);
+    expect(triggers.map(t => t.event)).toEqual(['create']);
+  });
+
+  it('reflectWrite on an existing file fires modify, does not re-insert', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectWrite('Notes.md');           // create
+    const inserted = fileMap['Notes.md'];
+    builder.reflectWrite('Notes.md');           // modify
+
+    expect(fileMap['Notes.md']).toBe(inserted); // same object, not replaced
+    expect(triggers.map(t => t.event)).toEqual(['create', 'modify']);
+  });
+
+  it('reflectWrite is a no-op (no trigger) when a folder occupies the path', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectMkdir('shared');             // folder at "shared"
+    const folder = fileMap['shared'];
+    expect(folder).toBeInstanceOf(FakeTFolder);
+
+    builder.reflectWrite('shared');             // pathological folder→file
+
+    // Folder untouched; no misleading modify/create fired for it.
+    expect(fileMap['shared']).toBe(folder);
+    expect(triggers.map(t => t.event)).toEqual(['create']); // only the mkdir
+  });
+
+  it('reflectMkdir on an absent path inserts a folder and fires create', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectMkdir('dir');
+
+    expect(fileMap['dir']).toBeInstanceOf(FakeTFolder);
+    expect(triggers.map(t => t.event)).toEqual(['create']);
+  });
+
+  it('reflectMkdir is idempotent when the folder is already modelled', () => {
+    const { vault, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectMkdir('dir');
+    builder.reflectMkdir('dir'); // second call must not re-fire create
+
+    expect(triggers.map(t => t.event)).toEqual(['create']);
+  });
+
+  it('reflectRename moves the fileMap entry and fires rename(old)', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectWrite('a.md');
+    builder.reflectRename('a.md', 'b.md');
+
+    expect(fileMap['b.md']).toBeInstanceOf(FakeTFile);
+    expect(fileMap['a.md']).toBeUndefined();
+    const renameEvt = triggers.find(t => t.event === 'rename');
+    expect(renameEvt?.args[1]).toBe('a.md'); // oldPath passed through
+  });
+
+  it('reflectRemove drops the fileMap entry and fires delete', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectWrite('gone.md');
+    builder.reflectRemove('gone.md');
+
+    expect(fileMap['gone.md']).toBeUndefined();
+    expect(triggers.map(t => t.event)).toEqual(['create', 'delete']);
+  });
+
+  it('reflectRemove on an unmodelled path is a benign no-op', () => {
+    const { vault, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    expect(() => builder.reflectRemove('never-seen.md')).not.toThrow();
+    expect(triggers).toEqual([]);
+  });
+});

--- a/plugin/tests/integration/helpers/assertConfigRoundTrip.ts
+++ b/plugin/tests/integration/helpers/assertConfigRoundTrip.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import type { ShadowVaultBootstrap, ShadowVaultLayout } from '../../../src/shadow/ShadowVaultBootstrap';
+import { ShadowVaultBootstrap, type ShadowVaultLayout } from '../../../src/shadow/ShadowVaultBootstrap';
 import type { SshProfile } from '../../../src/types';
 import type { TestClient } from './makeAdapter';
 
@@ -83,12 +83,22 @@ export async function assertConfigRoundTrip(
   await remoteClient.adapter.mkdir(remoteConfigDir);
   await remoteClient.adapter.write(remoteRelPath, JSON.stringify(remoteContent));
 
-  // ── 2. Run bootstrap ───────────────────────────────────────────────
+  // ── 2. Run bootstrap, then pull shared config ──────────────────────
   //
-  // Today this is purely-local: it creates the shadow vault directory
-  // structure and seeds `community-plugins.json` + `data.json`. It does
-  // NOT touch `<configDir>/<configBasename>`. That's the gap.
+  // `bootstrap()` is purely-local: it creates the shadow vault dir
+  // structure and seeds `community-plugins.json` + `data.json`. The
+  // remote→local pull for the shared-config allowlist is a separate
+  // async step (it needs the connected adapter, which bootstrap has
+  // no handle on). The production connect flow runs the exact same
+  // call right before `populateVaultFromRemote`; this mirrors it so
+  // the test exercises the real round-trip path. Closing this gap is
+  // the #342 fix.
   const result = await bootstrap.bootstrap(profile, allProfiles);
+  await ShadowVaultBootstrap.pullSharedObsidianConfig(
+    remoteClient.adapter,
+    remoteConfigDir,
+    result.layout.configDir,
+  );
 
   // ── 3. Compare local ↔ remote ─────────────────────────────────────
   const localAbsPath = path.join(result.layout.configDir, configBasename);

--- a/plugin/tests/integration/helpers/assertConfigRoundTrip.ts
+++ b/plugin/tests/integration/helpers/assertConfigRoundTrip.ts
@@ -18,12 +18,13 @@ import type { TestClient } from './makeAdapter';
  * whose remote already carries `<configDir>/app.json` (etc.), the
  * local file must equal the remote.
  *
- * Today the assertion **fails** because `ShadowVaultBootstrap` does
- * not have a remote-pull step for these shared files — see the
- * "Obsidian fills the rest on first open and leaves our pre-created
- * files alone" comment in `ShadowVaultBootstrap.bootstrapSync`. The
- * suite documents the missing contract via `it.fails(...)`. Removing
- * the `.fails` marker is part of whatever PR adds the pull step.
+ * The remote-pull step is `ShadowVaultBootstrap.pullSharedObsidianConfig`
+ * (#342 fix): `bootstrap()` itself is still purely-local, so this
+ * helper runs the pull right after it — the same sequence the
+ * production connect flow uses (`runAutoConnect` → pull → populate).
+ * The assertion passes once that pull lands the remote bytes on the
+ * local shadow disk; it fails (with the #342-gap message below) if a
+ * regression drops the pull.
  *
  * Why this is its own helper (vs. inlined in the test): the round-trip
  * setup has three independent moving parts (seed remote, run bootstrap,

--- a/plugin/tests/integration/helpers/harnessVault.ts
+++ b/plugin/tests/integration/helpers/harnessVault.ts
@@ -1,4 +1,5 @@
-import type { EventRef } from 'obsidian';
+import type { EventRef, Vault } from 'obsidian';
+import { VaultModelBuilder, type ObsidianClassDeps } from '../../../src/vault/VaultModelBuilder';
 
 /**
  * Shared in-process Vault test double for integration suites.
@@ -86,4 +87,23 @@ export class HarnessVault {
 /** Convert a Node Buffer to an ArrayBuffer view suitable for adapter.writeBinary. */
 export function asArrayBuffer(buf: Buffer): ArrayBuffer {
   return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+/**
+ * Build the writer-side reflector (#341) for a `HarnessVault`.
+ *
+ * Centralises the `VaultModelBuilder` construction + the two
+ * `as unknown as` casts that bridge the Harness stubs to Obsidian's
+ * `Vault` / `ObsidianClassDeps` types, so the self-reflect /
+ * invariants / property suites can't drift apart. Wire the result
+ * with `adapter.setWriterReflector(...)`.
+ */
+export function makeWriterReflector(vault: HarnessVault): VaultModelBuilder {
+  return new VaultModelBuilder(
+    vault as unknown as Vault,
+    {
+      TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
+      TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'],
+    },
+  );
 }

--- a/plugin/tests/integration/invariants.e2e.test.ts
+++ b/plugin/tests/integration/invariants.e2e.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import * as fs from 'node:fs';
 import type { Vault } from 'obsidian';
+import { VaultModelBuilder, type ObsidianClassDeps } from '../../src/vault/VaultModelBuilder';
 import { FakeFileExplorer } from '../helpers/FakeFileExplorer';
 import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
-import { HarnessVault, asArrayBuffer } from './helpers/harnessVault';
+import { HarnessVault, HarnessTFile, HarnessTFolder, asArrayBuffer } from './helpers/harnessVault';
 import {
   runScenario,
   formatReport,
@@ -56,6 +57,18 @@ describe('Layer 3 — invariant scenarios', () => {
     const writerVault = new HarnessVault();
     const writerFE = new FakeFileExplorer();
     detachFE = writerFE.attach(writerVault as unknown as Vault);
+
+    // #341 fix: wire the writer-side reflector so every adapter op
+    // mirrors into writerVault.fileMap + the trigger bus. Without
+    // this, I1 (fileMap mirror) and I2 (matching trigger) both fail
+    // on the very first op — which is exactly the regression the
+    // scenario runner is here to catch.
+    const builder = new VaultModelBuilder(
+      writerVault as unknown as Vault,
+      { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
+        TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
+    );
+    writer.adapter.setWriterReflector(builder);
 
     ctx = { client: writer, writerVault, writerFE, opsApplied: [] };
   });

--- a/plugin/tests/integration/invariants.e2e.test.ts
+++ b/plugin/tests/integration/invariants.e2e.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import * as fs from 'node:fs';
 import type { Vault } from 'obsidian';
-import { VaultModelBuilder, type ObsidianClassDeps } from '../../src/vault/VaultModelBuilder';
 import { FakeFileExplorer } from '../helpers/FakeFileExplorer';
 import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
-import { HarnessVault, HarnessTFile, HarnessTFolder, asArrayBuffer } from './helpers/harnessVault';
+import { HarnessVault, asArrayBuffer, makeWriterReflector } from './helpers/harnessVault';
 import {
   runScenario,
   formatReport,
@@ -63,12 +62,7 @@ describe('Layer 3 — invariant scenarios', () => {
     // this, I1 (fileMap mirror) and I2 (matching trigger) both fail
     // on the very first op — which is exactly the regression the
     // scenario runner is here to catch.
-    const builder = new VaultModelBuilder(
-      writerVault as unknown as Vault,
-      { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
-        TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
-    );
-    writer.adapter.setWriterReflector(builder);
+    writer.adapter.setWriterReflector(makeWriterReflector(writerVault));
 
     ctx = { client: writer, writerVault, writerFE, opsApplied: [] };
   });

--- a/plugin/tests/integration/invariants.property.e2e.test.ts
+++ b/plugin/tests/integration/invariants.property.e2e.test.ts
@@ -2,9 +2,10 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as fc from 'fast-check';
 import type { Vault } from 'obsidian';
+import { VaultModelBuilder, type ObsidianClassDeps } from '../../src/vault/VaultModelBuilder';
 import { FakeFileExplorer } from '../helpers/FakeFileExplorer';
 import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
-import { HarnessVault, asArrayBuffer } from './helpers/harnessVault';
+import { HarnessVault, HarnessTFile, HarnessTFolder, asArrayBuffer } from './helpers/harnessVault';
 import {
   runScenario,
   formatReport,
@@ -82,6 +83,17 @@ describe('Layer 3 — property-based invariants', () => {
     writerVault = new HarnessVault();
     writerFE = new FakeFileExplorer();
     detachFE = writerFE.attach(writerVault as unknown as Vault);
+
+    // #341 fix: wire the reflector BEFORE seeding so the seed writes
+    // land in writerVault.fileMap too. The generator treats
+    // SEED_PATHS as live and may rename/remove them, so they must be
+    // modelled for I1/I2 to hold on those ops.
+    const builder = new VaultModelBuilder(
+      writerVault as unknown as Vault,
+      { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
+        TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
+    );
+    writer.adapter.setWriterReflector(builder);
 
     // Seed the live path set on the remote. Use small distinct
     // payloads so a future hash-equality invariant could discriminate.

--- a/plugin/tests/integration/invariants.property.e2e.test.ts
+++ b/plugin/tests/integration/invariants.property.e2e.test.ts
@@ -2,10 +2,9 @@ import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import * as fs from 'node:fs';
 import * as fc from 'fast-check';
 import type { Vault } from 'obsidian';
-import { VaultModelBuilder, type ObsidianClassDeps } from '../../src/vault/VaultModelBuilder';
 import { FakeFileExplorer } from '../helpers/FakeFileExplorer';
 import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
-import { HarnessVault, HarnessTFile, HarnessTFolder, asArrayBuffer } from './helpers/harnessVault';
+import { HarnessVault, asArrayBuffer, makeWriterReflector } from './helpers/harnessVault';
 import {
   runScenario,
   formatReport,
@@ -88,12 +87,7 @@ describe('Layer 3 — property-based invariants', () => {
     // land in writerVault.fileMap too. The generator treats
     // SEED_PATHS as live and may rename/remove them, so they must be
     // modelled for I1/I2 to hold on those ops.
-    const builder = new VaultModelBuilder(
-      writerVault as unknown as Vault,
-      { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
-        TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
-    );
-    writer.adapter.setWriterReflector(builder);
+    writer.adapter.setWriterReflector(makeWriterReflector(writerVault));
 
     // Seed the live path set on the remote. Use small distinct
     // payloads so a future hash-equality invariant could discriminate.

--- a/plugin/tests/integration/self-reflect.e2e.test.ts
+++ b/plugin/tests/integration/self-reflect.e2e.test.ts
@@ -85,10 +85,14 @@ describe('Layer 1 — writer self-reflect (SFTP transport)', () => {
       { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
         TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
     );
-    // Silence the unused-variable check; builder is held for future
-    // cases that may want to seed state synthetically when a fix
-    // hasn't landed yet.
-    void builder;
+    // #341 fix: wire the builder as the adapter's writer-side
+    // reflector. From here every writer.adapter.write/rename/remove/
+    // mkdir mirrors straight into writerVault.fileMap + the
+    // vault.trigger bus the FakeFileExplorer listens on — the exact
+    // production wiring AdapterManager does for the SFTP transport.
+    // VaultModelBuilder structurally satisfies WriterReflector, so no
+    // cast is needed.
+    writer.adapter.setWriterReflector(builder);
   });
 
   afterAll(async () => {

--- a/plugin/tests/integration/self-reflect.e2e.test.ts
+++ b/plugin/tests/integration/self-reflect.e2e.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, beforeAll, afterAll, expect } from 'vitest';
 import * as fs from 'node:fs';
 import type { Vault } from 'obsidian';
-import { VaultModelBuilder, type ObsidianClassDeps } from '../../src/vault/VaultModelBuilder';
 import { FakeFileExplorer } from '../helpers/FakeFileExplorer';
 import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
 import { assertSelfReflect } from './helpers/assertSelfReflect';
-import { HarnessVault, HarnessTFile, HarnessTFolder, asArrayBuffer } from './helpers/harnessVault';
+import { HarnessVault, asArrayBuffer, makeWriterReflector } from './helpers/harnessVault';
 
 /**
  * Layer 1 of the sync-test framework — **writer self-reflect**.
@@ -68,7 +67,6 @@ describe('Layer 1 — writer self-reflect (SFTP transport)', () => {
   let writerVault: HarnessVault;
   let fakeFE: FakeFileExplorer;
   let detachFE: (() => void) | null = null;
-  let builder: VaultModelBuilder;
 
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
@@ -80,19 +78,12 @@ describe('Layer 1 — writer self-reflect (SFTP transport)', () => {
     fakeFE = new FakeFileExplorer();
     detachFE = fakeFE.attach(writerVault as unknown as Vault);
 
-    builder = new VaultModelBuilder(
-      writerVault as unknown as Vault,
-      { TFile: HarnessTFile as unknown as ObsidianClassDeps['TFile'],
-        TFolder: HarnessTFolder as unknown as ObsidianClassDeps['TFolder'] },
-    );
-    // #341 fix: wire the builder as the adapter's writer-side
-    // reflector. From here every writer.adapter.write/rename/remove/
-    // mkdir mirrors straight into writerVault.fileMap + the
-    // vault.trigger bus the FakeFileExplorer listens on — the exact
-    // production wiring AdapterManager does for the SFTP transport.
-    // VaultModelBuilder structurally satisfies WriterReflector, so no
-    // cast is needed.
-    writer.adapter.setWriterReflector(builder);
+    // #341 fix: wire the writer-side reflector — every
+    // writer.adapter.write/rename/remove/mkdir then mirrors straight
+    // into writerVault.fileMap + the vault.trigger bus the
+    // FakeFileExplorer listens on, exactly as AdapterManager wires it
+    // for the SFTP transport in production.
+    writer.adapter.setWriterReflector(makeWriterReflector(writerVault));
   });
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

Implements the production fixes that the 3-layer sync-test framework in #343 asserts. This is the **chained fix PR** #343's description calls for: it targets `feat/sync-test-framework` so the framework's e2e cases (authored as plain `it()` that fail on the SSH-integration job today) turn green, and the diff shows the framework caught the regression.

> Note: the framework cases use plain `it()` + a red (non-required) SSH-integration job rather than literal `it.fails(...)` — the `it.fails` text in #343 lives only in doc comments. So there are no `.fails` markers to strip; the fix is the wiring + production code below.

## #341 — writer self-reflect

- New `adapter/WriterReflector` interface. `VaultModelBuilder` gains `reflectWrite/reflectRename/reflectRemove/reflectMkdir` which **structurally** satisfy it (no `implements`, so no adapter→vault import edge).
- `SftpDataAdapter.setWriterReflector(...)`: after a successful `write`/`writeBinary`/`rename`/`remove`/`rmdir`/`mkdir`, the matching reflect fires, so the writer's own `vault.fileMap` + `vault.trigger(...)` bus follow a title-bar rename instead of staying bound to a stale `TFile`.
- `AdapterManager` wires the reflector for the **SFTP transport only**; RPC keeps the existing `FsChangeListener` echo path (wiring both would double-fire — RPC echo de-dup stays a follow-up, matching the still-red RPC self-reflect suite). Null reflector = legacy no-op, so non-shadow callers are unaffected.

## #342 — shared-config round-trip

- `ShadowVaultBootstrap.pullSharedObsidianConfig(...)` (static): copies the shared allowlist (`app.json` / `appearance.json` / `core-plugins.json` / `hotkeys.json`) **byte-verbatim** from remote into the local shadow config dir. Missing-on-remote is skipped, not an error.
- Called from the connect flow (`runAutoConnect`, before `populateVaultFromRemote`) so the next Obsidian restart reads fresh settings, and from the Layer-2 helper so the test exercises the real path.

## Test wiring

- `self-reflect` / `invariants` / `invariants.property` e2e suites wire the reflector in `beforeAll` (replacing the `void builder` placeholder in self-reflect).
- `assertConfigRoundTrip` now calls the new pull step after `bootstrap()`.

## Test plan

- [x] `tsc --noEmit` clean (Lint & type-check — src only)
- [x] `eslint "src/**/*.ts"` clean
- [x] `vitest run` unit: 69 files, 1015 passed / 1 skipped
- [ ] SSH-integration e2e (self-reflect SFTP, restart-roundtrip, invariants, invariants.property) — requires docker sshd; runs in the integration job
- [ ] RPC self-reflect stays red by design (echo de-dup is a separate follow-up)

## Merge order

Chained on #343. Merge #343 first, then rebase/retarget this onto `next`.

Generated with Claude Code