### PR TITLE
fix(docs): repair Quartz 404Page TDZ + build docs on PRs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,18 +46,36 @@ jobs:
       - name: Check docs wikilinks + anchors
         run: node scripts/check-docs-links.mjs
 
-      # ── Stable build (main → root of gh-pages) ───────────────────────────
-      - name: Build docs — stable
-        if: github.ref == 'refs/heads/main'
+      # ── Resolve channel + base URL ───────────────────────────────────────
+      # One build path for every trigger. The base URL is the only
+      # thing that differs between channels, so compute it once:
+      #   - stable  : push main      OR PR whose base is main
+      #   - dev     : push next      OR PR whose base is next (or any
+      #               other PR — build-only, never deployed, so the
+      #               exact URL doesn't matter, just that it builds)
+      - name: Resolve docs channel
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "main" ]] \
+             || [[ "${{ github.event_name }}" == "pull_request" && "${{ github.base_ref }}" == "main" ]]; then
+            echo "QUARTZ_BASE_URL=codes.sota-shimozono.com/obsidian-remote-ssh"     >> "$GITHUB_ENV"
+            echo "DOCS_CHANNEL=stable" >> "$GITHUB_ENV"
+          else
+            echo "QUARTZ_BASE_URL=codes.sota-shimozono.com/obsidian-remote-ssh/dev" >> "$GITHUB_ENV"
+            echo "DOCS_CHANNEL=dev" >> "$GITHUB_ENV"
+          fi
+
+      # ── Build (ALWAYS — incl. PRs, so a docs break is caught pre-merge
+      #    instead of turning main/next red post-merge) ──────────────────
+      - name: Build docs (${{ env.DOCS_CHANNEL }})
         working-directory: docs-site
-        env:
-          QUARTZ_BASE_URL: codes.sota-shimozono.com/obsidian-remote-ssh
         # Invoke via node directly — bypasses bin-shim/exec-bit issues
         # (npx fell back to a non-executable shim on the main-branch run).
+        # QUARTZ_BASE_URL comes from the resolve step via $GITHUB_ENV.
         run: node ./quartz/bootstrap-cli.mjs build -d ../docs
 
+      # ── Deploy (push to a release branch only — never on PRs) ────────────
       - name: Deploy — stable → gh-pages root
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs-site/public
@@ -67,18 +85,8 @@ jobs:
           clean-exclude: |
             dev/
 
-      # ── Dev build (next → /dev/ on gh-pages) ─────────────────────────────
-      - name: Build docs — dev
-        if: github.ref == 'refs/heads/next'
-        working-directory: docs-site
-        env:
-          QUARTZ_BASE_URL: codes.sota-shimozono.com/obsidian-remote-ssh/dev
-        # Invoke via node directly — bypasses bin-shim/exec-bit issues
-        # (npx fell back to a non-executable shim on the main-branch run).
-        run: node ./quartz/bootstrap-cli.mjs build -d ../docs
-
       - name: Deploy — dev → gh-pages /dev/
-        if: github.ref == 'refs/heads/next'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/next'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs-site/public

--- a/docs-site/quartz/components/Head.tsx
+++ b/docs-site/quartz/components/Head.tsx
@@ -23,6 +23,14 @@ export default (() => {
 
     const { css, js, additionalHead } = externalResources
 
+    // Declared once here, before the SEO blocks below (BreadcrumbList,
+    // WebSite, hreflang) read it. The original Quartz Head declared
+    // `slug` lower down; the SEO additions reference it earlier, so a
+    // late `const` produced a temporal-dead-zone crash ("Cannot access
+    // 'slug' before initialization") that aborted the whole build at
+    // the first emitter to render Head (404Page). Hoisting fixes it.
+    const slug = fileData.slug ?? ""
+
     const url = new URL(`https://${cfg.baseUrl ?? "example.com"}`)
     const path = url.pathname as FullSlug
     const baseDir = fileData.slug === "404" ? path : pathToRoot(fileData.slug!)
@@ -266,7 +274,8 @@ export default (() => {
     // Pages outside the per-language subtree (e.g. `index`, `tags/*`,
     // `404`) get no hreflang — correct, since they have no language
     // siblings to disambiguate against.
-    const slug = fileData.slug ?? ""
+    // `slug` is declared once near the top of this component (see the
+    // TDZ note there); reuse it rather than re-declaring.
     const langTwinMatch = slug.match(/^(en|ja)\/(.+)$/)
     const hreflangAlternates: Array<{ hrefLang: string; href: string }> = []
     if (langTwinMatch) {

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49-beta.1",
+  "version": "1.0.49-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49-beta.1",
+  "version": "1.0.49-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49-beta.1",
+  "version": "1.0.49-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.49-beta.1",
+      "version": "1.0.49-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49-beta.1",
+  "version": "1.0.49-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

`main`'s **Docs** workflow has been failing since the 1.0.48 merge (run 25675220382, 2026-05-11) — every run before that was green.

```
ERROR  Failed to emit from plugin `404Page`: Cannot access 'slug' before initialization
fatal error: all goroutines are asleep - deadlock!
exit code 1
```

**Root cause** — `docs-site/quartz/components/Head.tsx`. The 1.0.48 SEO work added BreadcrumbList / WebSite / hreflang blocks that read `slug` near the top of the component, but `const slug = fileData.slug ?? ""` was declared ~240 lines further down. That's a temporal dead zone: the first emitter to render `Head` (`404Page`) throws "Cannot access 'slug' before initialization", which aborts the entire site emit.

**Why it reached `main`** — `docs.yml` gated its build steps on `github.ref == refs/heads/{main,next}`, which never matches a PR's ref. So PRs only ran the wikilink lint; the Quartz build itself was never exercised pre-merge. (Matches the standing "docs build must run on PRs" intent.)

## Fix

1. **Head.tsx**: hoist the single `const slug` above its first use; drop the late re-declaration. Verified locally — `quartz build` now emits **266 files from 96 inputs, no error**.
2. **docs.yml restructure**:
   - build **always runs** (push *and* `pull_request`) → a docs break is caught on the PR, not post-merge;
   - channel/base-URL resolved once (stable for push-main / PR→main, dev otherwise), collapsing the two duplicated build steps into one;
   - deploy gated to `event_name == push` on main/next only — **PRs build but never deploy**. Deploy targets unchanged: `main` → gh-pages root (`clean-exclude: dev/`), `next` → gh-pages `/dev/`.

Beta bump `1.0.49-beta.1 → -beta.2` to satisfy version-check (PR into `next`); root `manifest.json` stays pinned per the beta-channel rule.

## Note on `main` timing

This targets `next` (beta channel, where feature/CI PRs land + version-check beta rules apply). `main`'s Docs check goes green when this reaches it via the normal `next → main` release sync. If you want `main` green immediately I can instead cut a direct stable hotfix into `main` — say the word.

## Test plan

- [x] Local `quartz build` succeeds (266 emitted, 0 errors)
- [ ] This PR's own **Docs** check runs the build (dogfoods the new PR-build path) and is green
- [ ] Other required checks green (version-check beta rules)
- [ ] After merge: push-next Docs deploys `/dev/`; next release carries the fix to `main`

Generated with Claude Code