### PR TITLE
fix(walk): paginate fs.walk so huge remote trees load (Bug B)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.1",
+      "version": "1.1.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -813,7 +813,7 @@ export default class RemoteSshPlugin extends Plugin {
     const walk = await walker.walk('');
     logger.info(
       `populateVaultFromRemote(${label}): ${walk.source}, ${walk.entries.length} entries ` +
-      `in ${walk.walkMs}ms` +
+      `in ${walk.walkMs}ms (pages=${walk.pages})` +
       (walk.fastPathError ? ` (fast-path fallback: ${walk.fastPathError})` : ''),
     );
 
@@ -828,6 +828,23 @@ export default class RemoteSshPlugin extends Plugin {
       logger.warn(
         `populateVaultFromRemote(${label}): first 5 errors: ` +
         JSON.stringify(result.errors.slice(0, 5), null, 2),
+      );
+    }
+
+    // Don't let a failed/clipped populate look like a working-but-empty
+    // vault (the silent "remote files won't open" symptom). Surface it.
+    if (walk.entries.length === 0) {
+      new Notice(
+        'Remote SSH: 0 files found on the remote. Check the profile’s ' +
+        'remotePath actually points at the vault (see console.log).',
+        10_000,
+      );
+    } else if (walk.truncated) {
+      new Notice(
+        `Remote SSH: remote tree is very large — loaded ${walk.entries.length} ` +
+        'entries but it is still incomplete. Point the profile’s remotePath ' +
+        'at the vault folder, not a large parent directory (see console.log).',
+        15_000,
       );
     }
     return summary;

--- a/plugin/src/proto/types.ts
+++ b/plugin/src/proto/types.ts
@@ -110,15 +110,21 @@ export interface ListResult { entries: Entry[] }
 
 /**
  * fs.walk — single-RPC alternative to recursively calling fs.list.
- * `maxEntries` caps the response size; the daemon returns
- * `truncated: true` when the budget is exhausted so the caller can
- * fall back to per-folder listing without truncation lying about
- * tree shape.
+ * `maxEntries` caps ONE page; the daemon returns `truncated: true`
+ * when more entries remain.
+ *
+ * `offset` paginates a large tree: the daemon's walk order is
+ * deterministic, so the caller fetches the next page by re-issuing
+ * the call with `offset = total entries already received` and keeps
+ * going while `truncated` is true. This lets a huge remote tree load
+ * fully instead of being discarded at the cap. Mirrors
+ * `server/internal/proto/types.go` WalkParams — keep in sync.
  */
 export interface WalkParams {
   path: string;
   recursive?: boolean;
   maxEntries?: number;
+  offset?: number;
 }
 export interface WalkEntry {
   /** Vault-relative (forward slashes), unlike `Entry.name` which is a basename. */

--- a/plugin/src/vault/BulkWalker.ts
+++ b/plugin/src/vault/BulkWalker.ts
@@ -44,14 +44,22 @@ export interface BulkWalkResult {
   /**
    * `'rpc-walk'` when the daemon's `fs.walk` produced the result;
    * `'fallback-list'` when we used the BFS-via-`adapter.list` path
-   * (no RPC, daemon doesn't advertise the capability, RPC walk
-   * threw, or it returned `truncated: true`).
+   * (no RPC, daemon doesn't advertise the capability, or the RPC
+   * walk threw). A truncated page is NO LONGER a fallback trigger —
+   * the fast path now paginates and drains every page.
    */
   source: 'rpc-walk' | 'fallback-list';
-  /** Whether the fast-path response was truncated (only meaningful when source === 'rpc-walk'). */
+  /**
+   * `true` only when the returned set is still INCOMPLETE — i.e. the
+   * fast path hit the defensive page guard on a pathologically huge
+   * tree (we return the large partial set rather than nothing).
+   * Normal completion (all pages drained) is `false`.
+   */
   truncated: boolean;
   /** Wall-clock for the walk itself, milliseconds. */
   walkMs: number;
+  /** rpc-walk only: number of `fs.walk` pages drained (1 for small trees). */
+  pages: number;
   /** When `fallback-list` because of a fast-path error, the error message; else null. */
   fastPathError: string | null;
 }
@@ -67,8 +75,15 @@ export interface BulkWalkResult {
  *   - No RPC connection injected (= SFTP transport).
  *   - Daemon doesn't advertise `fs.walk` in its capabilities.
  *   - RPC call throws.
- *   - RPC returns `truncated: true` (= MaxEntries exhausted; partial
- *     data would mislead the vault model).
+ *
+ * A `truncated: true` page is NOT a fallback trigger. The old
+ * behaviour (discard the partial result and do an unbounded
+ * per-folder BFS) never completed on a huge remote tree — e.g. a
+ * profile pointed at `~/work` with 50 000+ files — so the vault
+ * stayed empty and "files that exist on the remote can't be opened".
+ * The fast path now PAGINATES: it re-issues `fs.walk` with an
+ * increasing `offset` and drains every page, so the full tree loads
+ * in bounded-size chunks regardless of size.
  *
  * The fallback's per-entry `mtime` / `size` stay at 0 (matching the
  * pre-walker behaviour) — Obsidian fills those in lazily on file
@@ -80,31 +95,27 @@ export class BulkWalker {
 
   constructor(private readonly deps: BulkWalkerDeps) {}
 
+  /**
+   * Defensive ceiling so a misbehaving daemon that always answers
+   * `truncated:true` (or never advances the offset) can't spin
+   * forever. At the daemon's default 50 000-entry page this is
+   * 50 000 000 entries — far past any real vault — so a legitimate
+   * tree never hits it; only a broken daemon does.
+   */
+  private static readonly MAX_PAGES = 1_000;
+
   async walk(rootPath: string = ''): Promise<BulkWalkResult> {
     const start = Date.now();
     if (this.canUseFastPath()) {
       try {
         const result = await this.fastPath(rootPath);
-        if (!result.truncated) {
-          return {
-            ...result,
-            walkMs: Date.now() - start,
-            fastPathError: null,
-          };
-        }
-        // Truncated → server returned a partial snapshot. We can't
-        // hand a partial tree to VaultModelBuilder (it would silently
-        // miss files), so fall back to the per-folder traversal which
-        // doesn't have a budget.
-        logger.warn(
-          `BulkWalker: fs.walk returned truncated=true at ${result.entries.length} entries; ` +
-          'falling back to per-folder list',
-        );
-        const fallback = await this.fallbackPath(rootPath);
         return {
-          ...fallback,
+          ...result,
           walkMs: Date.now() - start,
-          fastPathError: 'truncated',
+          // `truncated` here means we stopped at the page guard on a
+          // pathological tree — surface it so populate can Notice the
+          // partial load instead of silently showing a clipped vault.
+          fastPathError: result.truncated ? 'page-guard' : null,
         };
       } catch (e) {
         const message = errorMessage(e);
@@ -138,30 +149,60 @@ export class BulkWalker {
     entries: RemoteEntry[];
     source: 'rpc-walk';
     truncated: boolean;
+    pages: number;
   }> {
     // canUseFastPath() guarded the caller, but assert for the type
     // narrowing flow analysis.
     if (!this.deps.rpcConnection) {
       throw new Error('BulkWalker.fastPath called without rpcConnection');
     }
-    const params: WalkParams = { path: rootPath, recursive: true };
-    if (this.deps.maxEntries != null) params.maxEntries = this.deps.maxEntries;
-    const result = await this.deps.rpcConnection.rpc.call('fs.walk', params);
-
-    const entries: RemoteEntry[] = result.entries.map(e => ({
-      path:        e.path,
-      isDirectory: e.type === 'folder',
-      ctime:       e.mtime,  // daemon doesn't expose ctime separately; mtime is the closest signal
-      mtime:       e.mtime,
-      size:        e.size,
-    }));
-    return { entries, source: 'rpc-walk', truncated: result.truncated };
+    const all: RemoteEntry[] = [];
+    let offset = 0;
+    let pages = 0;
+    for (;;) {
+      const params: WalkParams = { path: rootPath, recursive: true };
+      if (this.deps.maxEntries != null) params.maxEntries = this.deps.maxEntries;
+      if (offset > 0) params.offset = offset;
+      const page = await this.deps.rpcConnection.rpc.call('fs.walk', params);
+      for (const e of page.entries) {
+        all.push({
+          path:        e.path,
+          isDirectory: e.type === 'folder',
+          ctime:       e.mtime, // daemon has no separate ctime; mtime is the closest signal
+          mtime:       e.mtime,
+          size:        e.size,
+        });
+      }
+      pages++;
+      if (!page.truncated) {
+        return { entries: all, source: 'rpc-walk', truncated: false, pages };
+      }
+      if (page.entries.length === 0) {
+        // truncated=true but nothing delivered → the daemon cannot
+        // advance past this offset. Returning what we have (flagged
+        // incomplete) beats spinning forever.
+        logger.warn(
+          'BulkWalker: fs.walk reported truncated with an empty page; ' +
+          `stopping at ${all.length} entries (incomplete)`,
+        );
+        return { entries: all, source: 'rpc-walk', truncated: true, pages };
+      }
+      offset += page.entries.length;
+      if (pages >= BulkWalker.MAX_PAGES) {
+        logger.warn(
+          `BulkWalker: fs.walk exceeded ${BulkWalker.MAX_PAGES} pages ` +
+          `(${all.length} entries); stopping (tree pathologically large)`,
+        );
+        return { entries: all, source: 'rpc-walk', truncated: true, pages };
+      }
+    }
   }
 
   private async fallbackPath(rootPath: string): Promise<{
     entries: RemoteEntry[];
     source: 'fallback-list';
     truncated: false;
+    pages: number;
   }> {
     const entries: RemoteEntry[] = [];
     const queue: string[] = [rootPath];
@@ -184,6 +225,6 @@ export class BulkWalker {
         entries.push({ path: file, isDirectory: false, ctime: 0, mtime: 0, size: 0 });
       }
     }
-    return { entries, source: 'fallback-list', truncated: false };
+    return { entries, source: 'fallback-list', truncated: false, pages: 0 };
   }
 }

--- a/plugin/tests/BulkWalker.test.ts
+++ b/plugin/tests/BulkWalker.test.ts
@@ -83,26 +83,69 @@ describe('BulkWalker', () => {
     expect(callSpy).toHaveBeenCalledWith('fs.walk', { path: '', recursive: true, maxEntries: 7 });
   });
 
-  // ─── fast path → fallback (truncated, error) ────────────────────────────
+  // ─── fast path pagination + fallback-on-error ───────────────────────────
 
-  it('falls back to per-folder list when the daemon returns truncated=true', async () => {
-    const adapter = makeAdapter({
-      '': { folders: ['docs'], files: ['README.md'] },
-      'docs': { files: ['docs/a.md'] },
+  it('paginates: drains every page with an increasing offset, no fallback', async () => {
+    // The bug this guards: a truncated page used to be DISCARDED and
+    // replaced by an unbounded per-folder BFS that never finished on a
+    // huge tree → empty vault. Now it must page through and return the
+    // FULL stitched tree via rpc-walk.
+    const pages: WalkResult[] = [
+      { entries: [
+        { path: 'a.md', type: 'file', mtime: 1, size: 1 },
+        { path: 'b.md', type: 'file', mtime: 2, size: 2 },
+      ], truncated: true },
+      { entries: [
+        { path: 'c.md', type: 'file', mtime: 3, size: 3 },
+        { path: 'd.md', type: 'file', mtime: 4, size: 4 },
+      ], truncated: true },
+      { entries: [
+        { path: 'e.md', type: 'file', mtime: 5, size: 5 },
+      ], truncated: false },
+    ];
+    const seenOffsets: Array<number | undefined> = [];
+    const call = vi.fn(async (_m: string, p: { offset?: number }) => {
+      seenOffsets.push(p.offset);
+      return pages.shift()!;
     });
-    const { rpc } = makeRpc(['fs.walk'], {
-      entries: [{ path: 'partial.md', type: 'file', mtime: 1, size: 1 }],
-      truncated: true,
-    });
-    const walker = new BulkWalker({ adapter, rpcConnection: rpc });
+    const rpc: RpcConnectionSlice = {
+      info: { capabilities: ['fs.walk'] },
+      rpc: { call: call as unknown as RpcConnectionSlice['rpc']['call'] },
+    };
+    const walker = new BulkWalker({ adapter: makeAdapter({}), rpcConnection: rpc });
 
     const result = await walker.walk('');
 
-    expect(result.source).toBe('fallback-list');
-    expect(result.fastPathError).toBe('truncated');
-    expect(result.entries.map(e => e.path).sort()).toEqual(['README.md', 'docs', 'docs/a.md']);
-    // Fallback fills mtime/size with zeros (matches pre-walker behaviour).
-    expect(result.entries.every(e => e.mtime === 0 && e.size === 0)).toBe(true);
+    expect(result.source).toBe('rpc-walk');
+    expect(result.truncated).toBe(false);
+    expect(result.fastPathError).toBeNull();
+    expect(result.pages).toBe(3);
+    expect(result.entries.map(e => e.path)).toEqual(['a.md', 'b.md', 'c.md', 'd.md', 'e.md']);
+    // Real mtime/size preserved across pages (fast path, not the zeroed fallback).
+    expect(result.entries[4]).toMatchObject({ path: 'e.md', mtime: 5, size: 5 });
+    // Page 1 has no offset; pages 2/3 carry the running total.
+    expect(seenOffsets).toEqual([undefined, 2, 4]);
+  });
+
+  it('stops at the empty-page guard when the daemon truncates but delivers nothing', async () => {
+    const pages: WalkResult[] = [
+      { entries: [{ path: 'a.md', type: 'file', mtime: 1, size: 1 }], truncated: true },
+      { entries: [], truncated: true }, // daemon can't advance — must not spin
+    ];
+    const call = vi.fn(async () => pages.shift()!);
+    const rpc: RpcConnectionSlice = {
+      info: { capabilities: ['fs.walk'] },
+      rpc: { call: call as unknown as RpcConnectionSlice['rpc']['call'] },
+    };
+    const walker = new BulkWalker({ adapter: makeAdapter({}), rpcConnection: rpc });
+
+    const result = await walker.walk('');
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(result.source).toBe('rpc-walk');
+    expect(result.truncated).toBe(true);          // incomplete, surfaced
+    expect(result.fastPathError).toBe('page-guard');
+    expect(result.entries.map(e => e.path)).toEqual(['a.md']);
   });
 
   it('falls back when the fs.walk RPC throws', async () => {

--- a/server/internal/handlers/fs_walk.go
+++ b/server/internal/handlers/fs_walk.go
@@ -48,6 +48,10 @@ func FsWalk(vaultRoot string) rpc.Handler {
 		if max <= 0 {
 			max = DefaultWalkMaxEntries
 		}
+		offset := p.Offset
+		if offset < 0 {
+			offset = 0
+		}
 
 		abs, e := resolveOrErr(vaultRoot, p.Path)
 		if e != nil {
@@ -67,6 +71,10 @@ func FsWalk(vaultRoot string) rpc.Handler {
 
 		entries := make([]proto.WalkEntry, 0, 256)
 		truncated := false
+		// seen counts emittable entries in deterministic WalkDir order
+		// (across the whole tree, not just this page) so `offset` can
+		// skip the entries already delivered on prior pages.
+		seen := 0
 
 		walkFn := func(path string, d fs.DirEntry, walkErr error) error {
 			if walkErr != nil {
@@ -88,14 +96,11 @@ func FsWalk(vaultRoot string) rpc.Handler {
 			if path == abs {
 				return nil
 			}
-			if len(entries) >= max {
-				truncated = true
-				return errWalkLimitReached
-			}
 			einfo, err := d.Info()
 			if err != nil {
 				// Concurrent delete between readdir and stat — skip and
-				// keep going, matching fs.list's tolerance.
+				// keep going, matching fs.list's tolerance. Not counted
+				// toward `seen` (it never reaches any page).
 				return nil
 			}
 
@@ -110,6 +115,27 @@ func FsWalk(vaultRoot string) rpc.Handler {
 			// stable across daemon OSes (Windows daemons, if ever, would
 			// otherwise emit backslashes).
 			rel = filepath.ToSlash(rel)
+
+			// This is an emittable entry. Its global index decides
+			// which page it belongs to.
+			seen++
+			if seen <= offset {
+				// Already delivered on a previous page — skip emitting
+				// but keep the same descent behaviour so the traversal
+				// (and therefore the ordering) is identical to page 0.
+				if !p.Recursive && d.IsDir() {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			if len(entries) >= max {
+				// One more emittable entry exists beyond this page →
+				// there is a next page. (If the tree ended exactly at
+				// the budget we never get here, so truncated stays
+				// false and the client stops — no spurious empty page.)
+				truncated = true
+				return errWalkLimitReached
+			}
 
 			entries = append(entries, proto.WalkEntry{
 				Path:  rel,

--- a/server/internal/handlers/fs_walk_test.go
+++ b/server/internal/handlers/fs_walk_test.go
@@ -136,6 +136,68 @@ func TestFsWalk_HonorsMaxEntriesAndSetsTruncated(t *testing.T) {
 	}
 }
 
+func TestFsWalk_OffsetPaginationStitchesFullTreeNoDupesNoGaps(t *testing.T) {
+	v := newVault(t)
+	h := FsWalk(v.Root)
+
+	// Ground truth: one unpaginated walk (the deterministic order the
+	// pages must reproduce exactly).
+	rawFull, _ := json.Marshal(proto.WalkParams{Path: "", Recursive: true})
+	rFull, rerr := h(context.Background(), rawFull)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	full := rFull.(proto.WalkResult)
+	if full.Truncated {
+		t.Fatal("unpaginated walk of the small fixture must not truncate")
+	}
+	want := make([]string, 0, len(full.Entries))
+	for _, e := range full.Entries {
+		want = append(want, e.Path)
+	}
+
+	// Page through with a tiny budget so we cross several boundaries.
+	const pageSize = 3
+	got := make([]string, 0, len(want))
+	offset := 0
+	for page := 0; ; page++ {
+		if page > 100 {
+			t.Fatalf("pagination did not terminate (offset=%d)", offset)
+		}
+		raw, _ := json.Marshal(proto.WalkParams{
+			Path: "", Recursive: true, MaxEntries: pageSize, Offset: offset,
+		})
+		r, e := h(context.Background(), raw)
+		if e != nil {
+			t.Fatal(e)
+		}
+		res := r.(proto.WalkResult)
+		if len(res.Entries) > pageSize {
+			t.Fatalf("page %d returned %d entries, > MaxEntries %d", page, len(res.Entries), pageSize)
+		}
+		for _, en := range res.Entries {
+			got = append(got, en.Path)
+		}
+		if !res.Truncated {
+			break
+		}
+		if len(res.Entries) == 0 {
+			t.Fatalf("page %d: Truncated=true but 0 entries (would loop forever)", page)
+		}
+		offset += len(res.Entries)
+	}
+
+	// Exact same sequence, in the same order: no dupes, no gaps.
+	if len(got) != len(want) {
+		t.Fatalf("stitched %d entries, want %d (got=%v want=%v)", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("stitched[%d] = %q, want %q (full got=%v)", i, got[i], want[i], got)
+		}
+	}
+}
+
 func TestFsWalk_EntriesCarryMtimeAndSize(t *testing.T) {
 	v := newVault(t)
 	h := FsWalk(v.Root)

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -166,13 +166,25 @@ type CopyParams struct {
 }
 
 // WalkParams are the inputs to fs.walk — a single-RPC alternative to
-// recursively calling fs.list. `MaxEntries` caps the response size so
-// pathological vaults don't OOM the client; the daemon halts and sets
-// `Truncated: true` so the caller can fall back to per-folder listing.
+// recursively calling fs.list. `MaxEntries` caps one page so a
+// pathological vault doesn't OOM the client; the daemon halts and
+// sets `Truncated: true` when more remain.
+//
+// `Offset` paginates a large tree. The walk order is deterministic
+// (filepath.WalkDir = per-directory lexical, depth-first), so the
+// client fetches the next page by sending `Offset = total entries
+// already received`; the daemon skips that many emittable entries
+// before filling the next page. Stateless (no daemon-side cursor to
+// leak) at the cost of re-walking skipped entries — cheap, since it
+// is a local-FS traversal on the remote, not network I/O. A
+// concurrent mutation between pages can drift the boundary by a few
+// entries; tolerable for the cold-open populate (a reconnect
+// re-walks from scratch).
 type WalkParams struct {
 	Path       string `json:"path"`
 	Recursive  bool   `json:"recursive,omitempty"`
 	MaxEntries int    `json:"maxEntries,omitempty"`
+	Offset     int    `json:"offset,omitempty"`
 }
 
 // WalkEntry is one row in fs.walk's flat output. Unlike fs.list's


### PR DESCRIPTION
## Problem

A profile whose `remotePath` is a large directory (the reporter's `~/work` = 50 000+ files — a legitimate case; VSCode Remote-SSH handles it, and shared/collaborative working dirs are common) left the Obsidian vault **completely empty**: "remote files that exist from the start can't be opened".

## Root cause (confirmed from the field console.log)

`fs.walk` caps at `DefaultWalkMaxEntries = 50000` and returns `truncated:true`. `BulkWalker` then **discarded** the 50 000 valid entries and fell back to an **unbounded per-folder BFS** (`adapter.list` per directory over SSH). On a 50 000+ tree that is thousands of sequential round-trips and effectively never completes, so `populateVaultFromRemote` never returns → `vault.fileMap` stays empty. Log shows `fs.walk returned truncated=true at 50000` with **no** subsequent `populateVaultFromRemote(...) entries` line, ever.

## Fix — stateless offset pagination

- **daemon** (`fs_walk.go`, `proto/types.go`): new `WalkParams.Offset`. `filepath.WalkDir` order is deterministic, so the client fetches page N+1 with `offset = entries already received`; the daemon skips that many *emittable* entries then fills the next page. Stateless (no daemon cursor to leak); re-walking skipped entries is local-FS on the remote, not network. Concurrent-mutation boundary drift is documented and tolerable for the cold-open populate.
- **proto**: `offset` added to the Go struct **and** the hand-mirrored TS `WalkParams` (kept in sync per the file contract).
- **BulkWalker**: a truncated page is no longer a fallback trigger — `walk()` drains every page via increasing `offset` and returns the full `rpc-walk` tree. Defensive guards: stop on an empty truncated page and at `MAX_PAGES` so a misbehaving daemon can't spin forever (returned as `truncated:true` so populate can warn). Per-folder list remains only for no-RPC / capability-absent / RPC-threw.
- **populateVaultFromRemote**: logs `pages=`; shows a clear Notice on 0 entries or an incomplete (page-guard) load instead of silently presenting an empty vault.

Note: the earlier `list("") → no such file:` log was the stale-daemon-wrong-root issue already fixed on the #355 branch, **not** a BulkWalker empty-path bug (`SftpDataAdapter.list` handles `''` correctly) — no speculative change made there.

## Tests

- Go: `TestFsWalk_OffsetPaginationStitchesFullTreeNoDupesNoGaps` — paged walk (MaxEntries=3) stitches **exactly** the single-shot full walk order, no dupes/gaps, terminates.
- TS: pagination drains all pages with correct offsets; empty-page guard stops instead of spinning. Old "truncated→fallback" test replaced (that behavior was the bug).
- Full Go suite + full plugin unit suite (1048 passed / 1 skipped) green; typecheck + lint clean.

## Scope / follow-ups (agreed with reporter)

This is **Part 1** of the "scalable shadow vault" work. Part 2 (orphan local-file reconciliation + workspace-restore `no such file` storm) and Part 3 (whether Obsidian needs an include/exclude scope for genuinely huge indexed trees) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)