### PR TITLE
fix(shadow): push local shared-config to remote — close #342

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0-beta.0",
+      "version": "1.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0-beta.0",
+  "version": "1.1.0-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -27,6 +27,7 @@ import { BulkWalker } from './vault/BulkWalker';
 import { RenameLeafFollower } from './vault/RenameLeafFollower';
 import { ObsidianRegistry } from './shadow/ObsidianRegistry';
 import { ShadowVaultBootstrap } from './shadow/ShadowVaultBootstrap';
+import { SharedConfigWatcher } from './shadow/SharedConfigWatcher';
 import { ShadowVaultManager } from './shadow/ShadowVaultManager';
 import { WindowSpawner } from './shadow/WindowSpawner';
 import { ShadowStartupCoordinator } from './shadow/ShadowStartupCoordinator';
@@ -65,6 +66,13 @@ export default class RemoteSshPlugin extends Plugin {
   private largeTransferBar: LargeTransferBar | null = null;
   /** Owns the daemon fs.watch subscription + notification dispatch. */
   private fsChangeListener!: FsChangeListener;
+  /**
+   * #342 push half: watches the shadow vault's local config dir and
+   * pushes shared-config edits to the remote. Lives only for the
+   * duration of a connected session (started after the connect pull,
+   * stopped on disconnect/unload).
+   */
+  private sharedConfigWatcher: SharedConfigWatcher | null = null;
   private observability: ObservabilityInstaller | null = null;
   /**
    * #149 — re-entrant guard for `openRemoteTerminal()`. The
@@ -517,11 +525,13 @@ export default class RemoteSshPlugin extends Plugin {
     const da = this.adapterMgr.dataAdapter;
     const hostAdapter = this.app.vault.adapter;
     if (da && hostAdapter instanceof FileSystemAdapter) {
+      const localConfigDir = path.join(
+        hostAdapter.getBasePath(), this.app.vault.configDir,
+      );
+      const remoteConfigDir = this.app.vault.configDir;
       try {
         const cfg = await ShadowVaultBootstrap.pullSharedObsidianConfig(
-          da,
-          this.app.vault.configDir,
-          path.join(hostAdapter.getBasePath(), this.app.vault.configDir),
+          da, remoteConfigDir, localConfigDir,
         );
         if (cfg.errored.length > 0) {
           // The connection is up but some shared-config files the
@@ -540,6 +550,52 @@ export default class RemoteSshPlugin extends Plugin {
           `runAutoConnect(${tag}): shared-config pull failed: ${errorMessage(e)}`,
         );
       }
+
+      // #342 push half: pull only brought remote→local. Without this,
+      // a settings change made HERE never reaches the remote, so the
+      // next session's pull finds nothing and the change evaporates.
+      // Watch the local config dir and push divergent shared files.
+      this.sharedConfigWatcher?.stop();
+      const watcher = new SharedConfigWatcher({
+        watch: (onChange) => {
+          const w = fs.watch(
+            localConfigDir, { persistent: false },
+            (_evt, filename) => onChange(filename ? String(filename) : null),
+          );
+          return { close: () => w.close() };
+        },
+        readLocal: (b) => {
+          try { return fs.readFileSync(path.join(localConfigDir, b), 'utf-8'); }
+          catch { return null; }
+        },
+        flush: async () => {
+          const r = await ShadowVaultBootstrap.pushSharedObsidianConfig(
+            da, remoteConfigDir, localConfigDir,
+          );
+          if (r.errored.length > 0) {
+            new Notice(
+              `Remote SSH: ${r.errored.length} shared-config file` +
+              `${r.errored.length === 1 ? '' : 's'} (${r.errored.join(', ')}) ` +
+              'could not be pushed — settings change not yet saved remotely',
+            );
+          }
+        },
+        debounceMs: 1500,
+        setTimer: (cb, ms) => activeWindow.setTimeout(cb, ms),
+        clearTimer: (h) => activeWindow.clearTimeout(h as number),
+      });
+      // Seed the just-pulled bytes as the synced baseline so the
+      // pull's own writes (and Obsidian re-saving an identical file
+      // on open) don't immediately echo back to the remote.
+      for (const base of ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES) {
+        try {
+          watcher.markSynced(
+            base, fs.readFileSync(path.join(localConfigDir, base), 'utf-8'),
+          );
+        } catch { /* absent locally — nothing to baseline */ }
+      }
+      watcher.start();
+      this.sharedConfigWatcher = watcher;
     }
 
     // Adapter is patched; build the file model so File Explorer
@@ -631,6 +687,8 @@ export default class RemoteSshPlugin extends Plugin {
       // back to local file:// reads instead of blocking forever on a
       // dead transport. restore() clears dataAdapter so the
       // setReconnecting flag goes with it.
+      this.sharedConfigWatcher?.stop();
+      this.sharedConfigWatcher = null;
       this.adapterMgr.restore();
       this.setState(SyncState.ERROR);
       // s.reason is a string from ReconnectManager; wrap into Error
@@ -665,6 +723,10 @@ export default class RemoteSshPlugin extends Plugin {
     // session down so the shell channel close fires while the ssh2
     // Client is still around (cleaner teardown logs).
     this.app.workspace.detachLeavesOfType(VIEW_TYPE_REMOTE_TERMINAL);
+    // Stop the #342 config watcher before the transport goes — its
+    // flush pushes through the (about-to-be-restored) adapter.
+    this.sharedConfigWatcher?.stop();
+    this.sharedConfigWatcher = null;
     this.adapterMgr.restore();
     await this.conn.disconnectTransport();
     this.setState(SyncState.IDLE);

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -42,6 +42,16 @@ export interface SharedConfigReader {
 }
 
 /**
+ * The narrow write surface `pushSharedObsidianConfig` needs — the
+ * other half of the #342 round-trip. `SftpDataAdapter.write`
+ * satisfies it structurally, so the connect flow passes the patched
+ * adapter directly (symmetric with `SharedConfigReader`).
+ */
+export interface SharedConfigWriter {
+  write(normalizedPath: string, content: string): Promise<void>;
+}
+
+/**
  * Materialises the on-disk shadow vault for a profile so a separate
  * Obsidian window can open it as if it were any other local vault.
  *
@@ -283,6 +293,79 @@ export class ShadowVaultBootstrap {
       `skipped [${skipped.join(', ')}], errored [${errored.join(', ')}]`,
     );
     return { pulled, skipped, errored };
+  }
+
+  /**
+   * Push the local shadow vault's shared-config files to the remote —
+   * the other half of the #342 round-trip. Without this, a settings
+   * change made in the shadow window only ever lives on the local
+   * shadow disk: the next session's `pullSharedObsidianConfig` finds
+   * nothing new on the remote and the change "evaporates".
+   *
+   * Symmetric with the pull: each local file is `JSON.parse`-validated
+   * before it is sent, so a half-written local file (Obsidian saving
+   * mid-flush) never clobbers a healthy remote copy. Absent local
+   * files are skipped (not an error — a fresh vault legitimately has
+   * none yet); a remote write that throws is `errored` so the caller
+   * can surface it instead of silently losing settings again.
+   *
+   * Static for the same reason as the pull: callers have a writer +
+   * paths but not necessarily a constructed instance.
+   */
+  static async pushSharedObsidianConfig(
+    writer: SharedConfigWriter,
+    /** Vault-relative config dir, e.g. `.obsidian` (`app.vault.configDir`). */
+    remoteConfigDir: string,
+    /** Absolute local config dir, i.e. `ShadowVaultLayout.configDir`. */
+    localConfigDir: string,
+  ): Promise<{ pushed: string[]; skipped: string[]; errored: string[] }> {
+    const pushed: string[] = [];
+    const skipped: string[] = [];
+    const errored: string[] = [];
+
+    for (const basename of ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES) {
+      const localPath = path.join(localConfigDir, basename);
+      let content: string;
+      try {
+        content = fs.readFileSync(localPath, 'utf-8');
+      } catch {
+        // Absent locally — nothing to push (fresh vault). Not an error.
+        skipped.push(basename);
+        continue;
+      }
+      try {
+        JSON.parse(content);
+      } catch {
+        // Obsidian caught mid-save, or a corrupt local file — do NOT
+        // push broken JSON over a healthy remote copy.
+        logger.warn(
+          `pushSharedObsidianConfig: local ${basename} is not valid JSON; ` +
+          'not pushing (keeping remote copy untouched)',
+        );
+        skipped.push(basename);
+        errored.push(basename);
+        continue;
+      }
+      try {
+        await writer.write(`${remoteConfigDir}/${basename}`, content);
+        pushed.push(basename);
+      } catch (e) {
+        // A transient SSH error must not abort the rest or lose the
+        // change silently — surface it (errored) so the caller can
+        // Notice and the next connect retries.
+        logger.warn(
+          `pushSharedObsidianConfig: ${basename} push failed (${errorMessage(e)})`,
+        );
+        skipped.push(basename);
+        errored.push(basename);
+      }
+    }
+
+    logger.info(
+      `pushSharedObsidianConfig: pushed [${pushed.join(', ')}], ` +
+      `skipped [${skipped.join(', ')}], errored [${errored.join(', ')}]`,
+    );
+    return { pushed, skipped, errored };
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/src/shadow/SharedConfigWatcher.ts
+++ b/plugin/src/shadow/SharedConfigWatcher.ts
@@ -1,0 +1,124 @@
+import { ShadowVaultBootstrap } from './ShadowVaultBootstrap';
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/**
+ * Injectable surface so the debounce / diff / echo-suppression logic
+ * is unit-testable without a real filesystem watcher or timers.
+ */
+export interface SharedConfigWatcherDeps {
+  /**
+   * Start watching the local config dir. `onChange` is invoked with
+   * the changed file's basename, or `null` when the platform doesn't
+   * report a filename (treat as "any shared file may have changed").
+   * Returns a closer.
+   */
+  watch(onChange: (filename: string | null) => void): { close(): void };
+  /** Current local content of `<configDir>/<basename>`, or null if absent/unreadable. */
+  readLocal(basename: string): string | null;
+  /** Push the changed shared-config basenames to the remote. */
+  flush(changed: readonly string[]): Promise<void>;
+  /** Debounce window; coalesces a burst of saves into one push. */
+  debounceMs: number;
+  setTimer(cb: () => void, ms: number): unknown;
+  clearTimer(handle: unknown): void;
+}
+
+/**
+ * Closes the #342 round-trip's push half.
+ *
+ * `pullSharedObsidianConfig` brings remote shared config → local on
+ * connect, but nothing carried a LOCAL settings change back to the
+ * remote, so it never survived to the next session. This watches the
+ * shadow vault's local config dir and pushes a changed shared-config
+ * file to the remote — regardless of whether Obsidian wrote it via
+ * the patched adapter or a direct `fs` write (a real fs watcher sees
+ * both, since the shadow `.obsidian/` is local disk).
+ *
+ * Echo-suppression: the post-pull writes (and Obsidian re-saving an
+ * identical file on open) MUST NOT bounce straight back to the
+ * remote. `markSynced` records the last content known to match the
+ * remote; a debounced flush only pushes files whose current content
+ * differs from that. So a real edit pushes; a pull echo / no-op save
+ * does not.
+ */
+export class SharedConfigWatcher {
+  private static readonly SHARED = new Set<string>(
+    ShadowVaultBootstrap.SHARED_OBSIDIAN_CONFIG_FILES,
+  );
+
+  private closer: { close(): void } | null = null;
+  private timer: unknown = null;
+  private readonly dirty = new Set<string>();
+  /** Per-basename content last known to equal the remote copy. */
+  private readonly synced = new Map<string, string>();
+
+  constructor(private readonly deps: SharedConfigWatcherDeps) {}
+
+  /**
+   * Record content that already matches the remote (call right after
+   * a successful pull, with the bytes just written locally) so the
+   * watcher does not echo the pull's own writes back out.
+   */
+  markSynced(basename: string, content: string): void {
+    this.synced.set(basename, content);
+  }
+
+  start(): void {
+    if (this.closer) return;
+    this.closer = this.deps.watch((filename) => this.onEvent(filename));
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      this.deps.clearTimer(this.timer);
+      this.timer = null;
+    }
+    if (this.closer) {
+      try { this.closer.close(); } catch { /* best effort */ }
+      this.closer = null;
+    }
+    this.dirty.clear();
+  }
+
+  private onEvent(filename: string | null): void {
+    if (filename === null) {
+      // No filename from the platform — consider every shared file.
+      for (const f of SharedConfigWatcher.SHARED) this.dirty.add(f);
+    } else {
+      const base = filename.replace(/^.*[\\/]/, '');
+      if (!SharedConfigWatcher.SHARED.has(base)) return;
+      this.dirty.add(base);
+    }
+    if (this.timer !== null) this.deps.clearTimer(this.timer);
+    this.timer = this.deps.setTimer(() => {
+      this.timer = null;
+      void this.fire();
+    }, this.deps.debounceMs);
+  }
+
+  private async fire(): Promise<void> {
+    const candidates = [...this.dirty];
+    this.dirty.clear();
+    const changed: string[] = [];
+    for (const base of candidates) {
+      const content = this.deps.readLocal(base);
+      if (content === null) continue;            // deleted/unreadable — skip
+      if (this.synced.get(base) === content) continue; // pull echo / no-op save
+      changed.push(base);
+    }
+    if (changed.length === 0) return;
+    try {
+      await this.deps.flush(changed);
+      // Only mark synced once the push actually succeeded, so a
+      // failed push is retried on the next change instead of being
+      // masked as "already in sync".
+      for (const base of changed) {
+        const c = this.deps.readLocal(base);
+        if (c !== null) this.synced.set(base, c);
+      }
+    } catch (e) {
+      logger.warn(`SharedConfigWatcher: push failed (${errorMessage(e)})`);
+    }
+  }
+}

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -703,3 +703,83 @@ describe('ShadowVaultBootstrap.pullSharedObsidianConfig', () => {
       .toBe(healthy); // NOT clobbered with broken JSON
   });
 });
+
+// ─── pushSharedObsidianConfig (#342 round-trip: local → remote) ───────────────
+
+describe('ShadowVaultBootstrap.pushSharedObsidianConfig', () => {
+  let localConfigDir: string;
+
+  beforeEach(() => {
+    localConfigDir = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-push-')),
+      '.obsidian',
+    );
+    fs.mkdirSync(localConfigDir, { recursive: true });
+  });
+  afterEach(() => {
+    try { fs.rmSync(path.dirname(localConfigDir), { recursive: true, force: true }); }
+    catch { /* best effort */ }
+  });
+
+  /** Writer that records calls; `failOn` rejects for that basename. */
+  function makeWriter(failOn?: string) {
+    const writes: Record<string, string> = {};
+    return {
+      writes,
+      write: vi.fn(async (p: string, content: string) => {
+        const base = p.slice(p.lastIndexOf('/') + 1);
+        if (base === failOn) throw new Error('SSH write failed');
+        writes[base] = content;
+      }),
+    };
+  }
+
+  it('pushes every present & valid local file verbatim', async () => {
+    const appBody = JSON.stringify({ useMarkdownLinks: false });
+    fs.writeFileSync(path.join(localConfigDir, 'app.json'), appBody, 'utf-8');
+    fs.writeFileSync(path.join(localConfigDir, 'hotkeys.json'), '{}', 'utf-8');
+    const w = makeWriter();
+
+    const { pushed, skipped, errored } =
+      await ShadowVaultBootstrap.pushSharedObsidianConfig(w, '.obsidian', localConfigDir);
+
+    expect(pushed.sort()).toEqual(['app.json', 'hotkeys.json']);
+    expect(errored).toEqual([]);
+    expect(skipped.sort()).toEqual(['appearance.json', 'core-plugins.json']); // absent locally
+    expect(w.writes['app.json']).toBe(appBody); // verbatim, not re-serialised
+    expect(w.write).toHaveBeenCalledWith('.obsidian/app.json', appBody);
+  });
+
+  it('skips files absent locally (fresh vault — not an error)', async () => {
+    const w = makeWriter();
+    const { pushed, errored } =
+      await ShadowVaultBootstrap.pushSharedObsidianConfig(w, '.obsidian', localConfigDir);
+    expect(pushed).toEqual([]);
+    expect(errored).toEqual([]);
+    expect(w.write).not.toHaveBeenCalled();
+  });
+
+  it('does NOT push a half-written (invalid JSON) local file', async () => {
+    fs.writeFileSync(path.join(localConfigDir, 'app.json'), '{ not json', 'utf-8');
+    const w = makeWriter();
+
+    const { pushed, skipped, errored } =
+      await ShadowVaultBootstrap.pushSharedObsidianConfig(w, '.obsidian', localConfigDir);
+
+    expect(pushed).not.toContain('app.json');
+    expect(skipped).toContain('app.json');
+    expect(errored).toContain('app.json'); // surfaces — settings not silently lost
+    expect(w.write).not.toHaveBeenCalledWith('.obsidian/app.json', expect.anything());
+  });
+
+  it('reports a failed remote write as errored (not silently dropped)', async () => {
+    fs.writeFileSync(path.join(localConfigDir, 'app.json'), '{"a":1}', 'utf-8');
+    const w = makeWriter('app.json');
+
+    const { pushed, errored } =
+      await ShadowVaultBootstrap.pushSharedObsidianConfig(w, '.obsidian', localConfigDir);
+
+    expect(pushed).not.toContain('app.json');
+    expect(errored).toContain('app.json');
+  });
+});

--- a/plugin/tests/SharedConfigWatcher.test.ts
+++ b/plugin/tests/SharedConfigWatcher.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from 'vitest';
+import { SharedConfigWatcher } from '../src/shadow/SharedConfigWatcher';
+
+/**
+ * Harness: a fake fs watcher whose `trigger(name)` simulates a file
+ * event, a manual timer (`runTimer()` fires the pending debounce),
+ * an in-memory local-content map, and a flush spy.
+ */
+function harness(local: Record<string, string> = {}) {
+  let onChange: ((f: string | null) => void) | null = null;
+  let closed = false;
+  let pending: (() => void) | null = null;
+  const flush = vi.fn(async (_changed: readonly string[]) => {});
+  const w = new SharedConfigWatcher({
+    watch: (cb) => { onChange = cb; return { close: () => { closed = true; } }; },
+    readLocal: (b) => (b in local ? local[b] : null),
+    flush,
+    debounceMs: 1000,
+    setTimer: (cb) => { pending = cb; return 1; },
+    clearTimer: () => { pending = null; },
+  });
+  return {
+    w, flush,
+    trigger: (n: string | null) => onChange?.(n),
+    runTimer: () => { const p = pending; pending = null; p?.(); },
+    hasTimer: () => pending !== null,
+    isClosed: () => closed,
+    setLocal: (b: string, c: string) => { local[b] = c; },
+  };
+}
+
+describe('SharedConfigWatcher', () => {
+  it('pushes a genuinely changed shared file after the debounce', async () => {
+    const h = harness({ 'app.json': '{"promptDelete":true}' });
+    h.w.start();
+    h.trigger('app.json');
+    expect(h.flush).not.toHaveBeenCalled(); // debounced, not yet
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledWith(['app.json']);
+  });
+
+  it('suppresses the pull echo: markSynced content is not pushed back', async () => {
+    const h = harness({ 'app.json': '{"a":1}' });
+    h.w.markSynced('app.json', '{"a":1}'); // exactly what pull wrote locally
+    h.w.start();
+    h.trigger('app.json');               // the pull's own write event
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).not.toHaveBeenCalled();
+  });
+
+  it('pushes once the file actually diverges from the synced copy', async () => {
+    const h = harness({ 'app.json': '{"a":1}' });
+    h.w.markSynced('app.json', '{"a":1}');
+    h.w.start();
+    h.setLocal('app.json', '{"a":2}');   // user changed a setting
+    h.trigger('app.json');
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledWith(['app.json']);
+  });
+
+  it('coalesces a burst of events into a single flush', async () => {
+    const h = harness({ 'app.json': 'x', 'hotkeys.json': 'y' });
+    h.w.start();
+    h.trigger('app.json');
+    h.trigger('app.json');
+    h.trigger('hotkeys.json');
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledTimes(1);
+    expect(h.flush.mock.calls[0][0].slice().sort())
+      .toEqual(['app.json', 'hotkeys.json']);
+  });
+
+  it('ignores non-shared files (no debounce armed)', () => {
+    const h = harness({});
+    h.w.start();
+    h.trigger('workspace.json'); // per-client, not shared
+    h.trigger('random.md');
+    expect(h.hasTimer()).toBe(false);
+  });
+
+  it('a null filename considers every shared file', async () => {
+    const h = harness({ 'app.json': 'a', 'appearance.json': 'b' });
+    h.w.start();
+    h.trigger(null);
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledTimes(1);
+    expect(h.flush.mock.calls[0][0]).toEqual(
+      expect.arrayContaining(['app.json', 'appearance.json']),
+    );
+  });
+
+  it('stop() closes the watcher and cancels a pending flush', async () => {
+    const h = harness({ 'app.json': 'x' });
+    h.w.start();
+    h.trigger('app.json');
+    h.w.stop();
+    expect(h.isClosed()).toBe(true);
+    expect(h.hasTimer()).toBe(false);
+    h.runTimer(); // nothing pending
+    await Promise.resolve();
+    expect(h.flush).not.toHaveBeenCalled();
+  });
+
+  it('a failed push is retried on the next change (not masked as synced)', async () => {
+    const h = harness({ 'app.json': 'v1' });
+    h.flush.mockRejectedValueOnce(new Error('ssh down'));
+    h.w.start();
+    h.trigger('app.json');
+    h.runTimer();
+    await Promise.resolve(); await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledTimes(1); // failed
+
+    // Same content changes again later → must push again, because the
+    // failed push must NOT have been recorded as synced.
+    h.trigger('app.json');
+    h.runTimer();
+    await Promise.resolve();
+    expect(h.flush).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Closes #342.

## Problem

Issue #342 ("Settings aren't persistant"): a settings change in the shadow vault is written to the local `.obsidian/app.json`, but **never reaches the remote**, so the next session's `pullSharedObsidianConfig` finds nothing new and the change evaporates. Only the remote→local half existed; the round-trip was open.

## Fix — the push half (symmetric with the existing pull)

- **`ShadowVaultBootstrap.pushSharedObsidianConfig`**: mirror of pull. Reads each local shared file, `JSON.parse`-validates it (a half-written file mid-save must not clobber a healthy remote copy), writes it **verbatim** to the remote. Returns `{pushed,skipped,errored}` so a failed push *surfaces* instead of silently losing settings again.
- **`SharedConfigWatcher`**: watches the shadow vault's **local** config dir and debounce-pushes shared files that diverge. Because the shadow `.obsidian/` is local disk, an `fs.watch` catches the write **whether Obsidian used the patched adapter or a direct `fs` write** (the unresolved "Scenario B" from `bidirectional-sync-gap.md`). Echo-suppressed via `markSynced` so the pull's own writes / identical re-saves don't bounce back; a failed push is **retried**, not masked as synced.
- **main.ts**: after the connect pull, seed `markSynced` with the just-pulled bytes, start the watcher (flush = `pushSharedObsidianConfig` through the patched adapter, Notice on `errored`); stop it on disconnect and on reconnect-failed.

## Tests

- `pushSharedObsidianConfig`: verbatim push / absent-skip / invalid-JSON-not-pushed / write-fail-errored.
- `SharedConfigWatcher` (fully injected — no real fs/timers): debounce, echo-suppression, diverge-pushes, burst-coalesce, non-shared-ignored, null-filename, stop-cancels, **failed-push-retried**.
- Full plugin suite 1059 passed / 1 skipped; typecheck + lint clean.

## Round-trip now closed

session N: edit setting → local `.obsidian/app.json` changes → watcher debounce-pushes to remote → session N+1: `pullSharedObsidianConfig` brings it back. (One-restart read lag for the *same* session remains — Obsidian reads app.json at startup before connect — but persistence across sessions, the reported symptom, is fixed.)

Independent PR, base `next`. Plugin-only (no daemon/proto change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)