### PR TITLE
fix(shadow): propagate source-vault secrets into the shadow vault (#399) — 1.1.3-beta.0

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.2",
+      "version": "1.1.3-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.2",
+  "version": "1.1.3-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -922,6 +922,23 @@ export default class RemoteSshPlugin extends Plugin {
     const manager = new ShadowVaultManager(bootstrap, spawner);
 
     try {
+      // #399: flush the in-memory SecretStore to the SOURCE data.json
+      // BEFORE the bootstrap reads it. A password typed in ConnectModal
+      // lives only in `secretStore` memory until a save; without this
+      // the bootstrap seeds the shadow vault with empty secrets and its
+      // auto-connect fails with "No password stored for profile",
+      // opening an empty vault. Also persists the profile's freshly-set
+      // passwordRef. On the Settings-button path (no password typed)
+      // this is a harmless idempotent re-write of the current settings.
+      // A transient save failure must NOT abort the spawn (the shadow
+      // may still connect from previously-persisted secrets), so it is
+      // logged and swallowed rather than surfaced as a spawn failure.
+      try {
+        await this.saveSettings();
+      } catch (e) {
+        logger.warn(`openShadowVaultFor: pre-spawn settings flush failed (${errorMessage(e)}); continuing to spawn`);
+      }
+
       const result = await manager.openShadowFor(profile, this.settings.profiles);
       const how = result.pluginInstallMethod;
       const reg = result.registryCreated ? 'newly registered' : 'reused';

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -21,6 +21,18 @@ function isNonEmptyArray(v: unknown): boolean {
 }
 
 /**
+ * Narrow an unknown `secrets` (or `hostKeyStore`) blob to a plain
+ * string-keyed record, defaulting to `{}` for anything that isn't a
+ * non-array object. Keeps the #399 secret-merge below total even when a
+ * data.json holds a malformed `secrets` value.
+ */
+function asSecretRecord(v: unknown): Record<string, unknown> {
+  return (v && typeof v === 'object' && !Array.isArray(v))
+    ? (v as Record<string, unknown>)
+    : {};
+}
+
+/**
  * Where the shadow vault for a given profile lives on disk.
  */
 export interface ShadowVaultLayout {
@@ -163,6 +175,25 @@ export class ShadowVaultBootstrap {
       activeProfileId: profile.id,
       autoConnectProfileId: profile.id,
     };
+
+    // #399: a password entered in the SOURCE (local) vault must reach
+    // the shadow vault that actually runs the connect. `readBaseDataJson`
+    // prefers the EXISTING shadow data.json, so a secret persisted to
+    // source AFTER the first bootstrap would otherwise never propagate —
+    // the shadow's auto-connect then dies with "No password stored for
+    // profile" and the vault opens empty. Union the source's secrets
+    // over whatever the shadow has accumulated: source wins on a
+    // conflicting ref (it's the user's latest, just flushed by
+    // openShadowVaultFor before this bootstrap), while a secret typed
+    // directly in the shadow window (a ref absent from source) survives.
+    const mergedSecrets = {
+      ...asSecretRecord(baseData.secrets),
+      ...this.readSourceSecrets(),
+    };
+    if (Object.keys(mergedSecrets).length > 0) {
+      data.secrets = mergedSecrets;
+    }
+
     if (isFirstBootstrap) {
       const pending = this.collectPendingPluginSuggestions();
       if (pending.length > 0) {
@@ -600,6 +631,35 @@ export class ShadowVaultBootstrap {
           'continuing without it',
         );
       }
+    }
+    return {};
+  }
+
+  /**
+   * Read just the `secrets` blob from the SOURCE vault's data.json.
+   *
+   * Used to propagate a password persisted in the source (local) vault
+   * into the shadow that runs the connect (#399). Unlike
+   * `readBaseDataJson` — which prefers the shadow's own copy so its
+   * accumulated state survives — this always reads source, so the merge
+   * in `bootstrapSync` can let the source's latest secret win.
+   *
+   * Returns `{}` when source has no data.json, it can't be parsed, or it
+   * carries no (well-formed) secrets — all benign "nothing to add" cases.
+   */
+  private readSourceSecrets(): Record<string, unknown> {
+    const sourceDataPath = path.join(this.sourcePluginDir, 'data.json');
+    if (!fs.existsSync(sourceDataPath)) return {};
+    try {
+      const parsed: unknown = JSON.parse(fs.readFileSync(sourceDataPath, 'utf-8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return asSecretRecord((parsed as Record<string, unknown>).secrets);
+      }
+    } catch (e) {
+      logger.warn(
+        `ShadowVaultBootstrap: failed to read source secrets (${errorMessage(e)}); ` +
+        'shadow will rely on its own accumulated secrets',
+      );
     }
     return {};
   }

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -222,6 +222,63 @@ describe('ShadowVaultBootstrap.bootstrap', () => {
     expect(after.autoConnectProfileId).toBe('p1');
   });
 
+  it('#399: re-bootstrap propagates a NEW source secret the shadow lacks (was: shadow opens empty / "No password stored")', async () => {
+    // Field bug #399: the password is entered/persisted in the SOURCE
+    // (local) vault AFTER the shadow vault was first bootstrapped. The
+    // shadow's data.json secrets stayed empty because readBaseDataJson
+    // prefers the existing shadow file and never re-reads source — so
+    // the shadow auto-connect died with "No password stored for
+    // profile" and the vault opened empty.
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1', authMethod: 'password', passwordRef: 'p1:password' });
+
+    // First bootstrap: source has no secret yet → shadow gets none.
+    const first = await r.bootstrap(profile, [profile]);
+    const afterFirst = JSON.parse(fs.readFileSync(first.layout.pluginDataFile, 'utf-8'));
+    expect(afterFirst.secrets?.['p1:password']).toBeUndefined();
+
+    // The user now types the password in the SOURCE vault; saveSettings
+    // flushes the encrypted blob into the source plugin's data.json.
+    fs.writeFileSync(path.join(scratch.sourceDir, 'data.json'), JSON.stringify({
+      secrets: { 'p1:password': { iv: 'aa', tag: 'bb', data: 'cc' } },
+    }), 'utf-8');
+
+    // Re-bootstrap (user clicks Connect again, or the shadow re-spawns).
+    await r.bootstrap(profile, [profile]);
+
+    const afterSecond = JSON.parse(fs.readFileSync(first.layout.pluginDataFile, 'utf-8'));
+    expect(afterSecond.secrets?.['p1:password']).toEqual({ iv: 'aa', tag: 'bb', data: 'cc' });
+  });
+
+  it('#399: secrets merge is a union — shadow-only entries survive, source wins on a conflicting ref', async () => {
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const profile = makeProfile({ id: 'p1', authMethod: 'password', passwordRef: 'p1:password' });
+    const first = await r.bootstrap(profile, [profile]);
+
+    // Shadow accumulated its own secret (e.g. a passphrase typed
+    // directly in the shadow window) AND holds a now-stale copy of a
+    // ref the user just re-entered in the source vault.
+    const shadow = JSON.parse(fs.readFileSync(first.layout.pluginDataFile, 'utf-8'));
+    shadow.secrets = {
+      'shadow-only:passphrase': { iv: '00', tag: '00', data: 'shadow' },
+      'p1:password':            { iv: '00', tag: '00', data: 'stale' },
+    };
+    fs.writeFileSync(first.layout.pluginDataFile, JSON.stringify(shadow, null, 2), 'utf-8');
+
+    // Source holds the authoritative (latest) blob for the shared ref.
+    fs.writeFileSync(path.join(scratch.sourceDir, 'data.json'), JSON.stringify({
+      secrets: { 'p1:password': { iv: 'ff', tag: 'ff', data: 'fresh' } },
+    }), 'utf-8');
+
+    await r.bootstrap(profile, [profile]);
+
+    const merged = JSON.parse(fs.readFileSync(first.layout.pluginDataFile, 'utf-8')).secrets;
+    // shadow-only entry preserved (union, not overwrite)
+    expect(merged['shadow-only:passphrase']).toEqual({ iv: '00', tag: '00', data: 'shadow' });
+    // source wins on the conflicting ref — it's the user's latest password
+    expect(merged['p1:password']).toEqual({ iv: 'ff', tag: 'ff', data: 'fresh' });
+  });
+
   it('regression: source plugin\'s data.json is NEVER touched by install, even on re-bootstrap', async () => {
     // Stage a sentinel data.json in the SOURCE plugin dir — this
     // mirrors the dev-vault setup where the developer's hostKeyStore /

--- a/plugin/tests/openShadowVaultFor.test.ts
+++ b/plugin/tests/openShadowVaultFor.test.ts
@@ -115,3 +115,43 @@ describe('openShadowVaultFor — shadowSpawnInFlight guard (#352)', () => {
     expect(recordedNotices().some((n) => /still opening/.test(n))).toBe(true);
   });
 });
+
+describe('openShadowVaultFor — secret flush before spawn (#399)', () => {
+  beforeEach(() => {
+    openShadowForMock.mockReset();
+    clearNotices();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('persists settings (flushing the in-memory password into data.json) BEFORE spawning the shadow', async () => {
+    const plugin = makePlugin();
+    openShadowForMock.mockResolvedValue(okResult());
+
+    // Obsidian's Plugin.saveData is the disk sink saveSettings() writes
+    // through; the mock Plugin base doesn't model it, so install a spy.
+    const saveData = vi.fn().mockResolvedValue(undefined);
+    (plugin as unknown as { saveData: typeof saveData }).saveData = saveData;
+
+    // Mirror ConnectModal: the user types a password, which the plugin's
+    // own authResolver persists into its in-memory SecretStore — but NOT
+    // yet to disk. The flush is what carries it to the source data.json
+    // that ShadowVaultBootstrap then reads.
+    (plugin as unknown as { authResolver: { persistSecret(ref: string, v: string): void } })
+      .authResolver.persistSecret('p1:password', 'hunter2');
+
+    await plugin.openShadowVaultFor(profile);
+
+    // The flush must happen, and BEFORE the shadow spawn — otherwise the
+    // bootstrap reads a source data.json whose secrets are still empty
+    // and the shadow auto-connect dies with "No password stored".
+    expect(saveData).toHaveBeenCalledTimes(1);
+    const written = saveData.mock.calls[0][0] as { secrets?: Record<string, unknown> };
+    expect(written.secrets?.['p1:password']).toBeDefined();
+    expect(saveData.mock.invocationCallOrder[0])
+      .toBeLessThan(openShadowForMock.mock.invocationCallOrder[0]);
+  });
+});


### PR DESCRIPTION
## What & why

Fixes the primary bug in #399: connecting opened an **empty shadow vault** and the log showed `No password stored for profile "…"`. The password entered in the source (local) vault never reached the shadow vault that actually runs the SSH connect.

This is **not** a 1.1.0→1.1.1 regression — the entire `1.1.0..1.1.1` `plugin/src` diff is the mechanical `activeWindow → window` timer swap and never touches secrets/auth/shadow. The gap has existed since the shadow-vault architecture.

## Root cause

The shadow vault reads its password from its own `data.json` `secrets` blob, but the source secret never propagated there:

1. `ConnectModal.persistSecret` writes the password only to the in-memory `SecretStore`. `openShadowVaultFor` spawned the shadow **before** any `saveSettings()`, so `ShadowVaultBootstrap` read a source `data.json` whose `secrets` were still empty.
2. `readBaseDataJson` prefers the **existing** shadow `data.json` on re-bootstrap, so even a persisted source secret never propagated after the first spawn.

(The Settings "Connect" button has no password prompt at all, so it relied entirely on the source secret already being present.)

## Fix

- **`main.ts` `openShadowVaultFor`** — `await this.saveSettings()` before the spawn, flushing the in-memory password + freshly-set `passwordRef` into the source `data.json` the bootstrap reads. A save failure is logged and swallowed (never aborts the spawn).
- **`ShadowVaultBootstrap.bootstrapSync`** — union the source vault's `secrets` into the shadow `data.json` on every bootstrap. Source wins on a conflicting ref (the user's latest); a secret typed directly in the shadow window (a ref absent from source) survives.

## Tests (red before the fix)

- `ShadowVaultBootstrap`: re-bootstrap propagates a new source secret the shadow lacks; union precedence (shadow-only survives, source wins on conflict).
- `openShadowVaultFor`: settings are flushed before the shadow spawn.

Full unit suite green (1093 passed / 1 skipped); lint + `tsc --noEmit` + production build all clean.

## Scope / out of scope

- Scoped to **`secrets`** propagation. The `hostKeyStore` source→shadow gap is the same shape but separate; left as a possible follow-up.
- The **second** bug in #399 (RPC daemon binary not staged → `daemon binary not staged`) is tracked by #397 and the `feat/daemon-autodownload` branch — not addressed here.

## Release

`1.1.3-beta.0` — first beta of the 1.1.3 cycle (BRAT `--beta` channel). Stable `manifest.json` + `versions.json` stay pinned to 1.1.2.

Refs #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)
