### PR TITLE
fix(rpc): auto-redeploy daemon on stale vault-root (no manual pkill)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.4",
+      "version": "1.1.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.4",
+  "version": "1.1.0-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/ConnectionManager.ts
+++ b/plugin/src/ConnectionManager.ts
@@ -84,6 +84,18 @@ export class ConnectionManager {
     const home = await this.client.getRemoteHome();
     const absSocketPath = resolveRemotePath(remoteSocketPath, home);
     const absTokenPath  = resolveRemotePath(remoteTokenPath,  home);
+
+    // Absolute vault root, computed ONCE and used both for the
+    // reuse-validation compare and as the daemon's `--vault-root`.
+    // Passing this absolute form to the daemon (instead of the raw
+    // relative `effectivePath`) removes the daemon's implicit cwd
+    // dependency AND keeps both sides of the sameRemotePath() compare
+    // in the same path space — without that, e.g. remotePath "~"
+    // (→ effectivePath ".") made the client want "/home/u/." while
+    // the daemon's filepath.Abs reported "/home/u", a guaranteed
+    // false-mismatch → kill+redeploy on every connect.
+    const absVaultRoot = resolveRemotePath(effectivePath, home);
+
     const reused = await tryReuseExistingDaemon(this.client, absSocketPath, absTokenPath);
     if (reused) {
       // A daemon is already running, but its vault-root was fixed at
@@ -92,9 +104,11 @@ export class ConnectionManager {
       // wrong/missing tree → empty vault, every op `no such file`.
       // Validate the root and redeploy automatically on mismatch so
       // the user never has to SSH in and pkill the daemon by hand.
-      const wantRoot = resolveRemotePath(effectivePath, home);
-      const haveRoot = reused.info.vaultRoot;
-      if (sameRemotePath(haveRoot, wantRoot)) {
+      // `vaultRoot` is typed string but an older / third-party daemon
+      // can omit it on the wire → guard with `?? ''` (empty never
+      // matches a real root, so it redeploys, which is correct).
+      const haveRoot = reused.info.vaultRoot ?? '';
+      if (sameRemotePath(haveRoot, absVaultRoot)) {
         this.rpcConnection = reused;
         logger.info(
           `startRpcSession: reusing existing daemon for ${effectivePath} ` +
@@ -104,20 +118,27 @@ export class ConnectionManager {
       }
       logger.warn(
         `startRpcSession: existing daemon serves vaultRoot="${haveRoot}" but this ` +
-        `profile needs "${wantRoot}" — killing + redeploying so the profile's ` +
+        `profile needs "${absVaultRoot}" — killing + redeploying so the profile's ` +
         `remotePath takes effect (no manual pkill needed)`,
       );
-      try { reused.close(); } catch { /* best effort — deploy() pkills it anyway */ }
+      try {
+        reused.close();
+      } catch (e) {
+        // best effort — deploy() pkills + rm's socket/token anyway;
+        // logged (like every other close in this file) so a wedged
+        // transport leaves a trace instead of vanishing.
+        logger.warn(`startRpcSession: reused.close() on mismatch: ${errorMessage(e)}`);
+      }
       // fall through to deploy(): killExisting:true pkills the stale
       // daemon and redeploys at the correct vault-root.
     }
 
-    logger.info(`startRpcSession: deploying daemon to serve ${effectivePath}`);
+    logger.info(`startRpcSession: deploying daemon to serve ${absVaultRoot}`);
     const deployer = new ServerDeployer(this.client);
     const deploy = await deployer.deploy({
       localBinaryPath,
       remoteBinaryPath,
-      remoteVaultRoot: effectivePath,
+      remoteVaultRoot: absVaultRoot,
       remoteSocketPath,
       remoteTokenPath,
     });

--- a/plugin/src/ConnectionManager.ts
+++ b/plugin/src/ConnectionManager.ts
@@ -9,7 +9,7 @@ import { DEFAULT_BACKOFF } from './transport/Backoff';
 import { ServerDeployer, resolveRemotePath } from './transport/ServerDeployer';
 import { tryReuseExistingDaemon } from './transport/DaemonProbe';
 import { establishRpcConnection } from './transport/RpcConnection';
-import { normalizeRemotePath } from './util/pathUtils';
+import { normalizeRemotePath, sameRemotePath } from './util/pathUtils';
 import { logger } from './util/logger';
 import { errorMessage } from './util/errorMessage';
 import { sanitizeClientId, defaultClientId, defaultUserName } from './path/PathMapper';
@@ -86,12 +86,30 @@ export class ConnectionManager {
     const absTokenPath  = resolveRemotePath(remoteTokenPath,  home);
     const reused = await tryReuseExistingDaemon(this.client, absSocketPath, absTokenPath);
     if (reused) {
-      this.rpcConnection = reused;
-      logger.info(
-        `startRpcSession: reusing existing daemon for ${effectivePath} ` +
-        `(skipped kill+redeploy)`,
+      // A daemon is already running, but its vault-root was fixed at
+      // its deploy time. If the profile's remotePath changed (or the
+      // old root was deleted), reusing it would silently serve the
+      // wrong/missing tree → empty vault, every op `no such file`.
+      // Validate the root and redeploy automatically on mismatch so
+      // the user never has to SSH in and pkill the daemon by hand.
+      const wantRoot = resolveRemotePath(effectivePath, home);
+      const haveRoot = reused.info.vaultRoot;
+      if (sameRemotePath(haveRoot, wantRoot)) {
+        this.rpcConnection = reused;
+        logger.info(
+          `startRpcSession: reusing existing daemon for ${effectivePath} ` +
+          `(vaultRoot=${haveRoot}, skipped kill+redeploy)`,
+        );
+        return;
+      }
+      logger.warn(
+        `startRpcSession: existing daemon serves vaultRoot="${haveRoot}" but this ` +
+        `profile needs "${wantRoot}" — killing + redeploying so the profile's ` +
+        `remotePath takes effect (no manual pkill needed)`,
       );
-      return;
+      try { reused.close(); } catch { /* best effort — deploy() pkills it anyway */ }
+      // fall through to deploy(): killExisting:true pkills the stale
+      // daemon and redeploys at the correct vault-root.
     }
 
     logger.info(`startRpcSession: deploying daemon to serve ${effectivePath}`);

--- a/plugin/src/ConnectionManager.ts
+++ b/plugin/src/ConnectionManager.ts
@@ -86,14 +86,10 @@ export class ConnectionManager {
     const absTokenPath  = resolveRemotePath(remoteTokenPath,  home);
 
     // Absolute vault root, computed ONCE and used both for the
-    // reuse-validation compare and as the daemon's `--vault-root`.
-    // Passing this absolute form to the daemon (instead of the raw
-    // relative `effectivePath`) removes the daemon's implicit cwd
-    // dependency AND keeps both sides of the sameRemotePath() compare
-    // in the same path space — without that, e.g. remotePath "~"
-    // (→ effectivePath ".") made the client want "/home/u/." while
-    // the daemon's filepath.Abs reported "/home/u", a guaranteed
-    // false-mismatch → kill+redeploy on every connect.
+    // reuse-validation compare and as the daemon's `--vault-root`
+    // (removes the daemon's implicit cwd dependency and keeps both
+    // sides of the compare in the same path space — see the
+    // `sameRemotePath` JSDoc for the normalisation rationale).
     const absVaultRoot = resolveRemotePath(effectivePath, home);
 
     const reused = await tryReuseExistingDaemon(this.client, absSocketPath, absTokenPath);
@@ -111,7 +107,7 @@ export class ConnectionManager {
       if (sameRemotePath(haveRoot, absVaultRoot)) {
         this.rpcConnection = reused;
         logger.info(
-          `startRpcSession: reusing existing daemon for ${effectivePath} ` +
+          `startRpcSession: reusing existing daemon for ${absVaultRoot} ` +
           `(vaultRoot=${haveRoot}, skipped kill+redeploy)`,
         );
         return;

--- a/plugin/src/proto/types.ts
+++ b/plugin/src/proto/types.ts
@@ -18,8 +18,16 @@ export interface ServerInfo {
   protocolVersion: number;
   /** Method names the daemon implements, e.g. ["fs.stat", "fs.list", ...]. */
   capabilities: string[];
-  /** Absolute vault root on the remote host (informational; paths are vault-relative). */
-  vaultRoot: string;
+  /**
+   * Absolute vault root on the remote host (informational; paths are
+   * vault-relative). Optional: this field was added after the initial
+   * protocol, so an older or third-party daemon that passes the
+   * protocol-version check can still omit it on the wire. Consumers
+   * MUST treat an absent value as "unknown root" (the connect flow
+   * `?? ''`s it and redeploys). Do not drop the `?` — the runtime can
+   * be `undefined` even though the current daemon always sets it.
+   */
+  vaultRoot?: string;
 }
 
 export interface Stat {

--- a/plugin/src/util/pathUtils.ts
+++ b/plugin/src/util/pathUtils.ts
@@ -45,3 +45,26 @@ export function normalizeRemotePath(p: string): string {
   while (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
   return r;
 }
+
+/**
+ * Compare two ABSOLUTE remote (POSIX) paths for equality, tolerant of
+ * a trailing slash. Used to decide whether a reused RPC daemon's
+ * `ServerInfo.vaultRoot` matches the vault root the current profile
+ * needs — if it doesn't, the daemon is stale (the profile's
+ * remotePath changed, or the old root was deleted) and must be
+ * killed + redeployed instead of silently serving the wrong/missing
+ * tree.
+ *
+ * Deliberately strict: any non-trivial difference returns false so
+ * the caller redeploys. A spurious redeploy is cheap and safe; a
+ * false "match" reattaches to a daemon serving the wrong root, which
+ * is exactly the field bug (empty vault, every op `no such file`).
+ */
+export function sameRemotePath(a: string, b: string): boolean {
+  const strip = (s: string): string => {
+    let r = s.trim();
+    while (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
+    return r;
+  };
+  return strip(a) === strip(b);
+}

--- a/plugin/src/util/pathUtils.ts
+++ b/plugin/src/util/pathUtils.ts
@@ -55,16 +55,35 @@ export function normalizeRemotePath(p: string): string {
  * killed + redeployed instead of silently serving the wrong/missing
  * tree.
  *
- * Deliberately strict: any non-trivial difference returns false so
- * the caller redeploys. A spurious redeploy is cheap and safe; a
- * false "match" reattaches to a daemon serving the wrong root, which
- * is exactly the field bug (empty vault, every op `no such file`).
+ * Both sides are POSIX-normalised (`.`, `..`, `//`, trailing slash)
+ * before comparison: the client computes the wanted root by string
+ * join (`resolveRemotePath`) while the daemon reports its root via
+ * Go's `filepath.Abs`, which collapses `.`/`..`/`//`. Without
+ * normalisation, remotePath `~` (→ `/home/u/.`) vs the daemon's
+ * `/home/u` is a permanent false-mismatch → kill+redeploy on every
+ * connect. An empty/blank input (older daemon omitting the field,
+ * or `undefined`) never matches a real root — that intentionally
+ * forces a redeploy, which is the safe outcome.
+ *
+ * Still strict otherwise: a false "match" reattaches to a daemon
+ * serving the wrong root (the field bug — empty vault, every op
+ * `no such file`). A spurious redeploy is *safe* but not free — it
+ * costs a full pkill + binary upload + daemon restart (seconds on a
+ * slow link) — so the normalisation above exists to avoid firing it
+ * on legitimately-equal paths, not to make redeploy cheap.
  */
-export function sameRemotePath(a: string, b: string): boolean {
-  const strip = (s: string): string => {
-    let r = s.trim();
+export function sameRemotePath(a: string | undefined, b: string | undefined): boolean {
+  const norm = (s: string | undefined): string => {
+    const t = (s ?? '').trim();
+    if (t === '') return '';
+    let r = path.posix.normalize(t);
     while (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
     return r;
   };
-  return strip(a) === strip(b);
+  const na = norm(a);
+  const nb = norm(b);
+  // Empty (missing/blank root) must never count as a match, not even
+  // empty-vs-empty — it always means "can't trust this, redeploy".
+  if (na === '' || nb === '') return false;
+  return na === nb;
 }

--- a/plugin/src/util/pathUtils.ts
+++ b/plugin/src/util/pathUtils.ts
@@ -77,6 +77,10 @@ export function sameRemotePath(a: string | undefined, b: string | undefined): bo
     const t = (s ?? '').trim();
     if (t === '') return '';
     let r = path.posix.normalize(t);
+    // posix.normalize collapses ./../// but PRESERVES a trailing
+    // slash on non-root paths ('/a/b/' → '/a/b/') — strip it here so
+    // '/a/b' and '/a/b/' compare equal. Load-bearing: do not remove
+    // thinking normalize already handled it.
     while (r.length > 1 && r.endsWith('/')) r = r.slice(0, -1);
     return r;
   };

--- a/plugin/tests/ConnectionManager.test.ts
+++ b/plugin/tests/ConnectionManager.test.ts
@@ -1,5 +1,28 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the three transport collaborators startRpcSession touches.
+// `resolveRemotePath` is kept REAL (pure) so the absolute-vault-root
+// computation under test is exercised for real, not stubbed.
+vi.mock('../src/transport/DaemonProbe', () => ({
+  tryReuseExistingDaemon: vi.fn(),
+}));
+vi.mock('../src/transport/RpcConnection', () => ({
+  establishRpcConnection: vi.fn(),
+}));
+const deployMock = vi.fn();
+vi.mock('../src/transport/ServerDeployer', async (orig) => {
+  const actual = await orig<typeof import('../src/transport/ServerDeployer')>();
+  return {
+    ...actual, // keep the real resolveRemotePath
+    // A class (not an arrow) — ConnectionManager does `new ServerDeployer(client)`.
+    ServerDeployer: class { deploy = deployMock; },
+  };
+});
+
 import { ConnectionManager } from '../src/ConnectionManager';
+import { tryReuseExistingDaemon } from '../src/transport/DaemonProbe';
+import { establishRpcConnection } from '../src/transport/RpcConnection';
+import type { SshProfile } from '../src/types';
 
 describe('ConnectionManager static helpers', () => {
   it('resolveClientId sanitizes explicit clientId overrides', () => {
@@ -10,10 +33,8 @@ describe('ConnectionManager static helpers', () => {
     const fromBlank = ConnectionManager.resolveClientId({ clientId: '   ' });
     const fromEmpty = ConnectionManager.resolveClientId({ clientId: '' });
     const fromOmitted = ConnectionManager.resolveClientId({});
-    // All three should resolve to the same defaultClientId() value
     expect(fromBlank).toBe(fromEmpty);
     expect(fromEmpty).toBe(fromOmitted);
-    // sanitizeClientId is applied: only safe chars, no leading/trailing dash
     expect(fromBlank).toMatch(/^[A-Za-z0-9._-]+$/);
     expect(fromBlank).not.toMatch(/^-|-$/);
   });
@@ -28,11 +49,97 @@ describe('ConnectionManager static helpers', () => {
   it('formatUserLabel falls back when values are blank', () => {
     const label = ConnectionManager.formatUserLabel({ userName: '   ', clientId: '   ' });
     const [name, id] = label.split('@');
-    // Both sides of @ must be non-empty
     expect(name).toBeTruthy();
     expect(id).toBeTruthy();
-    // clientId side must be sanitized (no spaces, slashes, leading/trailing dashes)
     expect(id).toMatch(/^[A-Za-z0-9._-]+$/);
     expect(id).not.toMatch(/^-|-$/);
+  });
+});
+
+// ─── startRpcSession: daemon-reuse vault-root validation (#355) ───────────────
+// Pins the branch the connect e2e does NOT exercise (it always
+// fresh-deploys): reuse-on-match, kill+redeploy-on-mismatch, and the
+// `reused.info.vaultRoot ?? ''` guard against an old daemon omitting
+// the field.
+
+describe('ConnectionManager.startRpcSession — daemon-reuse vault-root guard', () => {
+  const tryReuse = vi.mocked(tryReuseExistingDaemon);
+  const estRpc = vi.mocked(establishRpcConnection);
+
+  const HOME = '/home/souta';
+  const profile = { id: 'p', name: 'P', remotePath: '~/work' } as unknown as SshProfile;
+
+  function makeClient() {
+    return {
+      getRemoteHome: vi.fn().mockResolvedValue(HOME),
+      openUnixStream: vi.fn().mockResolvedValue({}),
+    } as unknown as ConstructorParameters<typeof ConnectionManager>[0];
+  }
+  function makeMgr() {
+    return new ConnectionManager(makeClient(), { locateDaemonBinary: () => '/local/daemon' });
+  }
+  function reusedConn(vaultRoot: string | undefined) {
+    return {
+      info: { version: '0', protocolVersion: 1, capabilities: [], vaultRoot },
+      close: vi.fn(),
+    };
+  }
+
+  beforeEach(() => {
+    tryReuse.mockReset();
+    estRpc.mockReset();
+    deployMock.mockReset();
+    deployMock.mockResolvedValue({ token: 'tok', remoteSocketPath: 'sock' });
+    estRpc.mockResolvedValue({
+      info: { version: '0', protocolVersion: 1, capabilities: [], vaultRoot: `${HOME}/work` },
+      close: vi.fn(),
+    } as never);
+  });
+
+  it('reuses the daemon when its vaultRoot matches the profile root (no redeploy)', async () => {
+    const reused = reusedConn(`${HOME}/work`); // resolveRemotePath('work', HOME) === /home/souta/work
+    tryReuse.mockResolvedValue(reused as never);
+    const mgr = makeMgr();
+
+    await mgr.startRpcSession(profile, 'work');
+
+    expect(mgr.rpcConnection).toBe(reused);
+    expect(deployMock).not.toHaveBeenCalled();
+    expect(reused.close).not.toHaveBeenCalled();
+  });
+
+  it('closes the stale daemon and redeploys at the correct root on mismatch', async () => {
+    const reused = reusedConn(`${HOME}/work/OldVaultDev`); // different root
+    tryReuse.mockResolvedValue(reused as never);
+    const mgr = makeMgr();
+
+    await mgr.startRpcSession(profile, 'work');
+
+    expect(reused.close).toHaveBeenCalledTimes(1);
+    expect(deployMock).toHaveBeenCalledTimes(1);
+    // deploy() must get the ABSOLUTE resolved root, not the relative form.
+    expect(deployMock.mock.calls[0][0]).toMatchObject({
+      remoteVaultRoot: `${HOME}/work`,
+    });
+  });
+
+  it('treats an absent vaultRoot (old/3rd-party daemon) as a mismatch — redeploys, no throw', async () => {
+    const reused = reusedConn(undefined); // `?? ''` guard path
+    tryReuse.mockResolvedValue(reused as never);
+    const mgr = makeMgr();
+
+    await expect(mgr.startRpcSession(profile, 'work')).resolves.toBeUndefined();
+    expect(reused.close).toHaveBeenCalledTimes(1);
+    expect(deployMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deploys fresh when there is no daemon to reuse', async () => {
+    tryReuse.mockResolvedValue(null);
+    const mgr = makeMgr();
+
+    await mgr.startRpcSession(profile, 'work');
+
+    expect(deployMock).toHaveBeenCalledTimes(1);
+    expect(deployMock.mock.calls[0][0]).toMatchObject({ remoteVaultRoot: `${HOME}/work` });
   });
 });

--- a/plugin/tests/pathUtils.test.ts
+++ b/plugin/tests/pathUtils.test.ts
@@ -133,4 +133,27 @@ describe('sameRemotePath (RPC daemon vault-root validation)', () => {
     expect(sameRemotePath('/', '/')).toBe(true);
     expect(sameRemotePath('/', '')).toBe(false);
   });
+
+  it('normalises "." — remotePath "~" case that caused the redeploy loop', () => {
+    // resolveRemotePath('.', '/home/souta') = '/home/souta/.'
+    // daemon filepath.Abs('.') reports '/home/souta' → must MATCH now.
+    expect(sameRemotePath('/home/souta/.', '/home/souta')).toBe(true);
+  });
+
+  it('normalises ".." and collapses "//"', () => {
+    expect(sameRemotePath('/home/souta/work/../work', '/home/souta/work')).toBe(true);
+    expect(sameRemotePath('/home//souta/work', '/home/souta/work')).toBe(true);
+  });
+
+  it('empty-vs-empty is NOT a match (missing root always redeploys)', () => {
+    expect(sameRemotePath('', '')).toBe(false);
+    expect(sameRemotePath('   ', '/x')).toBe(false);
+  });
+
+  it('undefined inputs are safe (no throw) and never match', () => {
+    expect(() => sameRemotePath(undefined, '/home/souta/work')).not.toThrow();
+    expect(sameRemotePath(undefined, '/home/souta/work')).toBe(false);
+    expect(sameRemotePath('/home/souta/work', undefined)).toBe(false);
+    expect(sameRemotePath(undefined, undefined)).toBe(false);
+  });
 });

--- a/plugin/tests/pathUtils.test.ts
+++ b/plugin/tests/pathUtils.test.ts
@@ -6,6 +6,7 @@ import {
   normalizeRemotePath,
   posixJoin,
   relativeTo,
+  sameRemotePath,
   toLocalPath,
   toRemotePath,
 } from '../src/util/pathUtils';
@@ -99,5 +100,37 @@ describe('path utility helpers', () => {
 
   it('expandHome leaves non-tilde paths unchanged', () => {
     expect(expandHome('/srv/vault')).toBe('/srv/vault');
+  });
+});
+
+describe('sameRemotePath (RPC daemon vault-root validation)', () => {
+  it('equal paths match', () => {
+    expect(sameRemotePath('/home/souta/work', '/home/souta/work')).toBe(true);
+  });
+
+  it('trailing slash is ignored on either side', () => {
+    expect(sameRemotePath('/home/souta/work/', '/home/souta/work')).toBe(true);
+    expect(sameRemotePath('/home/souta/work', '/home/souta/work/')).toBe(true);
+    expect(sameRemotePath('/home/souta/work//', '/home/souta/work')).toBe(true);
+  });
+
+  it('surrounding whitespace is ignored', () => {
+    expect(sameRemotePath('  /home/souta/work  ', '/home/souta/work')).toBe(true);
+  });
+
+  it('a deeper/old root does NOT match the wanted root (the field bug)', () => {
+    // Stale daemon rooted at the deleted VaultDev vs profile now
+    // pointing at ~/work → must NOT reuse, must redeploy.
+    expect(sameRemotePath('/home/souta/work/VaultDev', '/home/souta/work')).toBe(false);
+  });
+
+  it('different paths do not match', () => {
+    expect(sameRemotePath('/home/souta/a', '/home/souta/b')).toBe(false);
+    expect(sameRemotePath('', '/home/souta/work')).toBe(false);
+  });
+
+  it('root path "/" is preserved (not stripped to empty)', () => {
+    expect(sameRemotePath('/', '/')).toBe(true);
+    expect(sameRemotePath('/', '')).toBe(false);
   });
 });


### PR DESCRIPTION
## The bug behind "changing remotePath does nothing"

Live-log root cause: `tryReuseExistingDaemon` reuses the running daemon based only on socket+token presence — it never checks the daemon's `ServerInfo.vaultRoot` against the profile's requested root. So after the user changed `remotePath` / deleted the old remote vault, the daemon kept serving its **original (now wrong/deleted) vault-root**:

```
remotePath normalized: "~/work" → "work"
startRpcSession: reusing existing daemon for work (skipped kill+redeploy)
BulkWalker: fs.walk failed (no such file: ) → populateVaultFromRemote: 0 entries
RpcError: no such file: 無題のファイル.md   (×N)
```

→ empty shadow vault, every op (incl. rename of a new note) fails. The only workaround was to SSH in and `pkill` the daemon — which the user (rightly) asked to be automatic.

## Fix

`ConnectionManager.startRpcSession`: after a reuse candidate is found, resolve the profile's `effectivePath` to absolute and compare with `reused.info.vaultRoot` via new `sameRemotePath` (trailing-slash/whitespace tolerant, otherwise strict). **On mismatch → close + fall through to `deployer.deploy()`**, whose `killExisting:true` pkills the stale daemon and redeploys at the correct root. A remotePath change now always takes effect; no manual pkill ever needed.

Conservative by design: a spurious redeploy is cheap; a false "match" reattaches to the wrong root (the field bug).

## Tests

`sameRemotePath` + 6 unit cases incl. the exact field scenario (`/home/souta/work/VaultDev` vs `/home/souta/work` → false → redeploy). `tsc`/`eslint` clean, `vitest` 70 files / 1057 passed / 1 skipped.

## Chain

`fix/daemon-reuse-vaultroot → fix/bootstrap-first-run-appjson (#354) → next`. Both fixes in one branch so a single local build verifies end-to-end: empty-app.json deadlock (#354) **and** stale-daemon root (this).

## Follow-up (not this PR)

If the redeployed daemon's root still doesn't exist on the remote, `fs.walk` still fails — bug (A): connect should `mkdir -p` the root or fail with a clear Notice instead of a silent empty vault. Tracked separately.

Generated with Claude Code