### PR TITLE
fix(plugin): switch root tsconfig to commonjs/node resolution for ObsidianReviewBot

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.8",
+  "version": "1.1.2-beta.9",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.8",
+  "version": "1.1.2-beta.9",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.8",
+  "version": "1.1.2-beta.9",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,8 @@
 {
   "extends": "./plugin/tsconfig.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "obsidian": ["plugin/node_modules/obsidian"],
-      "@xterm/xterm": ["plugin/node_modules/@xterm/xterm"],
-      "@xterm/addon-fit": ["plugin/node_modules/@xterm/addon-fit"]
-    }
+    "module": "commonjs",
+    "moduleResolution": "node"
   },
   "include": ["plugin/src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Override `module: "commonjs"` + `moduleResolution: "node"` in root `tsconfig.json`
- Remove `paths` / `baseUrl` (no longer needed)
- Bump `1.1.2-beta.8` → `1.1.2-beta.9`

## Why previous attempts failed

| Attempt | Why it failed |
|---|---|
| PR #384 — root `tsconfig.json` with `extends` only | `moduleResolution: "bundler"` inherited; obsidian `main: ""` makes bundler resolution fail |
| PR #387 — add `paths` mapping | `paths` does not override the broken `main: ""` lookup in `bundler` mode |

## Root cause

The `obsidian` npm package has `"main": ""` (empty string) and no `exports` field. With `moduleResolution: "bundler"`, TypeScript hits the empty `main`, cannot determine the package entry, and produces an `error` type — causing every Obsidian API access to cascade as `any`.

## Fix

```json
{
  "extends": "./plugin/tsconfig.json",
  "compilerOptions": {
    "module": "commonjs",
    "moduleResolution": "node"
  },
  "include": ["plugin/src/**/*.ts"]
}
```

`moduleResolution: "node"` uses the classic walk-up algorithm: starting from `plugin/src/<file>.ts`, it checks `plugin/src/node_modules/` → `plugin/node_modules/` → finds `obsidian`, `@xterm/*`, `@types/ssh2` reliably. This tsconfig is **only used by ESLint / the bot** — the actual plugin build still uses `plugin/tsconfig.json` with `bundler` resolution unchanged.

## Expected bot result

All `Unsafe member access .vault`, `'Terminal' is an error type`, `Unsafe call of a type that could not be resolved` etc. sourced from unresolved Obsidian/xterm packages should be gone after this merges.