### PR TITLE
fix(tsconfig): resolve Node types for the validator (typeRoots)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.11",
+  "version": "1.1.2-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.11",
+  "version": "1.1.2-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.11",
+  "version": "1.1.2-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.2-beta.11",
+      "version": "1.1.2-beta.12",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
@@ -26,7 +26,7 @@
         "eslint-plugin-obsidianmd": "^0.3.0",
         "fast-check": "^4.8.0",
         "jsdom": "^29.1.1",
-        "obsidian": "*",
+        "obsidian": "latest",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
       },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.11",
+  "version": "1.1.2-beta.12",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "./plugin/tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "typeRoots": ["./plugin/node_modules/@types"],
+    "types": ["node"]
   },
   "include": ["plugin/src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Fixes the root tsconfig so the ObsidianReviewBot's type checker can resolve Node types — killing the bulk of the `unsafe member access` false positives (`Buffer`, `.byteOffset`, `net.Server`, `.createServer`, `.listen`, EventEmitter `.once` …).

### Cause
The bot reads the **root** `tsconfig.json`, but there's no root `node_modules` (it lives in `plugin/node_modules`). So `@types/node` couldn't be found and `Buffer`/`net`/`EventEmitter` collapsed to `any`.

### Fix
```json
"typeRoots": ["./plugin/node_modules/@types"],
"types": ["node"]
```

### Verified locally
`tsc -p tsconfig.json --noEmit` resolves Node types — no `Buffer`/`net`/`Server` errors (only an unrelated `moduleResolution=node10 deprecated` notice).

### Next
Re-preview on community.obsidian.md to confirm the Buffer/net/Server unsafe-member-access warnings drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)