### PR TITLE
ci(release): aggregate beta-cycle changelog into stable release notes — 1.1.4-beta.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -294,31 +294,49 @@ jobs:
           }
           console.log("Dynamic code execution guard passed.");'
 
+      # Changelog range depends on the release channel:
+      #   • beta   → `--unreleased` = commits since the previous tag (the
+      #     prior beta), so each beta release lists only its own new commits.
+      #   • stable → the previous tag is the last BETA of this cycle, so
+      #     `--unreleased` would capture only the promote-plumbing commits
+      #     (all filtered by cliff.toml) → an EMPTY changelog. Instead span
+      #     the whole cycle since the last STABLE tag, so the stable release
+      #     notes carry everything accumulated across the betas.
+      # (`--tag` shows the about-to-be-created version in the heading; the tag
+      # itself doesn't exist yet — softprops creates it below. `--strip
+      # header` drops cliff's own `# Changelog` header.)
+      - name: Compute changelog range
+        id: clog_range
+        shell: bash
+        run: |
+          VER="${{ needs.precheck.outputs.version }}"
+          if [ "${{ needs.precheck.outputs.is_beta }}" = "true" ]; then
+            echo "args=--unreleased --tag $VER --strip header" >> "$GITHUB_OUTPUT"
+          else
+            LAST_STABLE=$(git tag --sort=-v:refname | grep -vE -- '-beta\.' | head -1)
+            echo "Last stable tag: ${LAST_STABLE:-<none>}"
+            if [ -n "$LAST_STABLE" ]; then
+              # `--ignore-tags beta`: the intermediate beta tags of this cycle
+              # sit inside the range; without this git-cliff splits the output
+              # per-tag (repeated group headings). Ignoring them consolidates
+              # everything under the single stable version heading.
+              echo "args=--tag $VER --strip header --ignore-tags beta ${LAST_STABLE}..HEAD" >> "$GITHUB_OUTPUT"
+            else
+              echo "args=--unreleased --tag $VER --strip header" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
       - name: Generate changelog (git-cliff, grouped by Conventional Commits type)
         id: changelog
-        # `--unreleased` (NOT `--latest`): the new tag for this run
-        # doesn't exist at this step — softprops creates it below —
-        # so `--latest` would resolve to the *previous* tag and emit
-        # the *previous* version's changelog (broken in 0.4.61). We
-        # want everything between the most recent tag and HEAD, which
-        # is exactly what `--unreleased` returns. `--tag` lets git-cliff
-        # show the about-to-be-created version in headings.
-        # `--strip header` drops cliff's own `# Changelog` header so
-        # the body slots cleanly under the "## What's changed" line
-        # the release body builds below.
-        # cliff.toml at repo root holds the grouping config (✨ Features
-        # / 🐛 Bug Fixes / 🚧 CI / etc.) and the Dependabot-noise
-        # suppression.
-        #
-        # Pinned to @v4 (not @v3): @v3's Dockerfile sits on the
-        # Debian Buster base image, and Buster reached EOL in
-        # 2024-06 — `deb.debian.org` now returns 404 for its
-        # `apt-get install jq` step, breaking every release run.
-        # @v4 is on a current Debian base.
+        # Pinned to @v4 (not @v3): @v3's Dockerfile sits on the Debian Buster
+        # base image (EOL 2024-06) — `deb.debian.org` now 404s its
+        # `apt-get install jq` step, breaking every release run. @v4 is on a
+        # current Debian base. cliff.toml holds the grouping + Dependabot /
+        # version-bump suppression.
         uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
-          args: --unreleased --tag ${{ needs.precheck.outputs.version }} --strip header
+          args: ${{ steps.clog_range.outputs.args }}
 
       - name: Create GitHub Release (creates tag too)
         uses: softprops/action-gh-release@v3

--- a/cliff.toml
+++ b/cliff.toml
@@ -58,6 +58,7 @@ commit_parsers = [
   { message = "^revert",   group = "⏪ Reverts" },
   { message = "^style",    skip = true },           # whitespace / formatting only
   { message = "^chore\\(deps", skip = true },        # Dependabot noise — drop entirely
+  { message = "^chore\\(release", skip = true },      # version-bump commits (chore(release): X-beta.N / X.Y.Z) — drop; plumbing, not user-facing changes
   { message = "^chore",    group = "🧹 Chores" },   # other chore commits (incl. scoped) — keep
   { message = "^release",  skip = true },           # auto-tag commits (legacy, kept defensively)
 ]

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.4-beta.0",
+  "version": "1.1.4-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.4-beta.0",
+  "version": "1.1.4-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.4-beta.0",
+  "version": "1.1.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.4-beta.0",
+      "version": "1.1.4-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.4-beta.0",
+  "version": "1.1.4-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Automates what was discussed after the 1.1.3 release review: **stable releases should carry the changelog accumulated across the cycle's beta bumps** (the 1.1.3 release shipped with an empty description).

## Root cause
The changelog step used `git-cliff --unreleased` = commits since the previous **tag**. For a stable promotion the previous tag is the last **beta** of the cycle, so the range held only promote-plumbing commits — all filtered by `cliff.toml` → **empty body**.

## Change
`release.yml` now branches the changelog range by channel:
- **beta** → `--unreleased` (incremental since the prior beta — unchanged).
- **stable** → `<last-stable-tag>..HEAD --ignore-tags beta` — spans the whole cycle since the previous **stable** tag, consolidated under one version heading (`--ignore-tags beta` stops git-cliff splitting the output into repeated per-beta-tag sections).

`cliff.toml`: also skip `chore(release):` version-bump commits so the notes show real changes, not bump plumbing.

## Verification
Ran `git-cliff` locally over `1.1.2..1.1.3` with the new config + `--ignore-tags beta`:
- one consolidated set of grouped sections (✨ Features / 🐛 Bug Fixes / 🧪 Tests / 📦 Build / 🧹 Chores),
- `chore(release): *-beta.N` commits dropped,
- `release.yml` re-validated as well-formed YAML.

The range is clean on **main**'s topology (only stable promote-merges sit between stable tags) — and the real release job runs on main. (A local run on this `next`-based branch shows some prior-cycle commits leaking in due to the next/main merge topology; that doesn't occur at release time on main.)

## Not included (separate / informational)
- The existing **1.1.3** release description (empty) — I'll backfill it directly via `gh release edit` since it predates this automation.
- "Extra unsupported files" recommendation: the daemon binaries + `daemon-manifest.json` are **required** for the #397 auto-download (Obsidian ignores them; the plugin fetches them at runtime). `manifest-beta.json` on stable is harmless; conditioning it is a low-value follow-up.
- Artifact attestations for `main.js`/`styles.css`: separate (adds `id-token` CI permissions) — can do if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
