### PR TITLE
test(daemon): RPC→SFTP downgrade coverage + deferred-hardening specs (#406) — 1.1.3-beta.2

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.3-beta.1",
+  "version": "1.1.3-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.3-beta.1",
+  "version": "1.1.3-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.3-beta.1",
+  "version": "1.1.3-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.3-beta.1",
+      "version": "1.1.3-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.3-beta.1",
+  "version": "1.1.3-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/tests/ConnectionManager.test.ts
+++ b/plugin/tests/ConnectionManager.test.ts
@@ -207,4 +207,29 @@ describe('ConnectionManager.startRpcSession — daemon binary fallback (#397)', 
     expect(ensureDaemonBinary).not.toHaveBeenCalled();
     expect(deployMock.mock.calls[0][0]).toMatchObject({ localBinaryPath: '/local/daemon' });
   });
+
+  it('#406 I-1: a reconnect downgrades to SFTP when the daemon is unavailable (does NOT throw into the retry loop)', async () => {
+    const ensureDaemonBinary = vi.fn().mockResolvedValue(null);
+    const client = { isAlive: vi.fn().mockReturnValue(true) } as unknown as ConstructorParameters<typeof ConnectionManager>[0];
+    const mgr = new ConnectionManager(client, { locateDaemonBinary: () => null, ensureDaemonBinary });
+    // reconnectAttempt reads activeProfile; seed an RPC one directly.
+    (mgr as unknown as { activeProfile: SshProfile }).activeProfile = { ...profile, transport: 'rpc' } as SshProfile;
+    const hooks = {
+      swapClient: vi.fn(),
+      prepareListenerForReconnect: vi.fn(),
+      resumeListenerAfterReconnect: vi.fn(),
+    };
+
+    // reconnectAttempt is private — invoke via cast. It must RESOLVE, not
+    // reject: a DaemonUnavailableError on reconnect is caught and the session
+    // continues on SFTP, rather than bubbling to ReconnectManager's retry loop
+    // (which would burn maxRetries and re-prompt consent).
+    await expect(
+      (mgr as unknown as { reconnectAttempt(h: typeof hooks): Promise<void> }).reconnectAttempt(hooks),
+    ).resolves.toBeUndefined();
+
+    expect(ensureDaemonBinary).toHaveBeenCalledTimes(1);
+    expect(mgr.rpcConnection).toBeNull();              // stayed on SFTP
+    expect(hooks.swapClient).toHaveBeenCalledTimes(1); // rebound to the SFTP fs client
+  });
 });

--- a/plugin/tests/ConnectionManager.test.ts
+++ b/plugin/tests/ConnectionManager.test.ts
@@ -223,7 +223,8 @@ describe('ConnectionManager.startRpcSession — daemon binary fallback (#397)', 
     // reconnectAttempt is private — invoke via cast. It must RESOLVE, not
     // reject: a DaemonUnavailableError on reconnect is caught and the session
     // continues on SFTP, rather than bubbling to ReconnectManager's retry loop
-    // (which would burn maxRetries and re-prompt consent).
+    // (which would burn maxRetries and surface a misleading "reconnect failed"
+    // instead of switching to SFTP).
     await expect(
       (mgr as unknown as { reconnectAttempt(h: typeof hooks): Promise<void> }).reconnectAttempt(hooks),
     ).resolves.toBeUndefined();

--- a/plugin/tests/DaemonDownloader.test.ts
+++ b/plugin/tests/DaemonDownloader.test.ts
@@ -177,3 +177,11 @@ describe('resolveDaemonConsent', () => {
     expect(persisted).toEqual([false]);
   });
 });
+
+// Deferred #406-review hardening, kept as executable specs (runnable TODOs)
+// in place of tracking issues — unskip and implement when prioritized.
+describe('deferred hardening (#406 review)', () => {
+  it.todo('verifies the cosign .bundle (sigstore) against the GitHub OIDC identity before deploy — closes the MITM gap that sha256-from-the-same-channel leaves open');
+  it.todo('shares the daemon binary cache across vaults/profiles (e.g. ~/.obsidian-remote/server-bin) so a second profile reuses the first download + single consent');
+  it.todo('re-verifies a cache-hit binary against its sha256 before reuse — defends post-write on-disk corruption (the atomic tmp+rename write already closes the mid-download crash window)');
+});

--- a/plugin/tests/connectProfile.daemon-downgrade.test.ts
+++ b/plugin/tests/connectProfile.daemon-downgrade.test.ts
@@ -26,41 +26,51 @@ const rpcProfile = {
 function makePlugin(err: Error) {
   const plugin = new RemoteSshPlugin(new App() as never) as RemoteSshPlugin;
   const disconnect = vi.fn().mockResolvedValue(undefined);
-  (plugin as unknown as { settings: unknown }).settings = { profiles: [rpcProfile], activeProfileId: null };
-  (plugin as unknown as { saveData: () => Promise<void> }).saveData = vi.fn().mockResolvedValue(undefined);
-  (plugin as unknown as { conn: unknown }).conn = {
+  const conn = {
     isAlive: () => false,
     connectSsh: vi.fn().mockResolvedValue(undefined),
     startRpcSession: vi.fn().mockRejectedValue(err),
     rpcConnection: null,
     client: { disconnect },
   };
-  (plugin as unknown as { adapterMgr: unknown }).adapterMgr = {
-    patch: vi.fn().mockResolvedValue(true),
-    replayOfflineQueue: vi.fn(),
+  const p = plugin as unknown as {
+    settings: unknown;
+    saveData: () => Promise<void>;
+    conn: unknown;
+    adapterMgr: unknown;
   };
-  return { plugin, disconnect };
+  p.settings = { profiles: [rpcProfile], activeProfileId: null };
+  p.saveData = vi.fn().mockResolvedValue(undefined);
+  p.conn = conn;
+  p.adapterMgr = { patch: vi.fn().mockResolvedValue(true), replayOfflineQueue: vi.fn().mockResolvedValue(undefined) };
+  return { plugin, conn, disconnect };
 }
 
 describe('connectProfile — RPC daemon failure handling (#399 / #406)', () => {
   beforeEach(() => clearNotices());
 
   it('downgrades to SFTP and still reaches CONNECTED when the daemon is unavailable', async () => {
-    const { plugin, disconnect } = makePlugin(new DaemonUnavailableError('remote arch unsupported'));
+    const { plugin, conn, disconnect } = makePlugin(new DaemonUnavailableError('remote arch unsupported'));
 
     await plugin.connectProfile(rpcProfile);
 
+    expect(conn.connectSsh).toHaveBeenCalledWith(rpcProfile);  // the SSH connect was really attempted
     expect(plugin.isConnected()).toBe(true);                   // connected, not errored out
     expect(disconnect).not.toHaveBeenCalled();                 // SSH session kept for SFTP
     expect(recordedNotices().some((n) => /SFTP/i.test(n))).toBe(true);
   });
 
   it('fails LOUD (no silent SFTP downgrade) when daemon verification fails', async () => {
-    const { plugin, disconnect } = makePlugin(new DaemonVerificationError('sha256 mismatch'));
+    const { plugin, conn, disconnect } = makePlugin(new DaemonVerificationError('sha256 mismatch'));
 
     await plugin.connectProfile(rpcProfile);
 
+    expect(conn.connectSsh).toHaveBeenCalledWith(rpcProfile);  // got past connect, into RPC startup
     expect(plugin.isConnected()).toBe(false);                  // ERROR, not CONNECTED
     expect(disconnect).toHaveBeenCalledTimes(1);               // connection torn down
+    // "loud" = a classified error Notice surfaced AND it did NOT take the
+    // silent SFTP-downgrade path (that path emits a distinct "via SFTP" notice).
+    expect(recordedNotices().length).toBeGreaterThan(0);
+    expect(recordedNotices().some((n) => /SFTP/i.test(n))).toBe(false);
   });
 });

--- a/plugin/tests/connectProfile.daemon-downgrade.test.ts
+++ b/plugin/tests/connectProfile.daemon-downgrade.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Importing main.ts pulls in RemoteTerminalView (extends the obsidian
+// ItemView, which the unit-test obsidian mock doesn't model). Stub the leaf
+// so the import graph resolves — the same shim openShadowVaultFor.test.ts uses.
+vi.mock('../src/ui/RemoteTerminalView', () => ({
+  RemoteTerminalView: class {},
+  VIEW_TYPE_REMOTE_TERMINAL: 'remote-terminal',
+}));
+
+import { App, recordedNotices, clearNotices } from 'obsidian';
+import RemoteSshPlugin from '../src/main';
+import { DaemonUnavailableError } from '../src/ConnectionManager';
+import { DaemonVerificationError } from '../src/transport/DaemonDownloader';
+import type { SshProfile } from '../src/types';
+
+const rpcProfile = {
+  id: 'p1', name: 'Prod', host: 'h', port: 22, username: 'u',
+  remotePath: '~/v', transport: 'rpc', authMethod: 'agent',
+} as unknown as SshProfile;
+
+// Build a plugin whose ConnectionManager fails the RPC startup with `err`,
+// with every other connectProfile collaborator stubbed to succeed. Exercises
+// the REAL connectProfile control flow; only the transport/adapter
+// collaborators are mocked. Returns the disconnect spy for teardown asserts.
+function makePlugin(err: Error) {
+  const plugin = new RemoteSshPlugin(new App() as never) as RemoteSshPlugin;
+  const disconnect = vi.fn().mockResolvedValue(undefined);
+  (plugin as unknown as { settings: unknown }).settings = { profiles: [rpcProfile], activeProfileId: null };
+  (plugin as unknown as { saveData: () => Promise<void> }).saveData = vi.fn().mockResolvedValue(undefined);
+  (plugin as unknown as { conn: unknown }).conn = {
+    isAlive: () => false,
+    connectSsh: vi.fn().mockResolvedValue(undefined),
+    startRpcSession: vi.fn().mockRejectedValue(err),
+    rpcConnection: null,
+    client: { disconnect },
+  };
+  (plugin as unknown as { adapterMgr: unknown }).adapterMgr = {
+    patch: vi.fn().mockResolvedValue(true),
+    replayOfflineQueue: vi.fn(),
+  };
+  return { plugin, disconnect };
+}
+
+describe('connectProfile — RPC daemon failure handling (#399 / #406)', () => {
+  beforeEach(() => clearNotices());
+
+  it('downgrades to SFTP and still reaches CONNECTED when the daemon is unavailable', async () => {
+    const { plugin, disconnect } = makePlugin(new DaemonUnavailableError('remote arch unsupported'));
+
+    await plugin.connectProfile(rpcProfile);
+
+    expect(plugin.isConnected()).toBe(true);                   // connected, not errored out
+    expect(disconnect).not.toHaveBeenCalled();                 // SSH session kept for SFTP
+    expect(recordedNotices().some((n) => /SFTP/i.test(n))).toBe(true);
+  });
+
+  it('fails LOUD (no silent SFTP downgrade) when daemon verification fails', async () => {
+    const { plugin, disconnect } = makePlugin(new DaemonVerificationError('sha256 mismatch'));
+
+    await plugin.connectProfile(rpcProfile);
+
+    expect(plugin.isConnected()).toBe(false);                  // ERROR, not CONNECTED
+    expect(disconnect).toHaveBeenCalledTimes(1);               // connection torn down
+  });
+});


### PR DESCRIPTION
Follow-up to the #406 review: encode the deferred items as **test code instead of tracking issues** — real tests for behavior that exists but lacked coverage, and `it.todo` executable specs for the not-yet-implemented hardening.

## New / changed coverage (real, green)

- **`connectProfile.daemon-downgrade.test.ts`** (new) — exercises the real `RemoteSshPlugin.connectProfile` (only the transport/adapter collaborators are mocked):
  - a `DaemonUnavailableError` → session **downgrades to SFTP and still reaches CONNECTED** (SSH kept, "via SFTP" notice).
  - a `DaemonVerificationError` → **fails loud** (ERROR state + `disconnect()`), NOT a silent downgrade — pins the I-3 boundary from the review.
- **`ConnectionManager.test.ts`** — `reconnectAttempt` catches `DaemonUnavailableError` and continues on SFTP (`rpcConnection` stays null, fs client rebinds) instead of throwing into `ReconnectManager`'s retry loop — pins I-1, which was previously fixed in source but untested.

## Deferred hardening — executable specs (`it.todo`)

In `DaemonDownloader.test.ts`, as runnable trackers (show as `todo` in the runner) rather than issues that rot:

1. cosign `.bundle` (sigstore) verification before deploy — closes the MITM gap that sha256-from-the-same-channel leaves open.
2. shared cross-vault binary cache (`~/.obsidian-remote/server-bin`) — one download + one consent across profiles.
3. cache-hit re-verification against sha256 — defends post-write on-disk corruption (the atomic tmp+rename write already closes the mid-download crash window).

## Checks

Tests-only; no production change. Full unit suite green: **1120 passed / 1 skipped / 3 todo**; `npm run lint` + `tsc --noEmit` clean.

(The earlier real-asset contract check — fetching the actual `1.1.3-beta.1` `daemon-manifest.json` + `obsidian-remote-server-linux-amd64` and verifying the real sha256 — also passed, confirming the `release.yml` ↔ `DaemonDownloader` contract holds on published artifacts.)

Refs #397, #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
