### PR TITLE
fix(styles): resolve xterm CSS bot warnings

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.3",
+  "version": "1.1.2-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.3",
+  "version": "1.1.2-beta.4",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.3",
+  "version": "1.1.2-beta.4",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/styles.css
+++ b/plugin/styles.css
@@ -372,22 +372,22 @@
     overflow: hidden;
 }
 
-.xterm-dim { opacity: 1 !important; }
+.xterm-dim.xterm-dim { opacity: 1; }
 
 .xterm-underline-1 { text-decoration: underline; }
-.xterm-underline-2 { text-decoration: double underline; }
-.xterm-underline-3 { text-decoration: wavy underline; }
-.xterm-underline-4 { text-decoration: dotted underline; }
-.xterm-underline-5 { text-decoration: dashed underline; }
+.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
+.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
+.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
+.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
 
-.xterm-overline { text-decoration: overline; }
-.xterm-overline.xterm-underline-1 { text-decoration: overline underline; }
-.xterm-overline.xterm-underline-2 { text-decoration: overline double underline; }
-.xterm-overline.xterm-underline-3 { text-decoration: overline wavy underline; }
-.xterm-overline.xterm-underline-4 { text-decoration: overline dotted underline; }
-.xterm-overline.xterm-underline-5 { text-decoration: overline dashed underline; }
+.xterm-overline { text-decoration-line: overline; }
+.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
+.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
+.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
+.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }
 
-.xterm-strikethrough { text-decoration: line-through; }
+.xterm-strikethrough { text-decoration-line: line-through; }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration {
     z-index: 6;


### PR DESCRIPTION
## Summary

- `.xterm-dim { opacity: 1 !important }` → `.xterm-dim.xterm-dim { opacity: 1 }` (specificity 0,2,0 beats xterm.js's 0,1,0 without !important)
- `text-decoration: double/wavy/dotted/dashed underline` shorthand → `text-decoration-line` + `text-decoration-style` longhand (Obsidian 1.4.5 partial support warning)
- Bumps beta to `1.1.2-beta.4`

## Test plan
- [ ] Terminal text with dim/underline/overline/strikethrough still renders correctly
- [ ] version-check CI: `1.1.2-beta.4` > `1.1.2-beta.3` ✓