### PR TITLE
fix(plugin): fix root tsconfig paths to resolve Obsidian/xterm types for bot

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.5",
+  "version": "1.1.2-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.5",
+  "version": "1.1.2-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.5",
+  "version": "1.1.2-beta.7",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -580,6 +580,7 @@ function insertIntoFileMap(vault: Vault, path: string, entry: TAbstractFile): vo
 // import edge. `Exact extends true` forces a compile error the moment
 // conformance breaks.
 type _Assert<T extends true> = T;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- compile-time conformance check, intentionally unused at runtime
 type _WriterReflectorConformance = _Assert<
   VaultModelBuilder extends WriterReflector ? true : false
 >;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,12 @@
 {
   "extends": "./plugin/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "obsidian": ["plugin/node_modules/obsidian"],
+      "@xterm/xterm": ["plugin/node_modules/@xterm/xterm"],
+      "@xterm/addon-fit": ["plugin/node_modules/@xterm/addon-fit"]
+    }
+  },
   "include": ["plugin/src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `baseUrl` + `paths` to root `tsconfig.json` to explicitly map `obsidian`, `@xterm/xterm`, `@xterm/addon-fit` → `plugin/node_modules/`
- Suppress `no-unused-vars` on `_WriterReflectorConformance` compile-time type assertion in VaultModelBuilder.ts
- Bump `1.1.2-beta.5` → `1.1.2-beta.7`

## Root Cause

PR #384 added the root `tsconfig.json` but the type resolution still failed. The `obsidian` package has `"main": ""` (empty string) with no `exports` field. With `moduleResolution: "bundler"`, TypeScript hits the empty `main`, cannot determine the package entry point, and falls back to `any` — causing all Obsidian API accesses to show as `Unsafe member access`.

`@xterm/xterm` and `@xterm/addon-fit` are similarly not found because the TypeScript program root is at repo root, not `plugin/`.

## Fix

```json
{
  "extends": "./plugin/tsconfig.json",
  "compilerOptions": {
    "baseUrl": ".",
    "paths": {
      "obsidian": ["plugin/node_modules/obsidian"],
      "@xterm/xterm": ["plugin/node_modules/@xterm/xterm"],
      "@xterm/addon-fit": ["plugin/node_modules/@xterm/addon-fit"]
    }
  },
  "include": ["plugin/src/**/*.ts"]
}
```

`paths` bypasses the broken `main`/`exports` lookup and points TypeScript directly to the packages' directories, where it finds the `types` field in their `package.json` files.

## Expected bot warnings resolved

- All `Unsafe member access .vault / .getAbstractFileByPath / .trigger / ...` on Obsidian API
- `'Terminal' is an 'error' type` / `'FitAddon' is an 'error' type`
- All `Unsafe member access .loadAddon / .open / .fit / ...` on xterm API
- `'TFile' is an 'error' type` / `'TFolder' is an 'error' type`
- `'_WriterReflectorConformance' is defined but never used`

## Test Plan

- [ ] ObsidianReviewBot re-scan: unsafe member access warnings for `.vault`, `.getAbstractFileByPath`, `.trigger`, xterm API should be gone
- [ ] Version check CI: `1.1.2-beta.7` > `1.1.2-beta.5` ✅