### PR TITLE
fix(shadow): restart guidance on first connect to a new profile — 1.1.4-beta.0

### DIFF
--- a/docs/en/getting-started/first-connect.md
+++ b/docs/en/getting-started/first-connect.md
@@ -10,7 +10,7 @@ description: "What happens when you click Connect: SSH handshake, daemon auto-de
 
 obsidian-remote-ssh does not edit your remote files directly through Obsidian's vault layer. Instead it:
 
-1. Creates a **local shadow vault** under `<plugin-dir>/shadow-vaults/<profile-id>/`. This is a real Obsidian vault on your local disk.
+1. Creates a **local shadow vault** under `~/.obsidian-remote/vaults/<profile-id>/`. This is a real Obsidian vault on your local disk.
 2. Mirrors the remote vault's files into that shadow vault (lazily — large files are fetched on first open).
 3. Watches both sides for changes and syncs them through the SSH-tunneled daemon RPC.
 
@@ -78,6 +78,11 @@ sequenceDiagram
   D-->>P: {version, protocolVersion, vaultRoot}
   P->>U: open shadow vault window
 ```
+
+> [!important] The first connect to a new profile needs an Obsidian restart
+> The shadow vault is added to Obsidian's vault list (`obsidian.json`) the first time you connect a profile. A **running** Obsidian only reads that list **at startup**, so the brand-new vault window can't open in the current session — clicking Connect appears to do nothing (the SSH connection itself succeeds; only the window doesn't appear).
+>
+> **Fully quit and reopen Obsidian, then click Connect again.** This is a one-time step per profile — every later connect opens the window immediately.
 
 ## After connect
 

--- a/docs/en/operations/troubleshooting.md
+++ b/docs/en/operations/troubleshooting.md
@@ -18,6 +18,12 @@ Most failures fall into a small number of buckets. This page maps symptom to lik
 | `Connection timeout` | Network / firewall | Same hop reachable via `ping`? sshd port open in firewall? |
 | `Daemon failed to start` (after binary upload) | Daemon crashed at startup | See **Daemon won't start** below |
 
+## Clicked Connect but no window opened (new profile)
+
+The **first** time you connect a newly-added profile, the remote vault window may not appear even though the connection itself succeeded (the plugin log shows `SSH ready`). The new shadow vault is registered in Obsidian's vault list (`obsidian.json`), but a running Obsidian only reads that list **at startup** — so it can't open the brand-new vault in the current session.
+
+**Fix:** fully quit and reopen Obsidian, then click Connect again. This is a one-time step per profile; every later connect opens the window immediately.
+
 ## Daemon won't start
 
 Check the daemon log: **Settings** → **Daemon** → "View log", or directly:

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.3",
+  "version": "1.1.4-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.3",
+  "version": "1.1.4-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.3",
+  "version": "1.1.4-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.3",
+      "version": "1.1.4-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.3",
+  "version": "1.1.4-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -961,11 +961,28 @@ export default class RemoteSshPlugin extends Plugin {
       const result = await manager.openShadowFor(profile, this.settings.profiles);
       const how = result.pluginInstallMethod;
       const reg = result.registryCreated ? 'newly registered' : 'reused';
-      new Notice(`Remote SSH: opened ${profile.name} in new window (${how}, ${reg})`);
       logger.info(
         `openShadowVaultFor: profile=${profile.name}, vault=${result.layout.vaultDir}, ` +
         `registry id=${result.registryId} (${reg}), plugin=${how}`,
       );
+      if (result.registryCreated) {
+        // First-ever open of this profile: the vault was just added to
+        // obsidian.json, but the already-running Obsidian only reads that
+        // file at startup — so the obsidian://open we just fired is a no-op
+        // and no window appears. Surface a PERSISTENT notice (duration 0)
+        // telling the user to restart, rather than the misleading "opened in
+        // new window" that never actually opened. Only happens once per
+        // profile (subsequent connects hit the `reused` branch).
+        new Notice(
+          `Remote SSH: "${profile.name}" is a newly registered vault. Obsidian only ` +
+          'loads new vaults at startup, so it cannot open it this session — fully ' +
+          'quit and reopen Obsidian, then click Connect again. (Only needed the ' +
+          'first time you open a profile.)',
+          0,
+        );
+      } else {
+        new Notice(`Remote SSH: opened ${profile.name} in new window (${how})`);
+      }
       // Spawn SUCCEEDED. The new window can take several seconds to
       // surface while Obsidian keeps THIS one focused — hold the guard
       // ~15s so an impatient double/triple-click can't fire a second

--- a/plugin/tests/openShadowVaultFor.test.ts
+++ b/plugin/tests/openShadowVaultFor.test.ts
@@ -155,3 +155,38 @@ describe('openShadowVaultFor — secret flush before spawn (#399)', () => {
       .toBeLessThan(openShadowForMock.mock.invocationCallOrder[0]);
   });
 });
+
+describe('openShadowVaultFor — new-vault restart guidance', () => {
+  beforeEach(() => {
+    openShadowForMock.mockReset();
+    clearNotices();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('tells the user to restart when the shadow vault was newly registered', async () => {
+    const plugin = makePlugin();
+    openShadowForMock.mockResolvedValue({ ...okResult(), registryCreated: true });
+
+    await plugin.openShadowVaultFor(profile);
+
+    // A freshly-registered vault can't open until Obsidian restarts (it caches
+    // obsidian.json at startup) — the user must be told, not shown a misleading
+    // "opened in new window" for a window that never appeared.
+    expect(recordedNotices().some((n) => /restart|quit and reopen/i.test(n))).toBe(true);
+    expect(recordedNotices().some((n) => /opened .* in new window/i.test(n))).toBe(false);
+  });
+
+  it('reports the opened window (no restart notice) when the vault was reused', async () => {
+    const plugin = makePlugin();
+    openShadowForMock.mockResolvedValue({ ...okResult(), registryCreated: false });
+
+    await plugin.openShadowVaultFor(profile);
+
+    expect(recordedNotices().some((n) => /opened .* in new window/i.test(n))).toBe(true);
+    expect(recordedNotices().some((n) => /restart|quit and reopen/i.test(n))).toBe(false);
+  });
+});


### PR DESCRIPTION
First beta of the 1.1.4 cycle (opened after 1.1.3 stable shipped). Fixes the **new-profile first-connect** friction surfaced while dogfooding 1.1.3.

## The bug (dogfound)

Connecting a **newly-added** profile appeared to do nothing — no vault window opened — even though the SSH connection itself succeeded. Root cause: the shadow vault is registered in Obsidian's vault list (`obsidian.json`) on first connect, but a **running** Obsidian only reads that file **at startup**, so the `obsidian://open` we fire is a no-op for a vault it hasn't loaded. A full restart (re-reads `obsidian.json`) fixes it. Confirmed from the field log: two Connect clicks 17 s apart both failed to open → not a race, it's the startup-cached vault list.

The plugin made this worse by showing a misleading **"opened in new window"** notice for a window that never appeared.

## Fix (option B — the safe, no-internal-API path)

`openShadowVaultFor` branches on `result.registryCreated`:
- **newly registered** → a **persistent notice** (duration 0): _“… is a newly registered vault. Obsidian only loads new vaults at startup … fully quit and reopen Obsidian, then click Connect again. (Only needed the first time you open a profile.)”_
- **reused** → the normal "opened in new window" notice.

This is a one-time-per-profile message; it turns a silent no-op into a clear instruction. (A seamless fix that opens the vault live without a restart would need Obsidian's undocumented vault-open IPC — tracked separately as a follow-up.)

## Docs

- `getting-started/first-connect.md`: an `[!important]` callout explaining the first-connect restart requirement; also fixed a stale shadow-vault path (`<plugin-dir>/shadow-vaults/` → `~/.obsidian-remote/vaults/`).
- `operations/troubleshooting.md`: a "Clicked Connect but no window opened (new profile)" symptom → fix entry.

## Tests / checks

`openShadowVaultFor`: newly-registered → restart notice (and NOT "opened in new window"); reused → "opened in new window" (and no restart notice). Full suite green (1122 passed / 1 skipped / 3 todo); lint + `tsc --noEmit` clean.

## Not in scope

The seamless live-open (Electron IPC to the running main process) — higher risk / undocumented API; worth a follow-up issue + probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
