### PR TITLE
fix(vault): keep editor tab open on writer rename (#341 follow-up)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49",
+  "version": "1.1.0-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.0.49",
+  "version": "1.1.0-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49",
+  "version": "1.1.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.0.49",
+      "version": "1.1.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.0.49",
+  "version": "1.1.0-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -24,6 +24,7 @@ import { classifyToNotice } from './transport/errorTaxonomy';
 import { VaultModelBuilder } from './vault/VaultModelBuilder';
 import { FsChangeListener } from './vault/FsChangeListener';
 import { BulkWalker } from './vault/BulkWalker';
+import { RenameLeafFollower } from './vault/RenameLeafFollower';
 import { ObsidianRegistry } from './shadow/ObsidianRegistry';
 import { ShadowVaultBootstrap } from './shadow/ShadowVaultBootstrap';
 import { ShadowVaultManager } from './shadow/ShadowVaultManager';
@@ -138,6 +139,35 @@ export default class RemoteSshPlugin extends Plugin {
       this.pendingEditsBar,
       () => this.settings,
       this.transferTracker,
+    );
+
+    // #341 follow-up: a writer rename reflects into the model fine,
+    // but Obsidian's own post-adapter `Vault.rename` reconcile crashes
+    // on this build and orphans the open tab. Own the editor-follow:
+    // if the file was open and Obsidian dropped it, re-open it. Gated
+    // by `isPatched` so an unconnected local vault is untouched.
+    const renameFollower = new RenameLeafFollower(
+      {
+        isPathOpen: (p) =>
+          this.app.workspace
+            .getLeavesOfType('markdown')
+            .some(
+              (l) =>
+                (l.view as unknown as { file?: { path?: string } } | undefined)
+                  ?.file?.path === p,
+            ),
+        reopen: (p) => {
+          const af = this.app.vault.getAbstractFileByPath(p);
+          if (af instanceof TFile) {
+            void this.app.workspace.getLeaf('tab').openFile(af);
+          }
+        },
+      },
+      () => this.adapterMgr.isPatched(),
+      (cb) => { activeWindow.setTimeout(cb, 0); },
+    );
+    this.registerEvent(
+      this.app.vault.on('rename', (file) => renameFollower.handleRename(file)),
     );
 
     this.addCommand({

--- a/plugin/src/vault/RenameLeafFollower.ts
+++ b/plugin/src/vault/RenameLeafFollower.ts
@@ -1,0 +1,67 @@
+import { logger } from '../util/logger';
+
+/**
+ * Narrow workspace surface this follower needs. main.ts adapts the
+ * real `app.workspace`; unit tests pass a fake — so this stays
+ * decoupled from Obsidian's runtime classes (the test-side obsidian
+ * mock exports `TFile` as a type alias, not a constructor, so an
+ * `instanceof TFile` here would be untestable).
+ */
+export interface RenameFollowWorkspace {
+  /** True if some markdown editor leaf currently shows the file at `path`. */
+  isPathOpen(path: string): boolean;
+  /** Re-open the file at `path` in a tab (restores a tab Obsidian dropped). */
+  reopen(path: string): void;
+}
+
+/**
+ * Keeps the open editor tab on a renamed file (#341 follow-up).
+ *
+ * A writer rename reflects correctly into `vault.fileMap`
+ * (`VaultModelBuilder.renameOne` preserves the `TFile` identity and
+ * fires `vault.trigger('rename', file, oldPath)`), but Obsidian's own
+ * post-adapter `Vault.rename` reconcile (`reconcileFile`) crashes on
+ * this Obsidian build — the documented "iu/nu …startsWith" throw, see
+ * the `FsChangeListener.applyChange` JSDoc — which aborts
+ * `FileManager.renameFile`'s editor-follow and leaves the open tab
+ * orphaned. Symptom: the file is renamed (model updated) but the tab
+ * closes and must be reopened.
+ *
+ * Our `renameOne` runs synchronously inside our own
+ * `vault.trigger('rename')`, which is *before* Obsidian's reconcile
+ * crash later in the same call stack — so this handler observes the
+ * tab still alive. It records that the file was open, then after the
+ * call stack unwinds (the crash included) checks whether Obsidian
+ * dropped the tab and, if so, re-opens the file. Idempotent: on a
+ * healthy build the native follow keeps the tab and this is a no-op.
+ *
+ * Gated by `isActive` (the patched adapter being installed) so a
+ * normal, unconnected local vault's rename behaviour is never touched.
+ */
+export class RenameLeafFollower {
+  constructor(
+    private readonly ws: RenameFollowWorkspace,
+    private readonly isActive: () => boolean,
+    /** Run `cb` after the current call stack (incl. Obsidian's reconcile). */
+    private readonly defer: (cb: () => void) => void,
+  ) {}
+
+  /** Bind to `vault.on('rename', …)`. `file` is the renamed entry. */
+  handleRename = (file: { path: string }): void => {
+    if (!this.isActive()) return;
+    // `file.path` is already the NEW path (renameOne mutated it before
+    // firing the event); the still-open leaf holds the same TFile, so
+    // it reports the new path too. A folder never shows in a markdown
+    // leaf, so `isPathOpen` is false for one — no folder filter needed.
+    const path = file.path;
+    if (!this.ws.isPathOpen(path)) return; // not open → nothing to protect
+    this.defer(() => {
+      if (this.ws.isPathOpen(path)) return; // native follow held — no-op
+      logger.info(
+        `RenameLeafFollower: Obsidian dropped the editor tab on rename; ` +
+        `re-opening "${path}"`,
+      );
+      this.ws.reopen(path);
+    });
+  };
+}

--- a/plugin/tests/RenameLeafFollower.test.ts
+++ b/plugin/tests/RenameLeafFollower.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { RenameLeafFollower } from '../src/vault/RenameLeafFollower';
+
+/**
+ * Harness: `isPathOpen` returns the next queued boolean per call so a
+ * test can model "open before the rename, dropped after Obsidian's
+ * crash" as `[true, false]`. `defer` queues callbacks the test flushes
+ * explicitly, proving the repair runs AFTER the call stack unwinds
+ * (i.e. after Obsidian's reconcile crash), not synchronously.
+ */
+function harness(openSeq: boolean[], active = true) {
+  const reopened: string[] = [];
+  const deferred: Array<() => void> = [];
+  let i = 0;
+  const follower = new RenameLeafFollower(
+    {
+      isPathOpen: () => openSeq[Math.min(i++, openSeq.length - 1)],
+      reopen: (p) => reopened.push(p),
+    },
+    () => active,
+    (cb) => { deferred.push(cb); },
+  );
+  return {
+    follower,
+    reopened,
+    flush: () => { for (const cb of deferred.splice(0)) cb(); },
+    deferredCount: () => deferred.length,
+  };
+}
+
+describe('RenameLeafFollower', () => {
+  it('re-opens the file when Obsidian drops the tab on rename (open→dropped)', () => {
+    const h = harness([/* before */ true, /* after crash */ false]);
+    h.follower.handleRename({ path: 'notes/renamed.md' });
+
+    // Nothing happens synchronously — the repair must wait until the
+    // rename + Obsidian's reconcile crash have unwound.
+    expect(h.reopened).toEqual([]);
+    expect(h.deferredCount()).toBe(1);
+
+    h.flush();
+    expect(h.reopened).toEqual(['notes/renamed.md']);
+  });
+
+  it('is a no-op on a healthy build where the tab survives (open→open)', () => {
+    const h = harness([true, true]);
+    h.follower.handleRename({ path: 'a.md' });
+    h.flush();
+    expect(h.reopened).toEqual([]); // native follow held — must not double-open
+  });
+
+  it('does not spuriously open a file that was not open before the rename', () => {
+    const h = harness([false]);
+    h.follower.handleRename({ path: 'closed.md' });
+    expect(h.deferredCount()).toBe(0); // bailed before scheduling
+    h.flush();
+    expect(h.reopened).toEqual([]);
+  });
+
+  it('is fully inert when the patched adapter is not active', () => {
+    const isOpen = vi.fn(() => true);
+    const reopened: string[] = [];
+    const deferred: Array<() => void> = [];
+    const follower = new RenameLeafFollower(
+      { isPathOpen: isOpen, reopen: (p) => reopened.push(p) },
+      () => false, // not connected — normal local vault
+      (cb) => { deferred.push(cb); },
+    );
+    follower.handleRename({ path: 'x.md' });
+    expect(isOpen).not.toHaveBeenCalled(); // doesn't even probe the workspace
+    expect(deferred).toHaveLength(0);
+    expect(reopened).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

Reported: renaming a file now reflects the new name, **but the open editor tab closes and must be reopened**.

## Root cause

The #341 fix made `SftpDataAdapter.rename()` synchronously reflect into `vault.fileMap` via `VaultModelBuilder.renameOne()` (identity-preserving, fires `vault.trigger('rename', file, oldPath)`). That part is correct — the model + File Explorer update ("反映される").

But the reflect runs **inside Obsidian's own `Vault.rename` call stack** (invoked from the monkey-patched `adapter.rename`). After `adapter.rename` resolves, Obsidian's `Vault.rename` runs its own post-adapter `reconcileFile`, which is independently documented as **crashing on this Obsidian build** (the "iu/nu …`startsWith`" throw — see `FsChangeListener.applyChange` JSDoc). That crash aborts `FileManager.renameFile`'s editor-follow → the open tab is orphaned/closed.

(The daemon's split rename echo — `deleted(old)`+`created(new)`, `watcher.go:306` — was ruled out: `removeOne`/`insertOne` are idempotent and run *after* `renameOne`, so leaked echoes are no-ops.)

## Fix

`RenameLeafFollower` (new, `src/vault/RenameLeafFollower.ts`) owns the editor-follow the broken native path can't deliver:

- subscribes to `vault.on('rename')` (fires inside our trigger, *before* Obsidian's later crash → sees the tab still alive),
- records the file was open, then **after the call stack unwinds** (the crash included) re-opens it **iff** Obsidian dropped the tab.
- Idempotent: on a healthy build the native follow holds → no-op.
- Gated by `adapterMgr.isPatched()` → a normal unconnected local vault is never touched.

## Tests

`tests/RenameLeafFollower.test.ts` — 4 cases: dropped→reopen, survived→no-op (no double-open), not-open→no spurious tab, not-active→fully inert.

Full unit suite green (1069 passed / 1 skipped), typecheck + lint clean.

## Caveat

This is a targeted workaround for the documented architectural gap (`docs/en/architecture/bidirectional-sync-gap.md`), not the v1.1 `RemoteFs` redesign. It restores the dropped file in a new tab (does not reuse the exact orphaned leaf) — predictable and low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)