### PR TITLE
feat(walk): profile "Ignore directories" — prune noise subtrees server-side

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.2",
+      "version": "1.1.0-beta.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.2",
+  "version": "1.1.0-beta.3",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -2,6 +2,22 @@ import type { PluginSettings, SshProfile } from './types';
 
 export const PLUGIN_ID = 'remote-ssh';
 
+/**
+ * Directory basenames pruned from the remote tree walk by default.
+ * VCS, dependency, build, cache and editor-metadata dirs that are
+ * never Obsidian content but dominate a real work directory (a
+ * git/node_modules-heavy `~/work` can be hundreds of thousands of
+ * files of pure noise). Pruning them server-side keeps a large
+ * shared remote root usable. `.obsidian` is deliberately NOT here —
+ * it is the vault config and must be walked.
+ */
+export const DEFAULT_WALK_IGNORE_DIRS: readonly string[] = [
+  '.git', 'node_modules', '.svn', '.hg',
+  '__pycache__', '.venv', 'venv', '.tox', '.mypy_cache', '.pytest_cache',
+  'target', 'dist', 'build', '.next', '.nuxt', '.cache', '.gradle',
+  '.idea', 'vendor', '.terraform',
+];
+
 export const DEFAULT_PROFILE: Omit<SshProfile, 'id' | 'name'> = {
   host: '',
   port: 22,
@@ -12,6 +28,7 @@ export const DEFAULT_PROFILE: Omit<SshProfile, 'id' | 'name'> = {
   keepaliveIntervalMs: 10000,
   keepaliveCountMax: 3,
   transport: 'sftp',
+  walkIgnoreDirs: [...DEFAULT_WALK_IGNORE_DIRS],
 };
 
 export const DEFAULT_SETTINGS: PluginSettings = {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -1,7 +1,7 @@
 import { Plugin, Notice, FileSystemAdapter, TFile, TFolder } from 'obsidian';
 import type { PluginSettings, SshProfile } from './types';
 import { SyncState } from './types';
-import { DEFAULT_SETTINGS } from './constants';
+import { DEFAULT_SETTINGS, DEFAULT_WALK_IGNORE_DIRS } from './constants';
 import { SftpClient } from './ssh/SftpClient';
 import { AuthResolver } from './ssh/AuthResolver';
 import { HostKeyStore } from './ssh/HostKeyStore';
@@ -809,6 +809,12 @@ export default class RemoteSshPlugin extends Plugin {
     const walker = new BulkWalker({
       adapter: this.app.vault.adapter,
       rpcConnection: this.conn.rpcConnection ?? undefined,
+      // Older profiles have no walkIgnoreDirs → fall back to the
+      // sensible defaults so existing users immediately benefit. An
+      // explicit empty array (user cleared it) means "ignore nothing"
+      // and is respected (?? only fills null/undefined).
+      ignoreDirs: this.conn.activeProfile?.walkIgnoreDirs
+        ?? [...DEFAULT_WALK_IGNORE_DIRS],
     });
     const walk = await walker.walk('');
     logger.info(

--- a/plugin/src/proto/types.ts
+++ b/plugin/src/proto/types.ts
@@ -125,6 +125,14 @@ export interface WalkParams {
   recursive?: boolean;
   maxEntries?: number;
   offset?: number;
+  /**
+   * Directory basenames to prune entirely (e.g. `node_modules`,
+   * `.git`). A pruned subtree is never walked, transferred, or
+   * counted toward pagination. Must be sent identically on every
+   * page so the deterministic order / offset stays stable. Mirrors
+   * `server/internal/proto/types.go` WalkParams.Ignore.
+   */
+  ignore?: string[];
 }
 export interface WalkEntry {
   /** Vault-relative (forward slashes), unlike `Entry.name` which is a basename. */

--- a/plugin/src/settings/ProfileForm.ts
+++ b/plugin/src/settings/ProfileForm.ts
@@ -2,7 +2,7 @@ import { Modal, App, Setting, Notice } from 'obsidian';
 import type { SshProfile, AuthMethod, RemoteTransport } from '../types';
 import type { AuthResolver } from '../ssh/AuthResolver';
 import type { HostKeyStore } from '../ssh/HostKeyStore';
-import { DEFAULT_PROFILE } from '../constants';
+import { DEFAULT_PROFILE, DEFAULT_WALK_IGNORE_DIRS } from '../constants';
 import { readSshConfig, type SshConfigEntry } from '../ssh/SshConfigReader';
 import { RemotePathBrowserModal } from '../ui/RemotePathBrowserModal';
 import * as crypto from 'crypto';
@@ -132,6 +132,27 @@ export class ProfileForm extends Modal {
           ).open();
         }));
     }
+
+    new Setting(contentEl)
+      .setName('Ignore directories')
+      .setDesc(
+        'One directory name per line. Any directory with this exact ' +
+        'name is skipped anywhere in the tree — never transferred or ' +
+        'indexed. Essential when the remote path is a large work dir ' +
+        '(node_modules / .git etc. would otherwise make it unusable).',
+      )
+      .addTextArea(t => {
+        const current = this.profile.walkIgnoreDirs ?? [...DEFAULT_WALK_IGNORE_DIRS];
+        t.setPlaceholder(DEFAULT_WALK_IGNORE_DIRS.join('\n'))
+          .setValue(current.join('\n'))
+          .onChange(v => {
+            this.profile.walkIgnoreDirs = v
+              .split('\n')
+              .map(s => s.trim())
+              .filter(s => s.length > 0);
+          });
+        t.inputEl.rows = 6;
+      });
 
     contentEl.createEl('h3', { text: 'Transport' });
     contentEl.createEl('p', {

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -61,6 +61,19 @@ export interface SshProfile {
    * `.obsidian-remote/token`.
    */
   rpcTokenPath?: string;
+  /**
+   * Directory names to skip when walking the remote tree into the
+   * vault model. A match is by exact basename anywhere in the tree
+   * (e.g. `node_modules`, `.git`) — the whole subtree is pruned, so
+   * it is never transferred over SSH nor indexed by Obsidian. This is
+   * what makes a large shared remote root (e.g. `~/work` with a
+   * git/node_modules-heavy work dir) usable at all.
+   *
+   * When omitted (older profiles), the walk falls back to
+   * `DEFAULT_WALK_IGNORE_DIRS`. New profiles are pre-filled with that
+   * list via `DEFAULT_PROFILE`.
+   */
+  walkIgnoreDirs?: string[];
 }
 
 export interface PluginSettings {

--- a/plugin/src/vault/BulkWalker.ts
+++ b/plugin/src/vault/BulkWalker.ts
@@ -36,6 +36,13 @@ export interface BulkWalkerDeps {
    * "truncated → fall back" branch without needing a real big vault.
    */
   maxEntries?: number;
+  /**
+   * Directory basenames to prune from the walk (e.g. `node_modules`,
+   * `.git`). Passed straight through to `fs.walk`'s `ignore` so the
+   * daemon never descends/transfers them. Only the fast path honours
+   * this; the per-folder fallback (SFTP / no daemon) does not yet.
+   */
+  ignoreDirs?: string[];
 }
 
 /** Outcome telemetry from a single `walk()` call. */
@@ -163,6 +170,7 @@ export class BulkWalker {
       const params: WalkParams = { path: rootPath, recursive: true };
       if (this.deps.maxEntries != null) params.maxEntries = this.deps.maxEntries;
       if (offset > 0) params.offset = offset;
+      if (this.deps.ignoreDirs?.length) params.ignore = this.deps.ignoreDirs;
       const page = await this.deps.rpcConnection.rpc.call('fs.walk', params);
       for (const e of page.entries) {
         all.push({

--- a/plugin/tests/BulkWalker.test.ts
+++ b/plugin/tests/BulkWalker.test.ts
@@ -83,6 +83,38 @@ describe('BulkWalker', () => {
     expect(callSpy).toHaveBeenCalledWith('fs.walk', { path: '', recursive: true, maxEntries: 7 });
   });
 
+  it('passes ignoreDirs through to fs.walk as `ignore`', async () => {
+    const adapter = makeAdapter({});
+    const callSpy = vi.fn(async () => ({ entries: [], truncated: false } as WalkResult));
+    const rpc: RpcConnectionSlice = {
+      info: { capabilities: ['fs.walk'] },
+      rpc: { call: callSpy as unknown as RpcConnectionSlice['rpc']['call'] },
+    };
+    const walker = new BulkWalker({
+      adapter, rpcConnection: rpc, ignoreDirs: ['node_modules', '.git'],
+    });
+
+    await walker.walk('');
+
+    expect(callSpy).toHaveBeenCalledWith('fs.walk', {
+      path: '', recursive: true, ignore: ['node_modules', '.git'],
+    });
+  });
+
+  it('omits `ignore` when ignoreDirs is empty or unset', async () => {
+    const adapter = makeAdapter({});
+    const callSpy = vi.fn(async () => ({ entries: [], truncated: false } as WalkResult));
+    const rpc: RpcConnectionSlice = {
+      info: { capabilities: ['fs.walk'] },
+      rpc: { call: callSpy as unknown as RpcConnectionSlice['rpc']['call'] },
+    };
+    const walker = new BulkWalker({ adapter, rpcConnection: rpc, ignoreDirs: [] });
+
+    await walker.walk('');
+
+    expect(callSpy).toHaveBeenCalledWith('fs.walk', { path: '', recursive: true });
+  });
+
   // ─── fast path pagination + fallback-on-error ───────────────────────────
 
   it('paginates: drains every page with an increasing offset, no fallback', async () => {

--- a/server/internal/handlers/fs_walk.go
+++ b/server/internal/handlers/fs_walk.go
@@ -52,6 +52,18 @@ func FsWalk(vaultRoot string) rpc.Handler {
 		if offset < 0 {
 			offset = 0
 		}
+		// Directory basenames to prune entirely. Pruned subtrees are
+		// never emitted, never counted toward pagination, and never
+		// descended into — so a git/node_modules-heavy work dir does
+		// not blow up the walk. The same list is passed on every page
+		// so the deterministic order (and offset accounting) stays
+		// stable across pages.
+		ignore := make(map[string]struct{}, len(p.Ignore))
+		for _, name := range p.Ignore {
+			if name != "" {
+				ignore[name] = struct{}{}
+			}
+		}
 
 		abs, e := resolveOrErr(vaultRoot, p.Path)
 		if e != nil {
@@ -95,6 +107,14 @@ func FsWalk(vaultRoot string) rpc.Handler {
 			// itself). Skip but keep descending.
 			if path == abs {
 				return nil
+			}
+			// Prune ignored directory subtrees BEFORE counting/emitting
+			// so the dir itself and everything under it is invisible to
+			// pagination and the client. Match is by exact basename.
+			if d.IsDir() {
+				if _, skip := ignore[d.Name()]; skip {
+					return fs.SkipDir
+				}
 			}
 			einfo, err := d.Info()
 			if err != nil {

--- a/server/internal/handlers/fs_walk_test.go
+++ b/server/internal/handlers/fs_walk_test.go
@@ -198,6 +198,83 @@ func TestFsWalk_OffsetPaginationStitchesFullTreeNoDupesNoGaps(t *testing.T) {
 	}
 }
 
+func TestFsWalk_IgnorePrunesSubtreeEntirely(t *testing.T) {
+	v := newVault(t)
+	h := FsWalk(v.Root)
+	raw, _ := json.Marshal(proto.WalkParams{
+		Path: "", Recursive: true, Ignore: []string{"docs"},
+	})
+	result, rerr := h(context.Background(), raw)
+	if rerr != nil {
+		t.Fatal(rerr)
+	}
+	res := result.(proto.WalkResult)
+
+	got := map[string]bool{}
+	for _, e := range res.Entries {
+		got[e.Path] = true
+		if e.Path == "docs" || (len(e.Path) >= 5 && e.Path[:5] == "docs/") {
+			t.Errorf("ignored subtree leaked: %q", e.Path)
+		}
+	}
+	// The pruned dir itself is gone, and everything else survives.
+	for _, want := range []string{"note.md", "img", "img/logo.png", "empty"} {
+		if !got[want] {
+			t.Errorf("expected %q present after pruning docs, got %v", want, res.Entries)
+		}
+	}
+	if got["docs"] {
+		t.Errorf("ignored dir 'docs' itself must not be emitted")
+	}
+}
+
+func TestFsWalk_IgnoreDoesNotShiftPaginationOffset(t *testing.T) {
+	// Pruned entries must not be counted toward `offset`, so paging
+	// with an ignore list stitches the SAME set as a single ignored
+	// walk (no dupes/gaps at page boundaries).
+	v := newVault(t)
+	h := FsWalk(v.Root)
+
+	rawFull, _ := json.Marshal(proto.WalkParams{
+		Path: "", Recursive: true, Ignore: []string{"docs"},
+	})
+	rFull, _ := h(context.Background(), rawFull)
+	want := []string{}
+	for _, e := range rFull.(proto.WalkResult).Entries {
+		want = append(want, e.Path)
+	}
+
+	got := []string{}
+	offset := 0
+	for page := 0; page <= 50; page++ {
+		raw, _ := json.Marshal(proto.WalkParams{
+			Path: "", Recursive: true, MaxEntries: 1, Offset: offset,
+			Ignore: []string{"docs"},
+		})
+		r, e := h(context.Background(), raw)
+		if e != nil {
+			t.Fatal(e)
+		}
+		res := r.(proto.WalkResult)
+		for _, en := range res.Entries {
+			got = append(got, en.Path)
+		}
+		if !res.Truncated {
+			break
+		}
+		offset += len(res.Entries)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("paged-with-ignore stitched %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("stitched[%d]=%q want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestFsWalk_EntriesCarryMtimeAndSize(t *testing.T) {
 	v := newVault(t)
 	h := FsWalk(v.Root)

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -180,11 +180,19 @@ type CopyParams struct {
 // concurrent mutation between pages can drift the boundary by a few
 // entries; tolerable for the cold-open populate (a reconnect
 // re-walks from scratch).
+//
+// `Ignore` prunes directory subtrees by exact basename (e.g.
+// "node_modules", ".git"). A pruned dir is never emitted, never
+// descended into, and never counted toward pagination — this is what
+// keeps a large shared remote root (a git/deps-heavy work dir) from
+// blowing up the walk. The same list must be sent on every page so
+// the deterministic order / offset accounting stays stable.
 type WalkParams struct {
-	Path       string `json:"path"`
-	Recursive  bool   `json:"recursive,omitempty"`
-	MaxEntries int    `json:"maxEntries,omitempty"`
-	Offset     int    `json:"offset,omitempty"`
+	Path       string   `json:"path"`
+	Recursive  bool     `json:"recursive,omitempty"`
+	MaxEntries int      `json:"maxEntries,omitempty"`
+	Offset     int      `json:"offset,omitempty"`
+	Ignore     []string `json:"ignore,omitempty"`
 }
 
 // WalkEntry is one row in fs.walk's flat output. Unlike fs.list's


### PR DESCRIPTION
## Why

Field finding: the reporter's `~/work` is **747,273 entries** (`populateVaultFromRemote(...): rpc-walk, 747273 entries in 58795ms (pages=15)`). Pagination (#357) makes the walk *complete*, but Obsidian eagerly indexes the whole vault, so 747k — overwhelmingly `.git` / `node_modules` / build dirs — is still unusable. A large shared remote work dir is a legitimate, common case (VSCode Remote-SSH handles it), so the tool must cope.

## What

Per the reporter's request: an **"Ignore directories" field in the SSH profile** (multi-line), pre-filled with the typical noise dirs by default.

- `SshProfile.walkIgnoreDirs?: string[]` + `DEFAULT_WALK_IGNORE_DIRS` (`.git`, `node_modules`, `target`, `dist`, `.venv`, `__pycache__`, …; **not** `.obsidian`). `DEFAULT_PROFILE` seeds it so new profiles are pre-filled. Older profiles fall back to the default list at walk time; an explicit empty list = "ignore nothing" (respected).
- **ProfileForm**: multi-line "Ignore directories" textarea (one name per line), placeholdered + pre-filled with defaults.
- **proto**: `WalkParams.Ignore` (Go) + TS mirror `ignore?: string[]`.
- **daemon `fs.walk`**: prune any directory whose exact basename is in the ignore set via `fs.SkipDir`, **before** counting/emitting — so a pruned subtree is never transferred, never indexed, and never shifts pagination offsets.
- **BulkWalker** forwards `ignoreDirs → fs.walk.ignore`; `populateVaultFromRemote` passes `activeProfile.walkIgnoreDirs ?? DEFAULT`.

Matching is **exact directory basename** (not glob) — simple, matches the "node_modules / .git" mental model. Glob/`.obsidianignore`-style is a possible future extension.

## Tests

- Go: subtree fully pruned (the dir itself is not emitted; siblings survive) + **paged-with-ignore stitches the same set as a single ignored walk** (pruned entries don't drift the offset).
- TS: `BulkWalker` forwards `ignoreDirs` as `ignore`; omits it when empty.
- Full plugin (1050 passed / 1 skipped) + full Go suite green; typecheck + lint clean.

## Chain / scope

Chained on **#357** (needs its `WalkParams` pagination base). This is the "Part 3" mitigation the reporter and I agreed on after Part 1 (#357) confirmed the walk completes at scale. The per-folder SFTP fallback does not yet honour ignore (RPC-only for now) — noted in code; follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)