### PR TITLE
test(e2e): reconnect spec + e2e gate on next (PR-C, chained on #352)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,13 @@ name: E2E smoke (Playwright + Obsidian)
 
 on:
   pull_request:
-    branches: [main]
+    # Both release branches. `next` is where features (and the
+    # connect-lifecycle / connect-failure specs) land first — gating
+    # it here is what stops a broken connect reaching stable again
+    # (1.0.49 shipped connect-broken because nothing exercised the
+    # real connect path on a next PR). Mark "Obsidian E2E smoke" as a
+    # required check on next in branch protection to make it binding.
+    branches: [main, next]
     paths:
       # Plugin or daemon source — anything that could change the
       # Obsidian-side behaviour the spec drives.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/connect-reconnect.spec.ts
+++ b/plugin/e2e/connect-reconnect.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+import * as net from 'node:net';
+import * as path from 'node:path';
+import { execSync } from 'node:child_process';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import {
+  logPathFor,
+  waitForLog,
+  waitForCount,
+  countLog,
+  assertAtMost,
+} from './helpers/log-oracle';
+
+/**
+ * Reconnect e2e (Phase 2) — guards "再接続したときに vault が適切に
+ * 読み込めない" from the field report.
+ *
+ * Flow: connect over SFTP with a valid path → kill the docker sshd
+ * (unexpected drop) → assert the plugin actually enters the reconnect
+ * loop (it must be VISIBLE, not a silent dead session) → bring sshd
+ * back → assert it recovers, with no spawn storm.
+ *
+ * Recovered-oracle for SFTP: `setState` doesn't log and recovery has
+ * no other stable logged line, but a successful reconnect re-runs
+ * `SftpClient.connect`, which emits a *fresh* `SFTP channel open`.
+ * So "the `SFTP channel open` count grew past the pre-drop baseline"
+ * is the reliable, transport-correct recovery signal.
+ *
+ * This is the flakiest spec by nature (real docker kill + backoff +
+ * real Obsidian). Budgets are generous and sshd is restored as soon
+ * as the first failed attempt is observed, to stay inside the
+ * ReconnectManager retry budget (1s×1.5→30s, ~5 retries).
+ *
+ * HARD-FAILS if sshd is unreachable at start — a connect-path spec
+ * that silently skips is how the incident shipped green.
+ */
+
+const SSHD_HOST = '127.0.0.1';
+const SSHD_PORT = 2222;
+const PLUGIN_ROOT = path.resolve(__dirname, '..');
+
+test.setTimeout(360_000);
+
+async function assertSshdReachable(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const sock = net
+      .connect({ host: SSHD_HOST, port: SSHD_PORT })
+      .setTimeout(5_000)
+      .once('connect', () => { sock.destroy(); resolve(); })
+      .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
+      .once('error', reject);
+  }).catch((e) => {
+    throw new Error(
+      `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
+      `(${(e as Error).message}). Run \`npm run sshd:start\` first.`,
+    );
+  });
+}
+
+function sshd(action: 'start' | 'stop'): void {
+  execSync(`npm run sshd:${action}`, { cwd: PLUGIN_ROOT, stdio: 'pipe' });
+}
+
+test.describe('connect reconnect (SFTP, sshd drop → recover)', () => {
+  let scaffold: ScaffoldResult;
+  let scaffoldHandle: ObsidianHandle | null = null;
+  let shadowHandle: ObsidianHandle | null = null;
+  let sshdRestored = true;
+
+  test.beforeAll(async () => {
+    await assertSshdReachable();
+    scaffold = scaffoldTestVault({ transport: 'sftp' });
+  });
+
+  test.afterAll(async () => {
+    // Never leave the shared docker sshd down for later specs/runs.
+    if (!sshdRestored) {
+      try { sshd('start'); } catch { /* best effort */ }
+    }
+    try { await shadowHandle?.cleanup(); } catch { /* best effort */ }
+    try { await scaffoldHandle?.cleanup(); } catch { /* best effort */ }
+    scaffold?.cleanup();
+  });
+
+  test('an unexpected sshd drop enters a visible reconnect loop and recovers', async () => {
+    scaffoldHandle = await launchObsidian(scaffold.vaultPath);
+    await driveConnectFlow(scaffoldHandle.page);
+    const shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 20_000);
+    await scaffoldHandle.cleanup();
+    scaffoldHandle = null;
+
+    shadowHandle = await launchObsidian(shadowVaultPath);
+    const shadowLog = logPathFor(shadowVaultPath);
+
+    // 1. Establish a healthy connection first.
+    await waitForLog(shadowLog, /SFTP channel open/, 60_000, 'initial SFTP open');
+    await waitForLog(
+      shadowLog,
+      /Adapter patched via SFTP/,
+      60_000,
+      'initial connect must patch',
+    );
+    const baselineOpens = countLog(shadowLog, /SFTP channel open/);
+
+    // 2. Drop the remote unexpectedly.
+    sshd('stop');
+    sshdRestored = false;
+
+    // 3. The drop MUST surface as a reconnect loop, not a silent dead
+    //    session (the field complaint was a connection that just
+    //    stopped working with no feedback).
+    await waitForLog(
+      shadowLog,
+      /reconnect attempt \d+\/\d+ failed/,
+      90_000,
+      'an unexpected drop must enter a VISIBLE reconnect loop',
+    );
+
+    // 4. Restore the remote immediately — stay within the retry
+    //    budget so a later attempt can succeed.
+    sshd('start');
+    sshdRestored = true;
+
+    // 5. Recovery: a successful reconnect re-opens the SFTP channel,
+    //    so the open-count must grow past the pre-drop baseline.
+    await waitForCount(
+      shadowLog,
+      /SFTP channel open/,
+      baselineOpens + 1,
+      150_000,
+      'reconnect must recover (a fresh SFTP channel open after restore)',
+    );
+
+    // 6. No spawn storm through the whole drop/recover cycle.
+    assertAtMost(
+      shadowLog,
+      /WindowSpawner: firing obsidian:\/\/open/,
+      2,
+      'reconnect must not loop-spawn the shadow vault',
+    );
+
+    // 7. The vault is usable again — File Explorer still renders.
+    const explorerVisible = await shadowHandle.page
+      .locator('.nav-files-container .nav-file-title')
+      .first()
+      .isVisible({ timeout: 30_000 })
+      .catch(() => false);
+    expect(
+      explorerVisible,
+      'File Explorer should still render after reconnect',
+    ).toBe(true);
+  });
+});

--- a/plugin/e2e/connect-reconnect.spec.ts
+++ b/plugin/e2e/connect-reconnect.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from '@playwright/test';
-import * as net from 'node:net';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import {
@@ -16,6 +15,7 @@ import {
   countLog,
   assertAtMost,
 } from './helpers/log-oracle';
+import { assertSshdReachable, waitForSshdReachable } from './helpers/sshd';
 
 /**
  * Reconnect e2e (Phase 2) — guards "再接続したときに vault が適切に
@@ -41,27 +41,9 @@ import {
  * that silently skips is how the incident shipped green.
  */
 
-const SSHD_HOST = '127.0.0.1';
-const SSHD_PORT = 2222;
 const PLUGIN_ROOT = path.resolve(__dirname, '..');
 
 test.setTimeout(360_000);
-
-async function assertSshdReachable(): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const sock = net
-      .connect({ host: SSHD_HOST, port: SSHD_PORT })
-      .setTimeout(5_000)
-      .once('connect', () => { sock.destroy(); resolve(); })
-      .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
-      .once('error', reject);
-  }).catch((e) => {
-    throw new Error(
-      `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
-      `(${(e as Error).message}). Run \`npm run sshd:start\` first.`,
-    );
-  });
-}
 
 function sshd(action: 'start' | 'stop'): void {
   execSync(`npm run sshd:${action}`, { cwd: PLUGIN_ROOT, stdio: 'pipe' });
@@ -106,7 +88,6 @@ test.describe('connect reconnect (SFTP, sshd drop → recover)', () => {
       60_000,
       'initial connect must patch',
     );
-    const baselineOpens = countLog(shadowLog, /SFTP channel open/);
 
     // 2. Drop the remote unexpectedly.
     sshd('stop');
@@ -122,10 +103,26 @@ test.describe('connect reconnect (SFTP, sshd drop → recover)', () => {
       'an unexpected drop must enter a VISIBLE reconnect loop',
     );
 
+    // Capture the baseline open-count HERE, not right after the
+    // initial patch. Reading it earlier races the rolling log buffer:
+    // the initial connect can emit more than one `SFTP channel open`
+    // and a late-flushed one would inflate the baseline OR, worse,
+    // satisfy the `+1` recovery check below from a *pre-drop* open
+    // (false pass). At this point sshd is down and the reconnect-fail
+    // line is logged well after every pre-drop open — so the count is
+    // stable and no new open can appear until we restore.
+    const baselineOpens = countLog(shadowLog, /SFTP channel open/);
+
     // 4. Restore the remote immediately — stay within the retry
     //    budget so a later attempt can succeed.
     sshd('start');
     sshdRestored = true;
+    // `npm run sshd:start` returns the moment `docker compose up -d`
+    // exits — sshd inside the container is NOT accepting connections
+    // yet. Wait for the port to actually come back so a slow/failed
+    // restart fails as a HARNESS fault here, not as a misleading
+    // "reconnect must recover" plugin failure 150s later.
+    await waitForSshdReachable(60_000);
 
     // 5. Recovery: a successful reconnect re-opens the SFTP channel,
     //    so the open-count must grow past the pre-drop baseline.
@@ -146,14 +143,16 @@ test.describe('connect reconnect (SFTP, sshd drop → recover)', () => {
     );
 
     // 7. The vault is usable again — File Explorer still renders.
-    const explorerVisible = await shadowHandle.page
-      .locator('.nav-files-container .nav-file-title')
-      .first()
-      .isVisible({ timeout: 30_000 })
-      .catch(() => false);
-    expect(
-      explorerVisible,
+    //    `expect(...).toBeVisible` auto-waits AND surfaces the real
+    //    Playwright failure (page closed, target crashed, selector
+    //    never matched). The old `.isVisible().catch(() => false)`
+    //    swallowed all of those into a bare `false`, turning a crashed
+    //    page into a context-free "expected true, got false".
+    await expect(
+      shadowHandle.page
+        .locator('.nav-files-container .nav-file-title')
+        .first(),
       'File Explorer should still render after reconnect',
-    ).toBe(true);
+    ).toBeVisible({ timeout: 30_000 });
   });
 });

--- a/plugin/e2e/helpers/log-oracle.ts
+++ b/plugin/e2e/helpers/log-oracle.ts
@@ -106,6 +106,34 @@ export async function waitForLog(
 }
 
 /**
+ * Poll until `pattern` has occurred at least `min` times, or throw
+ * after `timeoutMs`. Used by the reconnect spec: a successful SFTP
+ * reconnect emits a *fresh* `SFTP channel open` line, so "count grew
+ * past the pre-drop baseline" is the reliable recovered-oracle for
+ * the SFTP transport (setState doesn't log; recovery has no other
+ * stable logged signal).
+ */
+export async function waitForCount(
+  logPath: string,
+  pattern: RegExp,
+  min: number,
+  timeoutMs: number,
+  label: string,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let n = 0;
+  while (Date.now() < deadline) {
+    n = countLog(logPath, pattern);
+    if (n >= min) return;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(
+    `log-oracle: ${label} — ${pattern} occurred ${n}× (< ${min}) within ` +
+    `${timeoutMs}ms at ${logPath}`,
+  );
+}
+
+/**
  * Assert `pattern` occurs at most `max` times — the spawn-loop guard.
  * In the broken build `WindowSpawner: firing obsidian://open` repeated
  * dozens of times; a healthy connect fires it a bounded number.

--- a/plugin/e2e/helpers/sshd.ts
+++ b/plugin/e2e/helpers/sshd.ts
@@ -13,15 +13,20 @@ import * as net from 'node:net';
 export const SSHD_HOST = '127.0.0.1';
 export const SSHD_PORT = 2222;
 
-export async function assertSshdReachable(): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
+/** One-shot TCP probe — resolves if the port accepts a connection. */
+function probeSshd(): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
     const sock = net
       .connect({ host: SSHD_HOST, port: SSHD_PORT })
       .setTimeout(5_000)
       .once('connect', () => { sock.destroy(); resolve(); })
       .once('timeout', () => { sock.destroy(); reject(new Error('timeout')); })
       .once('error', reject);
-  }).catch((e) => {
+  });
+}
+
+export async function assertSshdReachable(): Promise<void> {
+  await probeSshd().catch((e) => {
     throw new Error(
       `docker test sshd not reachable at ${SSHD_HOST}:${SSHD_PORT} ` +
       `(${(e as Error).message}). Run \`npm run sshd:start\` first. ` +
@@ -29,4 +34,35 @@ export async function assertSshdReachable(): Promise<void> {
       `must not pass CI green (that is how 1.0.49 shipped broken).`,
     );
   });
+}
+
+/**
+ * Poll until sshd accepts connections again, or throw after
+ * `timeoutMs`. `npm run sshd:start` exits 0 the moment `docker
+ * compose up -d` returns — the container's sshd is NOT yet accepting
+ * connections at that point. Without this wait the reconnect spec's
+ * recovery assertion times out and blames the *plugin* ("reconnect
+ * must recover") when the real fault is "the harness never brought
+ * sshd back". This makes that failure attributable.
+ */
+export async function waitForSshdReachable(
+  timeoutMs: number,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr = 'unknown';
+  while (Date.now() < deadline) {
+    try {
+      await probeSshd();
+      return;
+    } catch (e) {
+      lastErr = (e as Error).message;
+      await new Promise((r) => setTimeout(r, 1_000));
+    }
+  }
+  throw new Error(
+    `sshd did not become reachable at ${SSHD_HOST}:${SSHD_PORT} within ` +
+    `${timeoutMs}ms after restart (last: ${lastErr}). This is a HARNESS ` +
+    `fault (sshd:start ran but the container never came back), NOT a ` +
+    `plugin reconnect failure — fix the docker test sshd, not the plugin.`,
+  );
 }

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.7",
+      "version": "1.1.0-beta.8",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.7",
+  "version": "1.1.0-beta.8",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Chain: feat/connect-e2e-ci → #352 → #351 → next. PR-C.

### Phase 2 — reconnect e2e (`connect-reconnect.spec.ts`)

Guards "再接続したときに vault が適切に読み込めない":

1. Connect over SFTP (valid path) → assert healthy (`SFTP channel open` + `Adapter patched via SFTP`).
2. `npm run sshd:stop` (unexpected drop).
3. Assert a **visible** reconnect loop (`reconnect attempt N/M failed`) — the field complaint was a session that just died with no feedback.
4. `npm run sshd:start` (immediately, to stay inside the ~5-retry backoff budget).
5. Assert **recovery** via a *fresh* `SFTP channel open` beyond the pre-drop baseline — the only transport-correct recovered-oracle for SFTP (`setState` doesn't log; recovery has no other stable logged line).
6. No spawn storm; File Explorer still renders.

`afterAll` restores sshd even on failure so the shared container is never left down. New `log-oracle.waitForCount` (poll until ≥N) backs the recovery oracle. This is the flakiest spec by nature (real docker kill + backoff + real Obsidian) — generous budgets, sshd restored as soon as the first failed attempt is seen.

### Phase 4 — e2e gate on `next` (`e2e.yml`)

`pull_request: branches: [main]` → `[main, next]`. `next` is where features (and these connect specs) land first; gating it is what stops a broken connect reaching stable again — 1.0.49 shipped connect-broken precisely because nothing exercised the real connect path on a next PR. The job already does `sshd:start` + Obsidian AppImage + Xvfb + **no continue-on-error**, so the trigger is the entire change.

> Making **"Obsidian E2E smoke"** a *required* check on `next` is a branch-protection setting (Settings → Branches), not YAML — maintainer action. Noted inline in the workflow.

### Scope / safety

No `src/` changes (e2e specs + workflow only) → tsc/lint/vitest unaffected. e2e runs real Obsidian + docker sshd (CI job / local).

### Merge order

#351 → #352 → this. Once green: the connect lifecycle (happy / bad-path / reconnect) is covered end-to-end and gated on next, closing the coverage gap that let 1.0.49 ship broken.

### Reminder (code-external)

The actual reported "can't connect" vault is fixed by correcting that profile's `remotePath` to an existing remote dir — see #352.

Generated with Claude Code