### PR TITLE
fix(plugin): add root tsconfig.json to resolve ObsidianReviewBot type errors

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.4",
+  "version": "1.1.2-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.4",
+  "version": "1.1.2-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.4",
+  "version": "1.1.2-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./plugin/tsconfig.json",
+  "include": ["plugin/src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Add `tsconfig.json` at repo root extending `plugin/tsconfig.json` with `include: ["plugin/src/**/*.ts"]`
- Bump version `1.1.2-beta.4` → `1.1.2-beta.5`

## Root Cause

ObsidianReviewBot runs ESLint from the **repo root**. `plugin/eslint.config.mjs` has:

```js
parserOptions: { project: "./tsconfig.json" }
```

`./tsconfig.json` resolves to `<repo-root>/tsconfig.json`, which did not exist (only `tsconfig.quartz.json` was there). The TypeScript language service failed to start its program, making all Obsidian API types unresolvable — causing 300+ `@typescript-eslint/no-unsafe-member-access`, `no-unsafe-call`, and `no-unsafe-assignment` warnings across the entire plugin source.

## Fix

```json
{
  "extends": "./plugin/tsconfig.json",
  "include": ["plugin/src/**/*.ts"]
}
```

`extends` inherits all `compilerOptions` from `plugin/tsconfig.json` (including `moduleResolution: "bundler"`, `lib`, `types: ["node"]`). TypeScript's module resolution walks up from `plugin/src/` files and correctly finds `plugin/node_modules/obsidian`, so all Obsidian API types resolve.

`include` is explicitly set because `extends` does NOT inherit `include`/`exclude` from the base config — without it the include would default to `**/*` and accidentally pull in Quartz `.tsx` files at root.

## Test Plan

- [ ] ObsidianReviewBot re-scan: 300+ `Unsafe member access .vault` / `Unsafe call` / `Unsafe assignment` warnings should be gone
- [ ] `plugin/` ESLint still passes: `npm run lint` in `plugin/`
- [ ] Version check CI passes: `1.1.2-beta.5` > `1.1.2-beta.4` on `next`