### PR TITLE
feat(daemon): auto-download the daemon binary from the GitHub release (Refs #397)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.2",
+      "version": "1.1.3-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/ConnectionManager.ts
+++ b/plugin/src/ConnectionManager.ts
@@ -18,7 +18,21 @@ export type RpcConnectionHandle = Awaited<ReturnType<typeof establishRpcConnecti
 
 export interface ConnectionDeps {
   locateDaemonBinary: () => string | null;
+  /**
+   * Download + cache the daemon binary for the remote's arch when it isn't
+   * staged locally (community-store installs don't ship it). Returns the
+   * local path, or null when the remote arch is unsupported or the user
+   * declined the download — the caller then downgrades to SFTP.
+   */
+  ensureDaemonBinary: (client: SftpClient) => Promise<string | null>;
 }
+
+/**
+ * Raised by {@link ConnectionManager.startRpcSession} when no daemon binary
+ * could be obtained (unsupported remote arch, or the user declined the
+ * download). The connect flow catches it and falls back to SFTP transport.
+ */
+export class DaemonUnavailableError extends Error {}
 
 /**
  * Hooks the reconnect attempt calls after re-establishing the transport
@@ -70,10 +84,14 @@ export class ConnectionManager {
    * and `daemonDeployer` are populated.
    */
   async startRpcSession(profile: SshProfile, effectivePath: string): Promise<void> {
-    const localBinaryPath = this.deps.locateDaemonBinary();
+    // Prefer a locally-staged binary (dev builds); otherwise download +
+    // cache the right per-arch binary from the GitHub release (the path
+    // community-store installs take, since the package can't ship it).
+    const localBinaryPath =
+      this.deps.locateDaemonBinary() ?? (await this.deps.ensureDaemonBinary(this.client));
     if (!localBinaryPath) {
-      throw new Error(
-        'daemon binary not staged. Run `npm run build:server` (or `build:full`) and reload the plugin.',
+      throw new DaemonUnavailableError(
+        'daemon binary unavailable: the remote arch is unsupported or the download was declined.',
       );
     }
 

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, Notice, FileSystemAdapter, TFile, TFolder } from 'obsidian';
+import { Plugin, Notice, Modal, FileSystemAdapter, TFile, TFolder, requestUrl } from 'obsidian';
 import type { PluginSettings, SshProfile } from './types';
 import { SyncState } from './types';
 import { DEFAULT_SETTINGS, DEFAULT_WALK_IGNORE_DIRS } from './constants';
@@ -36,7 +36,11 @@ import { ObservabilityInstaller } from './util/ObservabilityInstaller';
 import { normalizeRemotePath } from './util/pathUtils';
 import * as path from 'path';
 import { errorMessage } from "./util/errorMessage";
-import { ConnectionManager } from "./ConnectionManager";
+import { ConnectionManager, DaemonUnavailableError } from "./ConnectionManager";
+import { detectRemoteTarget, ensureDaemonBinary as downloadDaemonBinary } from './transport/DaemonDownloader';
+
+/** GitHub `owner/repo` the daemon binaries are released from. */
+const DAEMON_RELEASE_REPO = 'sotashimozono/obsidian-remote-ssh';
 import { TransferTracker } from "./util/TransferTracker";
 import { LargeTransferBar } from "./ui/LargeTransferBar";
 import { OnboardingModal } from "./ui/OnboardingModal";
@@ -134,6 +138,7 @@ export default class RemoteSshPlugin extends Plugin {
     });
     this.conn = new ConnectionManager(client, {
       locateDaemonBinary: () => this.locateDaemonBinary(),
+      ensureDaemonBinary: (c) => this.ensureDaemonBinary(c),
     });
     this.conn.activeRemoteBasePath = null;
 
@@ -451,7 +456,7 @@ export default class RemoteSshPlugin extends Plugin {
       return;
     }
 
-    const transport = profile.transport ?? 'sftp';
+    let transport = profile.transport ?? 'sftp';
     let rpcSummary = '';
     if (transport === 'rpc') {
       try {
@@ -460,15 +465,25 @@ export default class RemoteSshPlugin extends Plugin {
         const ver  = this.conn.rpcConnection?.info.version ?? '?';
         rpcSummary = ` — daemon ${ver}, ${caps} capabilities`;
       } catch (e) {
-        this.setState(SyncState.ERROR);
-        const { notice, classified } = classifyToNotice(e);
-        logger.error(`RPC startup failed: ${classified.title}`, {
-          category: classified.category, code: classified.code,
-          original: classified.original.message, profileId: profile.id,
-        });
-        new Notice(notice);
-        try { await this.conn.client.disconnect(); } catch { /* ignore */ }
-        return;
+        if (e instanceof DaemonUnavailableError) {
+          // Unsupported remote arch, or the user declined the daemon
+          // download → keep the session on SFTP. Vault read/write/sync
+          // still work; daemon-only features (fast walk, thumbnails, live
+          // watch, image/PDF rendering) are unavailable.
+          logger.warn(`RPC unavailable, falling back to SFTP: ${e.message}`);
+          new Notice('Remote SSH: daemon unavailable — connected via SFTP (reduced features).');
+          transport = 'sftp';
+        } else {
+          this.setState(SyncState.ERROR);
+          const { notice, classified } = classifyToNotice(e);
+          logger.error(`RPC startup failed: ${classified.title}`, {
+            category: classified.category, code: classified.code,
+            original: classified.original.message, profileId: profile.id,
+          });
+          new Notice(notice);
+          try { await this.conn.client.disconnect(); } catch { /* ignore */ }
+          return;
+        }
       }
     }
 
@@ -1089,6 +1104,88 @@ export default class RemoteSshPlugin extends Plugin {
       'server-bin', 'obsidian-remote-server-linux-amd64',
     );
     return fs.existsSync(candidate) ? candidate : null;
+  }
+
+  /**
+   * Acquire a daemon binary for the REMOTE's os/arch when one isn't staged
+   * locally. Community-store installs don't ship `server-bin/`, so we probe
+   * the remote with `uname`, download the matching binary from this plugin's
+   * GitHub release, verify it against `daemon-manifest.json` (sha256), and
+   * cache it under `server-bin/`. Returns null (→ caller downgrades to SFTP)
+   * for unsupported arches, a declined download, or any failure.
+   */
+  private async ensureDaemonBinary(client: SftpClient): Promise<string | null> {
+    const target = await detectRemoteTarget(async (cmd) => (await client.exec(cmd)).stdout);
+    if (!target) {
+      logger.warn('ensureDaemonBinary: unsupported remote os/arch (uname); staying on SFTP');
+      return null;
+    }
+    const adapter = this.app.vault.adapter;
+    if (!(adapter instanceof FileSystemAdapter)) return null;
+    const cacheDir = path.join(
+      adapter.getBasePath(),
+      this.app.vault.configDir, 'plugins', this.manifest.id, 'server-bin',
+    );
+
+    // Consent gate: Obsidian discourages silent external downloads, so ask
+    // once and remember the answer in settings.
+    if (!this.settings.daemonDownloadConsented) {
+      const consented = await this.confirmDaemonDownload(this.manifest.version);
+      if (!consented) {
+        logger.info('ensureDaemonBinary: user declined daemon download; staying on SFTP');
+        return null;
+      }
+      this.settings.daemonDownloadConsented = true;
+      await this.saveSettings();
+    }
+
+    try {
+      const local = await downloadDaemonBinary(
+        {
+          fetchBinary: async (url) => new Uint8Array((await requestUrl({ url })).arrayBuffer),
+          fetchText: async (url) => (await requestUrl({ url })).text,
+          cacheDir,
+          cacheHit: (abs) => fs.existsSync(abs),
+          writeExecutable: async (abs, bytes) => {
+            await fs.promises.mkdir(path.dirname(abs), { recursive: true });
+            await fs.promises.writeFile(abs, bytes);
+            await fs.promises.chmod(abs, 0o755);
+          },
+          repo: DAEMON_RELEASE_REPO,
+          version: this.manifest.version,
+        },
+        target,
+      );
+      new Notice(`Remote SSH: downloaded daemon for ${target.os}/${target.arch}.`);
+      return local;
+    } catch (e) {
+      logger.error(`ensureDaemonBinary: download/verify failed: ${errorMessage(e)}`);
+      new Notice(`Remote SSH: daemon download failed — ${errorMessage(e)}. Using SFTP.`);
+      return null;
+    }
+  }
+
+  /** One-time consent dialog for the daemon auto-download. */
+  private confirmDaemonDownload(version: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      const modal = new Modal(this.app);
+      modal.titleEl.setText('Download remote daemon?');
+      modal.contentEl.createEl('p', {
+        text:
+          `Remote SSH can download a small helper daemon (release ${version}) from ` +
+          'this plugin’s GitHub release. It is uploaded to your SSH host and ' +
+          'verified by sha256, and enables fast sync, live watch, and image/PDF ' +
+          'preview. Decline to stay on plain SFTP (these extras are then off).',
+      });
+      let decided = false;
+      const buttons = modal.contentEl.createDiv({ cls: 'modal-button-container' });
+      const ok = buttons.createEl('button', { text: 'Download', cls: 'mod-cta' });
+      ok.addEventListener('click', () => { decided = true; resolve(true); modal.close(); });
+      const no = buttons.createEl('button', { text: 'Use SFTP' });
+      no.addEventListener('click', () => { decided = true; resolve(false); modal.close(); });
+      modal.onClose = () => { if (!decided) resolve(false); };
+      modal.open();
+    });
   }
 
   isConnected(): boolean {

--- a/plugin/src/transport/DaemonDownloader.ts
+++ b/plugin/src/transport/DaemonDownloader.ts
@@ -1,0 +1,133 @@
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+/**
+ * Runtime acquisition of the Go daemon binary.
+ *
+ * The Obsidian community store ships only `main.js` / `manifest.json` /
+ * `styles.css`, so the daemon binary can't ride along in the plugin
+ * package. Instead we fetch the right per-arch binary from the plugin's
+ * GitHub release on first RPC connect, verify it against the release's
+ * `daemon-manifest.json` (sha256), and cache it under the plugin folder's
+ * `server-bin/`. Subsequent connects hit the local cache.
+ *
+ * Unsupported remote arches (or download/verify failure) let the caller
+ * downgrade to the SFTP transport rather than hard-failing.
+ */
+
+export type DaemonOs = 'linux' | 'darwin';
+export type DaemonArch = 'amd64' | 'arm64';
+
+export interface DaemonTarget {
+  os: DaemonOs;
+  arch: DaemonArch;
+}
+
+export interface DaemonDownloaderDeps {
+  /** Fetch a release asset as bytes (Obsidian `requestUrl` arraybuffer). */
+  fetchBinary: (url: string) => Promise<Uint8Array>;
+  /** Fetch a release asset as text (the manifest JSON). */
+  fetchText: (url: string) => Promise<string>;
+  /** Absolute path to the plugin's `server-bin/` cache dir. */
+  cacheDir: string;
+  /** Persist downloaded bytes to disk and mark executable (chmod +x). */
+  writeExecutable: (absPath: string, bytes: Uint8Array) => Promise<void>;
+  /** True if a cached file already exists. */
+  cacheHit: (absPath: string) => boolean;
+  /** `owner/repo` for the release URL. */
+  repo: string;
+  /** Release tag to fetch from (= plugin version, e.g. `1.1.3`). */
+  version: string;
+}
+
+const BINARY_PREFIX = 'obsidian-remote-server';
+const MANIFEST_NAME = 'daemon-manifest.json';
+
+export function binaryFilename(t: DaemonTarget): string {
+  return `${BINARY_PREFIX}-${t.os}-${t.arch}`;
+}
+
+/**
+ * Map `uname -s` / `uname -m` output to our release arch tuple. Returns
+ * null for anything we don't ship a binary for (Windows server, FreeBSD,
+ * 32-bit, …) so the caller downgrades to SFTP.
+ */
+export function parseUname(unameS: string, unameM: string): DaemonTarget | null {
+  const s = unameS.trim().toLowerCase();
+  const m = unameM.trim().toLowerCase();
+  let os: DaemonOs;
+  if (s === 'linux') os = 'linux';
+  else if (s === 'darwin') os = 'darwin';
+  else return null;
+  let arch: DaemonArch;
+  if (m === 'x86_64' || m === 'amd64') arch = 'amd64';
+  else if (m === 'aarch64' || m === 'arm64') arch = 'arm64';
+  else return null;
+  return { os, arch };
+}
+
+/**
+ * Detect the remote host's os/arch via `uname`. Queried as two separate
+ * commands (`uname -s`, `uname -m`) because not every remote shell accepts
+ * the combined `uname -s -m` form consistently.
+ */
+export async function detectRemoteTarget(
+  exec: (cmd: string) => Promise<string>,
+): Promise<DaemonTarget | null> {
+  const s = await exec('uname -s');
+  const m = await exec('uname -m');
+  return parseUname(s, m);
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+/** Thrown when a downloaded binary fails sha256 verification. */
+export class DaemonVerificationError extends Error {}
+
+/**
+ * Ensure a local daemon binary for the remote's arch, downloading and
+ * verifying from the GitHub release if it isn't already cached. Returns the
+ * absolute local path.
+ *
+ * Throws {@link DaemonVerificationError} on a sha256 mismatch or a missing
+ * manifest entry — we never hand back an unverified binary for deployment.
+ */
+export async function ensureDaemonBinary(
+  deps: DaemonDownloaderDeps,
+  target: DaemonTarget,
+): Promise<string> {
+  const filename = binaryFilename(target);
+  const dest = path.join(deps.cacheDir, filename);
+  if (deps.cacheHit(dest)) return dest;
+
+  const base = `https://github.com/${deps.repo}/releases/download/${deps.version}`;
+
+  const manifestRaw = await deps.fetchText(`${base}/${MANIFEST_NAME}`);
+  let manifest: Record<string, string>;
+  try {
+    manifest = JSON.parse(manifestRaw) as Record<string, string>;
+  } catch (e) {
+    throw new DaemonVerificationError(
+      `${MANIFEST_NAME} is not valid JSON (release ${deps.version}): ${(e as Error).message}`,
+    );
+  }
+  const expected = manifest[filename];
+  if (!expected) {
+    throw new DaemonVerificationError(
+      `${MANIFEST_NAME} has no entry for ${filename} (release ${deps.version})`,
+    );
+  }
+
+  const bytes = await deps.fetchBinary(`${base}/${filename}`);
+  const got = sha256Hex(bytes);
+  if (got !== expected.toLowerCase()) {
+    throw new DaemonVerificationError(
+      `daemon binary sha256 mismatch for ${filename}: expected ${expected}, got ${got}`,
+    );
+  }
+
+  await deps.writeExecutable(dest, bytes);
+  return dest;
+}

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -120,6 +120,12 @@ export interface PluginSettings {
    */
   telemetryEnabled?: boolean;
   /**
+   * Whether the user consented to auto-downloading the daemon binary from
+   * the GitHub release. Asked once on the first RPC connect when no binary
+   * is staged locally (community-store installs); remembered thereafter.
+   */
+  daemonDownloadConsented?: boolean;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/tests/DaemonDownloader.test.ts
+++ b/plugin/tests/DaemonDownloader.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import {
+  parseUname,
+  binaryFilename,
+  detectRemoteTarget,
+  ensureDaemonBinary,
+  DaemonVerificationError,
+  type DaemonDownloaderDeps,
+  type DaemonTarget,
+} from '../src/transport/DaemonDownloader';
+
+describe('parseUname', () => {
+  it('maps linux x86_64 -> linux-amd64', () => {
+    expect(parseUname('Linux', 'x86_64')).toEqual({ os: 'linux', arch: 'amd64' });
+  });
+  it('maps darwin arm64 -> darwin-arm64', () => {
+    expect(parseUname('Darwin', 'arm64')).toEqual({ os: 'darwin', arch: 'arm64' });
+  });
+  it('maps linux aarch64 -> linux-arm64', () => {
+    expect(parseUname('Linux', 'aarch64')).toEqual({ os: 'linux', arch: 'arm64' });
+  });
+  it('maps darwin x86_64 -> darwin-amd64', () => {
+    expect(parseUname('Darwin', 'x86_64')).toEqual({ os: 'darwin', arch: 'amd64' });
+  });
+  it('is case-insensitive and trims whitespace', () => {
+    expect(parseUname(' Linux\n', 'AMD64')).toEqual({ os: 'linux', arch: 'amd64' });
+  });
+  it('returns null for Windows (MINGW/MSYS uname)', () => {
+    expect(parseUname('MINGW64_NT-10.0', 'x86_64')).toBeNull();
+  });
+  it('returns null for unsupported OS', () => {
+    expect(parseUname('FreeBSD', 'amd64')).toBeNull();
+  });
+  it('returns null for 32-bit arch', () => {
+    expect(parseUname('Linux', 'i686')).toBeNull();
+  });
+});
+
+describe('binaryFilename', () => {
+  it('formats os-arch', () => {
+    expect(binaryFilename({ os: 'darwin', arch: 'arm64' })).toBe('obsidian-remote-server-darwin-arm64');
+  });
+});
+
+describe('detectRemoteTarget', () => {
+  it('queries `uname -s` then `uname -m`', async () => {
+    const calls: string[] = [];
+    const exec = async (cmd: string): Promise<string> => {
+      calls.push(cmd);
+      return cmd === 'uname -s' ? 'Linux' : 'x86_64';
+    };
+    expect(await detectRemoteTarget(exec)).toEqual({ os: 'linux', arch: 'amd64' });
+    expect(calls).toEqual(['uname -s', 'uname -m']);
+  });
+  it('returns null on unsupported remote', async () => {
+    const exec = async (cmd: string): Promise<string> =>
+      cmd === 'uname -s' ? 'OpenBSD' : 'amd64';
+    expect(await detectRemoteTarget(exec)).toBeNull();
+  });
+});
+
+describe('ensureDaemonBinary', () => {
+  const target: DaemonTarget = { os: 'linux', arch: 'amd64' };
+  const filename = 'obsidian-remote-server-linux-amd64';
+  const bytes = new Uint8Array([0x7f, 0x45, 0x4c, 0x46, 0x01, 0x02, 0x03]); // fake ELF-ish
+  const sha = createHash('sha256').update(bytes).digest('hex');
+
+  function makeDeps(
+    over: Partial<DaemonDownloaderDeps> = {},
+  ): DaemonDownloaderDeps & { written: Map<string, Uint8Array>; urls: string[] } {
+    const written = new Map<string, Uint8Array>();
+    const urls: string[] = [];
+    return {
+      written,
+      urls,
+      fetchText: async (u) => {
+        urls.push(u);
+        return JSON.stringify({ [filename]: sha });
+      },
+      fetchBinary: async (u) => {
+        urls.push(u);
+        return bytes;
+      },
+      cacheDir: '/vault/.obsidian/plugins/remote-ssh/server-bin',
+      cacheHit: () => false,
+      writeExecutable: async (p, b) => {
+        written.set(p, b);
+      },
+      repo: 'sotashimozono/obsidian-remote-ssh',
+      version: '1.1.3',
+      ...over,
+    };
+  }
+
+  it('downloads, verifies sha256, caches, and returns the path', async () => {
+    const deps = makeDeps();
+    const p = await ensureDaemonBinary(deps, target);
+    expect(p).toContain(filename);
+    expect(deps.written.get(p)).toEqual(bytes);
+  });
+
+  it('uses the cache and does NOT download on a cache hit', async () => {
+    let fetched = false;
+    const deps = makeDeps({
+      cacheHit: () => true,
+      fetchBinary: async () => {
+        fetched = true;
+        return bytes;
+      },
+    });
+    const p = await ensureDaemonBinary(deps, target);
+    expect(p).toContain(filename);
+    expect(fetched).toBe(false);
+  });
+
+  it('throws DaemonVerificationError on sha256 mismatch (never caches)', async () => {
+    const deps = makeDeps({
+      fetchText: async () => JSON.stringify({ [filename]: 'deadbeef' }),
+    });
+    await expect(ensureDaemonBinary(deps, target)).rejects.toBeInstanceOf(DaemonVerificationError);
+    expect(deps.written.size).toBe(0);
+  });
+
+  it('throws when the manifest has no entry for the target', async () => {
+    const deps = makeDeps({
+      fetchText: async () => JSON.stringify({ 'obsidian-remote-server-darwin-arm64': sha }),
+    });
+    await expect(ensureDaemonBinary(deps, target)).rejects.toBeInstanceOf(DaemonVerificationError);
+  });
+
+  it('throws on malformed manifest JSON', async () => {
+    const deps = makeDeps({ fetchText: async () => 'not json{' });
+    await expect(ensureDaemonBinary(deps, target)).rejects.toBeInstanceOf(DaemonVerificationError);
+  });
+
+  it('builds the GitHub release URLs from repo + version (manifest first, then binary)', async () => {
+    const deps = makeDeps();
+    await ensureDaemonBinary(deps, target);
+    expect(deps.urls).toEqual([
+      'https://github.com/sotashimozono/obsidian-remote-ssh/releases/download/1.1.3/daemon-manifest.json',
+      'https://github.com/sotashimozono/obsidian-remote-ssh/releases/download/1.1.3/obsidian-remote-server-linux-amd64',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
Closes the community-store usability gap from #397. The daemon binary can't ride in the plugin package (Obsidian distributes only `main.js`/`manifest.json`/`styles.css`), so the plugin now **downloads it from the GitHub release on first RPC connect**, verifies sha256, and caches it.

## Flow
1. RPC connect with no local binary → probe remote `uname -s` / `uname -m`
2. Unsupported arch (Windows / FreeBSD / 32-bit) → **downgrade to SFTP**
3. One-time **consent dialog** (Obsidian discourages silent external fetch; remembered in settings)
4. Download `obsidian-remote-server-<os>-<arch>` from `releases/download/<version>/`
5. Verify against `daemon-manifest.json` sha256 → cache under `server-bin/`
6. Any download/verify failure → SFTP downgrade (never a hard fail)

## Code
- **`DaemonDownloader.ts`** (new, pure + dependency-injected) — arch mapping, URL building, fetch + sha256 verify + cache. **17 unit tests** (real sha256, mock fetch, URL/cache/mismatch).
- **`ConnectionManager`** — `ConnectionDeps.ensureDaemonBinary`, `DaemonUnavailableError`, `startRpcSession` uses `locate ?? ensure`.
- **`main.ts`** — `ensureDaemonBinary` (`requestUrl` + fs + consent Modal), `connectProfile` catches `DaemonUnavailableError` → SFTP.
- **`types.ts`** — `daemonDownloadConsented` flag.

## Verified
- `tsc --noEmit` → 0, `npm run lint` → 0
- DaemonDownloader 17 + ConnectionManager existing tests → pass

## Remaining 1.1.3 follow-ups (separate)
- exclude `manifest-beta.json` from the stable release asset
- artifact attestation in `release.yml`
- behavior justification (shell/clipboard usage review)
- README: document the auto-download

Refs #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)