### PR TITLE
chore(release): 1.1.1-beta.0

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.0",
+      "version": "1.1.1-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Summary

First beta of the 1.1.1 line on `next`, cut after merging the dependabot dependency updates below.

- `1.1.0` → `1.1.1-beta.0` via `npm run bump:beta:start`
- **Beta channel only**: `plugin/manifest.json` + root `manifest-beta.json` advance (BRAT `--beta`). Stable `manifest.json` and `versions.json` stay pinned to the last stable release, per `scripts/bump-version.mjs`.

### Dependency updates included since 1.1.0
- #366 — bump ws 8.19.0 → 8.20.1 (/docs-site)
- #367 — bump actions/setup-node 4 → 6
- #368 — bump actions/checkout 4 → 6
- #365 — bump golang.org/x/image 0.40.0 → 0.41.0 (/server)

#369 (dev-deps group, 9 updates) is **excluded** — its \`Lint & type-check\` check is failing; tracked separately.

## Changed files
\`plugin/package.json\`, \`plugin/package-lock.json\`, \`plugin/manifest.json\`, root \`manifest-beta.json\` (version-only, +5/−5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)