### PR TITLE
fix(types): clear remaining validator unsafe-* / CSS-portability warnings

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.13",
+  "version": "1.1.2-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2-beta.13",
+  "version": "1.1.2-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.13",
+  "version": "1.1.2-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.2-beta.13",
+      "version": "1.1.2-beta.14",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2-beta.13",
+  "version": "1.1.2-beta.14",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/AdapterPatcher.ts
+++ b/plugin/src/adapter/AdapterPatcher.ts
@@ -61,7 +61,7 @@ export class AdapterPatcher<T extends object> {
         if (typeof replDesc.value === 'function') {
           const fn = replDesc.value as (...args: unknown[]) => unknown;
           Object.defineProperty(this.target, name, {
-            value: fn.bind(this.replacement),
+            value: (...args: unknown[]): unknown => fn.apply(this.replacement, args),
             writable: true,
             configurable: true,
             enumerable: true,

--- a/plugin/src/adapter/ResourceBridge.ts
+++ b/plugin/src/adapter/ResourceBridge.ts
@@ -32,12 +32,18 @@ export type FetchBinaryFn = (vaultPath: string) => Promise<Uint8Array>;
  * cache entry and re-issues with `expectedMtime: undefined` so the
  * webview gets a fresh slice rather than a stale one.
  */
+export interface BinaryRange {
+  bytes: Uint8Array;
+  mtime: number;
+  totalSize: number;
+}
+
 export type FetchBinaryRangeFn = (
   vaultPath: string,
   offset: number,
   length: number,
   expectedMtime?: number,
-) => Promise<{ bytes: Uint8Array; mtime: number; totalSize: number }>;
+) => Promise<BinaryRange>;
 
 /**
  * Async fetcher for daemon-resized image thumbnails. Optional: the
@@ -324,7 +330,7 @@ export class ResourceBridge {
       // Pin follow-up requests to the cached generation so the daemon
       // rejects mid-stream edits with PreconditionFailed (#171).
       const expectedMtime = this.lookupMtime(rawPath);
-      let result;
+      let result: BinaryRange;
       try {
         result = await fetchRange(rawPath, explicit.start, explicit.length, expectedMtime);
       } catch (e) {

--- a/plugin/src/offline/QueueReplayer.ts
+++ b/plugin/src/offline/QueueReplayer.ts
@@ -7,12 +7,13 @@ import { errorMessage } from "../util/errorMessage";
  * `SftpDataAdapter.replayQueuedOp` so a fake adapter (test fixture)
  * can satisfy the same contract.
  */
+export type ReplayOutcome =
+  | { result: 'ok' }
+  | { result: 'conflict' }
+  | { result: 'error'; message: string };
+
 export interface ReplayTarget {
-  replayQueuedOp(op: QueuedOp): Promise<
-    | { result: 'ok' }
-    | { result: 'conflict' }
-    | { result: 'error'; message: string }
-  >;
+  replayQueuedOp(op: QueuedOp): Promise<ReplayOutcome>;
 }
 
 export interface ReplayReport {
@@ -55,7 +56,7 @@ export class QueueReplayer {
     logger.info(`QueueReplayer: draining ${initialPending.length} pending entries`);
 
     for (const entry of initialPending) {
-      let outcome;
+      let outcome: ReplayOutcome;
       try {
         outcome = await this.target.replayQueuedOp(entry.op);
       } catch (e) {

--- a/plugin/src/util/logger.ts
+++ b/plugin/src/util/logger.ts
@@ -136,8 +136,8 @@ export class Logger {
     // those methods, so capturing them would encourage exactly the
     // anti-pattern the rule exists to prevent.
     const snapshot: ConsoleSnapshot = {
-      warn: console.warn.bind(console),
-      error: console.error.bind(console),
+      warn: console.warn.bind(console) as ConsoleFn,
+      error: console.error.bind(console) as ConsoleFn,
     };
     this.originalConsole = snapshot;
     console.warn = (...args: unknown[]) => {

--- a/plugin/styles.css
+++ b/plugin/styles.css
@@ -375,19 +375,19 @@
 .xterm-dim.xterm-dim { opacity: 1; }
 
 .xterm-underline-1 { text-decoration: underline; }
-.xterm-underline-2 { text-decoration-line: underline; text-decoration-style: double; }
-.xterm-underline-3 { text-decoration-line: underline; text-decoration-style: wavy; }
-.xterm-underline-4 { text-decoration-line: underline; text-decoration-style: dotted; }
-.xterm-underline-5 { text-decoration-line: underline; text-decoration-style: dashed; }
+.xterm-underline-2 { text-decoration: underline double; }
+.xterm-underline-3 { text-decoration: underline wavy; }
+.xterm-underline-4 { text-decoration: underline dotted; }
+.xterm-underline-5 { text-decoration: underline dashed; }
 
-.xterm-overline { text-decoration-line: overline; }
-.xterm-overline.xterm-underline-1 { text-decoration-line: overline underline; }
-.xterm-overline.xterm-underline-2 { text-decoration-line: overline underline; text-decoration-style: double; }
-.xterm-overline.xterm-underline-3 { text-decoration-line: overline underline; text-decoration-style: wavy; }
-.xterm-overline.xterm-underline-4 { text-decoration-line: overline underline; text-decoration-style: dotted; }
-.xterm-overline.xterm-underline-5 { text-decoration-line: overline underline; text-decoration-style: dashed; }
+.xterm-overline { text-decoration: overline; }
+.xterm-overline.xterm-underline-1 { text-decoration: overline underline; }
+.xterm-overline.xterm-underline-2 { text-decoration: overline underline double; }
+.xterm-overline.xterm-underline-3 { text-decoration: overline underline wavy; }
+.xterm-overline.xterm-underline-4 { text-decoration: overline underline dotted; }
+.xterm-overline.xterm-underline-5 { text-decoration: overline underline dashed; }
 
-.xterm-strikethrough { text-decoration-line: line-through; }
+.xterm-strikethrough { text-decoration: line-through; }
 
 .xterm-screen .xterm-decoration-container .xterm-decoration {
     z-index: 6;


### PR DESCRIPTION
## Summary
Clears the remaining validator warnings (after #393 made types resolve): a few real `any` leaks + a CSS portability note. All were **Warnings (no Errors)**, now cleaned up.

## Fixes
| File | Warning | Fix |
|---|---|---|
| ResourceBridge | `.mtime`/`.totalSize`/`.bytes` on any | name return type `BinaryRange` + `let result: BinaryRange` |
| QueueReplayer | `.result`/`.message` on any | extract `ReplayOutcome` + `let outcome: ReplayOutcome` |
| logger | unsafe-assignment (console.bind) | cast to `ConsoleFn` |
| AdapterPatcher | unsafe-assignment (fn.bind) | equivalent arrow wrapper |
| styles.css | text-decoration partial on Obsidian 1.4.5 | sub-properties → shorthand |

Root cause of the TS ones: `let x;` decays to `any` because evolving-any doesn't survive a `try/catch` reassignment, so the later `x.field` accesses were unsafe.

## Verified
- validator-sim eslint (root deps, cwd=root) → **0 problems**
- plugin `tsc --noEmit` + `npm run lint` → **0 / EXIT 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)