### PR TITLE
test(e2e): connect-lifecycle SFTP spec (red-first; connect fix follows)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.5",
+  "version": "1.0.49-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49-beta.3",
+  "version": "1.1.0-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/connect-lifecycle.spec.ts
+++ b/plugin/e2e/connect-lifecycle.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+import * as net from 'node:net';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { logPathFor, waitForLog, assertAtMost } from './helpers/log-oracle';
+
+/**
+ * Connect-lifecycle e2e — the coverage that was missing while a
+ * broken connect shipped to stable (1.0.49).
+ *
+ * Every prior spec "gracefully skips if sshd is unreachable" and only
+ * asserts that *something* appeared — so a connect that opens SFTP
+ * then stalls in `AdapterManager.patch` / `runAutoConnect` /
+ * `populateVaultFromRemote` (the exact production incident: SFTP
+ * channel open, then no patch/populate logs, then a WindowSpawner
+ * re-spawn loop) passed CI green. This spec is deliberately the
+ * opposite:
+ *
+ *   - HARD FAIL, never skip. sshd down ⇒ test failure, not a skip.
+ *   - Drives the FULL real lifecycle in real Obsidian over SFTP
+ *     (the transport the incident was reported on):
+ *       scaffold → Connect → shadow spawn → shadow window
+ *       auto-connect → AdapterManager.patch → runAutoConnect →
+ *       populateVaultFromRemote.
+ *   - Asserts the structured-log trail that was *absent* in the
+ *     incident, AND bounds the WindowSpawner count that was *runaway*.
+ *
+ * Expected to be RED on the current build (reproduces the incident),
+ * GREEN once the connect orchestration is fixed. That ordering is the
+ * point — the test proves the fix, and guards the regression.
+ */
+
+const SSHD_HOST = '127.0.0.1';
+const SSHD_PORT = 2222;
+
+test.setTimeout(240_000);
+
+async function assertSshdReachable(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const sock = net
+      .connect({ host: SSHD_HOST, port: SSHD_PORT })
+      .setTimeout(5_000)
+      .once('connect', () => { sock.destroy(); resolve(); })
+      .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
+      .once('error', reject);
+  }).catch((e) => {
+    throw new Error(
+      `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
+      `(${(e as Error).message}). Run \`npm run sshd:start\` first. ` +
+      `This spec HARD-FAILS instead of skipping — a broken connect ` +
+      `must not pass CI green (that is how 1.0.49 shipped broken).`,
+    );
+  });
+}
+
+test.describe('connect lifecycle (SFTP)', () => {
+  let scaffold: ScaffoldResult;
+  let scaffoldHandle: ObsidianHandle | null = null;
+  let shadowHandle: ObsidianHandle | null = null;
+
+  test.beforeAll(async () => {
+    await assertSshdReachable();
+    scaffold = scaffoldTestVault({ transport: 'sftp' });
+  });
+
+  test.afterAll(async () => {
+    try { await shadowHandle?.cleanup(); } catch { /* best effort */ }
+    try { await scaffoldHandle?.cleanup(); } catch { /* best effort */ }
+    scaffold?.cleanup();
+  });
+
+  test('Connect → patch → runAutoConnect → populate completes end-to-end over SFTP', async () => {
+    // 1. Real Obsidian on the scaffold vault, plugin force-loaded.
+    scaffoldHandle = await launchObsidian(scaffold.vaultPath);
+
+    // 2. Drive the real Connect command; the plugin bootstraps a
+    //    shadow vault and registers it in obsidian.json.
+    await driveConnectFlow(scaffoldHandle.page);
+    const shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 20_000);
+
+    // 3. The connecting (scaffold) window must NOT be stuck
+    //    re-bootstrapping/re-spawning the shadow — the production
+    //    symptom was dozens of these within milliseconds.
+    assertAtMost(
+      logPathFor(scaffold.vaultPath),
+      /WindowSpawner: firing obsidian:\/\/open/,
+      3,
+      'scaffold window must not loop-spawn the shadow vault',
+    );
+
+    // 4. Hand off to a fresh Obsidian on the shadow vault — this is
+    //    the window that auto-connects (runAutoConnect on layout).
+    await scaffoldHandle.cleanup();
+    scaffoldHandle = null;
+    shadowHandle = await launchObsidian(shadowVaultPath);
+    const shadowLog = logPathFor(shadowVaultPath);
+
+    // 5. The post-SFTP-open orchestration that was SILENT in the
+    //    incident MUST produce its trail:
+    //    a) SSH/SFTP actually opened
+    await waitForLog(
+      shadowLog,
+      /SFTP channel open/,
+      60_000,
+      'SFTP channel must open',
+    );
+    //    b) the adapter was patched over the SFTP transport
+    await waitForLog(
+      shadowLog,
+      /Adapter patched via SFTP/,
+      60_000,
+      'adapter must patch after SFTP open (absent in the incident)',
+    );
+    //    c) the remote tree was actually walked into the vault model
+    await waitForLog(
+      shadowLog,
+      /populateVaultFromRemote\(shadow-[^)]*\):.*entries/,
+      90_000,
+      'vault must populate from remote (absent in the incident)',
+    );
+
+    // 6. And the shadow window must not itself be loop-spawning.
+    assertAtMost(
+      shadowLog,
+      /WindowSpawner: firing obsidian:\/\/open/,
+      2,
+      'shadow window must not loop-spawn',
+    );
+
+    // 7. Observable end state: File Explorer shows remote content.
+    //    (The remote docker vault is the integration fixture tree.)
+    const fileExplorerHasEntries = await shadowHandle.page
+      .locator('.nav-files-container .nav-file-title')
+      .first()
+      .isVisible({ timeout: 30_000 })
+      .catch(() => false);
+    expect(
+      fileExplorerHasEntries,
+      'File Explorer should render remote files after populate',
+    ).toBe(true);
+  });
+});

--- a/plugin/e2e/connect-lifecycle.spec.ts
+++ b/plugin/e2e/connect-lifecycle.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import * as net from 'node:net';
 import {
   launchObsidian,
   driveConnectFlow,
@@ -8,6 +7,7 @@ import {
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { logPathFor, waitForLog, assertAtMost } from './helpers/log-oracle';
+import { assertSshdReachable } from './helpers/sshd';
 
 /**
  * Connect-lifecycle e2e — the coverage that was missing while a
@@ -35,28 +35,7 @@ import { logPathFor, waitForLog, assertAtMost } from './helpers/log-oracle';
  * point — the test proves the fix, and guards the regression.
  */
 
-const SSHD_HOST = '127.0.0.1';
-const SSHD_PORT = 2222;
-
 test.setTimeout(240_000);
-
-async function assertSshdReachable(): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const sock = net
-      .connect({ host: SSHD_HOST, port: SSHD_PORT })
-      .setTimeout(5_000)
-      .once('connect', () => { sock.destroy(); resolve(); })
-      .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
-      .once('error', reject);
-  }).catch((e) => {
-    throw new Error(
-      `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
-      `(${(e as Error).message}). Run \`npm run sshd:start\` first. ` +
-      `This spec HARD-FAILS instead of skipping — a broken connect ` +
-      `must not pass CI green (that is how 1.0.49 shipped broken).`,
-    );
-  });
-}
 
 test.describe('connect lifecycle (SFTP)', () => {
   let scaffold: ScaffoldResult;
@@ -116,13 +95,25 @@ test.describe('connect lifecycle (SFTP)', () => {
       60_000,
       'adapter must patch after SFTP open (absent in the incident)',
     );
-    //    c) the remote tree was actually walked into the vault model
-    await waitForLog(
+    //    c) the remote tree was actually walked into the vault model.
+    //    A partial / empty populate STILL logs this line ("0 entries")
+    //    — the literal production symptom (SFTP open, then an empty
+    //    vault). Asserting the line appeared is not enough; assert the
+    //    walk yielded a non-empty tree.
+    const populateEntry = await waitForLog(
       shadowLog,
-      /populateVaultFromRemote\(shadow-[^)]*\):.*entries/,
+      /populateVaultFromRemote\(shadow-[^)]*\):.*?\d+ entries/,
       90_000,
       'vault must populate from remote (absent in the incident)',
     );
+    const populatedCount = Number(
+      /(\d+) entries/.exec(populateEntry.msg ?? '')?.[1] ?? '0',
+    );
+    expect(
+      populatedCount,
+      'populate must walk a non-empty remote tree — 0 entries is the ' +
+      'empty-vault incident the line-only assertion would pass',
+    ).toBeGreaterThan(0);
 
     // 6. And the shadow window must not itself be loop-spawning.
     assertAtMost(

--- a/plugin/e2e/helpers/log-oracle.ts
+++ b/plugin/e2e/helpers/log-oracle.ts
@@ -1,0 +1,120 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Structured-log oracle for the connect-lifecycle e2e.
+ *
+ * The plugin's logger writes JSON-lines to
+ * `<vault>/.obsidian/plugins/remote-ssh/console.log` (a rolling
+ * buffer — NUL-padded, the last line may be partial). The connect
+ * lifecycle leaves a deterministic trail there: `Adapter patched via
+ * SFTP|RPC`, `populateVaultFromRemote(...): … built`,
+ * `WindowSpawner: firing obsidian://open`, etc.
+ *
+ * The diagnosed production failure was precisely the *absence* of the
+ * patch/populate lines plus a *runaway* count of the WindowSpawner
+ * line. So a robust e2e asserts on this trail rather than on UI
+ * timing alone — the log is the single source of truth for "did the
+ * post-SFTP-open orchestration actually run".
+ */
+
+export interface LogEntry {
+  ts?: string;
+  level?: string;
+  msg?: string;
+}
+
+export function logPathFor(vaultPath: string): string {
+  return path.join(
+    vaultPath,
+    '.obsidian',
+    'plugins',
+    'remote-ssh',
+    'console.log',
+  );
+}
+
+/**
+ * Parse the JSON-lines log. Tolerant of the rolling buffer's NUL
+ * padding and a truncated final line — anything unparseable is
+ * skipped rather than throwing, so a mid-write read just yields
+ * fewer entries and the caller's poll retries.
+ */
+export function readLogEntries(logPath: string): LogEntry[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(logPath, 'utf8');
+  } catch {
+    return []; // not created yet — caller polls
+  }
+  const out: LogEntry[] = [];
+  for (const line of raw.replace(/\0/g, '').split('\n')) {
+    const s = line.trim();
+    if (!s) continue;
+    try {
+      out.push(JSON.parse(s) as LogEntry);
+    } catch {
+      // partial / non-JSON line — skip
+    }
+  }
+  return out;
+}
+
+/** Count entries whose `msg` matches `pattern`. */
+export function countLog(logPath: string, pattern: RegExp): number {
+  return readLogEntries(logPath).filter(
+    (e) => typeof e.msg === 'string' && pattern.test(e.msg),
+  ).length;
+}
+
+/**
+ * Poll until at least one entry's `msg` matches `pattern`, or throw
+ * after `timeoutMs`. The throw message includes the last few log
+ * lines so a failure tells you *where* the lifecycle stalled — the
+ * exact diagnostic the production incident lacked.
+ */
+export async function waitForLog(
+  logPath: string,
+  pattern: RegExp,
+  timeoutMs: number,
+  label: string,
+): Promise<LogEntry> {
+  const deadline = Date.now() + timeoutMs;
+  let entries: LogEntry[] = [];
+  while (Date.now() < deadline) {
+    entries = readLogEntries(logPath);
+    const hit = entries.find(
+      (e) => typeof e.msg === 'string' && pattern.test(e.msg),
+    );
+    if (hit) return hit;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  const tail = entries
+    .slice(-12)
+    .map((e) => `  ${e.ts ?? '?'} [${e.level ?? '?'}] ${e.msg ?? ''}`)
+    .join('\n');
+  throw new Error(
+    `log-oracle: ${label} — no log line matched ${pattern} within ` +
+    `${timeoutMs}ms at ${logPath}.\nLast lines:\n${tail || '  (log empty / absent)'}`,
+  );
+}
+
+/**
+ * Assert `pattern` occurs at most `max` times — the spawn-loop guard.
+ * In the broken build `WindowSpawner: firing obsidian://open` repeated
+ * dozens of times; a healthy connect fires it a bounded number.
+ */
+export function assertAtMost(
+  logPath: string,
+  pattern: RegExp,
+  max: number,
+  label: string,
+): void {
+  const n = countLog(logPath, pattern);
+  if (n > max) {
+    throw new Error(
+      `log-oracle: ${label} — expected ${pattern} at most ${max}× but ` +
+      `saw ${n}× at ${logPath} (runaway loop — the production symptom)`,
+    );
+  }
+}

--- a/plugin/e2e/helpers/log-oracle.ts
+++ b/plugin/e2e/helpers/log-oracle.ts
@@ -52,7 +52,13 @@ export function readLogEntries(logPath: string): LogEntry[] {
     const s = line.trim();
     if (!s) continue;
     try {
-      out.push(JSON.parse(s) as LogEntry);
+      const parsed: unknown = JSON.parse(s);
+      // A log line is a JSON *object*; `JSON.parse` also accepts bare
+      // scalars (`123`, `"x"`, `null`) — casting those to LogEntry
+      // would be a lie that silently yields `{msg: undefined}` rows.
+      if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        out.push(parsed as LogEntry);
+      }
     } catch {
       // partial / non-JSON line — skip
     }

--- a/plugin/e2e/helpers/sshd.ts
+++ b/plugin/e2e/helpers/sshd.ts
@@ -1,0 +1,32 @@
+import * as net from 'node:net';
+
+/**
+ * Docker test-sshd reachability gate, shared by the connect-lifecycle /
+ * connect-failure / reconnect specs.
+ *
+ * These specs HARD-FAIL (never skip) when sshd is down: a broken
+ * connect must not pass CI green — that is precisely how 1.0.49
+ * shipped broken. Keeping this in one place stops the three specs
+ * from drifting apart (they previously each carried a verbatim copy).
+ */
+
+export const SSHD_HOST = '127.0.0.1';
+export const SSHD_PORT = 2222;
+
+export async function assertSshdReachable(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const sock = net
+      .connect({ host: SSHD_HOST, port: SSHD_PORT })
+      .setTimeout(5_000)
+      .once('connect', () => { sock.destroy(); resolve(); })
+      .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
+      .once('error', reject);
+  }).catch((e) => {
+    throw new Error(
+      `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
+      `(${(e as Error).message}). Run \`npm run sshd:start\` first. ` +
+      `This spec HARD-FAILS instead of skipping — a broken connect ` +
+      `must not pass CI green (that is how 1.0.49 shipped broken).`,
+    );
+  });
+}

--- a/plugin/e2e/helpers/vault-scaffold.ts
+++ b/plugin/e2e/helpers/vault-scaffold.ts
@@ -18,6 +18,16 @@ export interface ScaffoldResult {
   cleanup: () => void;
 }
 
+export interface ScaffoldOptions {
+  /**
+   * Transport for the seeded test profile. Defaults to `'rpc'` so
+   * existing specs (smoke/sync/reflect/demo) are unaffected. The
+   * connect-lifecycle spec passes `'sftp'` — the transport the
+   * production connect-stall incident was reported on.
+   */
+  transport?: 'sftp' | 'rpc';
+}
+
 /**
  * Create a temporary Obsidian vault with the remote-ssh plugin
  * pre-installed and a test SSH profile pre-configured.
@@ -26,7 +36,8 @@ export interface ScaffoldResult {
  * auto-connect on launch if `autoConnectProfileId` is set in
  * `data.json`.
  */
-export function scaffoldTestVault(): ScaffoldResult {
+export function scaffoldTestVault(opts: ScaffoldOptions = {}): ScaffoldResult {
+  const transport = opts.transport ?? 'rpc';
   const pluginRoot = path.resolve(__dirname, '..', '..');
   const vaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'e2e-vault-'));
 
@@ -77,7 +88,7 @@ export function scaffoldTestVault(): ScaffoldResult {
         authMethod: 'privateKey',
         privateKeyPath,
         remotePath: TEST_VAULT_REMOTE,
-        transport: 'rpc',
+        transport,
         connectTimeoutMs: 30_000,
         keepaliveIntervalMs: 10_000,
         keepaliveCountMax: 3,

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.5",
+  "version": "1.0.49-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49-beta.3",
+  "version": "1.1.0-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.5",
+  "version": "1.0.49-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.5",
+      "version": "1.0.49-beta.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49-beta.3",
+  "version": "1.1.0-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.49-beta.3",
+      "version": "1.1.0-beta.6",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.5",
+  "version": "1.0.49-beta.3",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49-beta.3",
+  "version": "1.1.0-beta.6",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Why

Stable **1.0.49** shipped with a broken connect: console.log shows `SFTP channel open`, then **no** `Adapter patched` / `runAutoConnect` / `populateVaultFromRemote` lines, then a runaway `WindowSpawner: firing obsidian://open` re-spawn loop. It passed every PR green because **the connect orchestration has zero automated coverage** — integration tests drive a bare adapter over docker sshd; the Playwright specs skip when sshd is unreachable and only assert "something appeared".

This is the **#343-style "test that must be satisfied"** PR. The connect-orchestration fix is the **next PR** in the chain and turns this green (same pattern as #343 → #346/#347).

## What ships

- `e2e/helpers/log-oracle.ts` — JSON-lines reader over the plugin's `console.log`; `waitForLog` (throws with a tail diagnostic — the signal the incident lacked), `assertAtMost` (spawn-loop guard).
- `e2e/helpers/vault-scaffold.ts` — `scaffoldTestVault({transport})`; default `'rpc'` keeps smoke/sync/reflect/demo unaffected, this spec passes `'sftp'`.
- `e2e/connect-lifecycle.spec.ts` — drives the **full real lifecycle in real Obsidian over SFTP** and **HARD-FAILS** (never skips). Asserts the trail that was absent in the incident (`SFTP channel open` → `Adapter patched via SFTP` → `populateVaultFromRemote`) and bounds the runaway `WindowSpawner` count. **Expected RED on current build** (reproduces the incident), GREEN once connect is fixed.

## Safety / sequencing

`e2e.yml` triggers on `pull_request:[main]` + weekly cron — **not** PR→next. So landing this red spec into next does **not** block next's required checks. Making it a **required full gate** is deferred (Phase 4) until the connect fix is green — we never stack on a red base.

Beta bump `1.0.49-beta.2 → -beta.3` for version-check; root `manifest.json` + `versions.json` stay pinned per the beta rule.

## Next in the chain

PR-B: root-cause + fix the connect orchestration stall (`runShadowStartup` / `runAutoConnect` / `AdapterManager.patch` / `pullSharedObsidianConfig` / `populateVaultFromRemote`) so this spec goes green; then PR-C wires it as a required CI gate + adds the reconnect scenario.

## Test plan

- [ ] Local: `npm run build && npm run sshd:start && npx playwright test e2e/connect-lifecycle.spec.ts` → RED reproducing the incident (no `Adapter patched via SFTP` / spawn-loop)
- [ ] After PR-B (connect fix): same command → GREEN
- [ ] Existing smoke/sync/reflect/demo unaffected (scaffold default still rpc)

Generated with Claude Code