### PR TITLE
docs: README refresh — value-first, badges last — 1.1.5-beta.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,210 +1,110 @@
 # Remote SSH for Obsidian
 
-[![CI](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/ci.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/ci.yml)
-[![Integration](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/integration.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/integration.yml)
-[![Security](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/security.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/sotashimozono/obsidian-remote-ssh/branch/next/graph/badge.svg)](https://codecov.io/gh/sotashimozono/obsidian-remote-ssh)
-[![Docs](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/docs.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/docs.yml)
-
-[![GitHub release](https://img.shields.io/github/v/release/sotashimozono/obsidian-remote-ssh?display_name=tag&sort=semver)](https://github.com/sotashimozono/obsidian-remote-ssh/releases)
-[![Downloads](https://img.shields.io/github/downloads/sotashimozono/obsidian-remote-ssh/total)](https://github.com/sotashimozono/obsidian-remote-ssh/releases)
-[![Open issues](https://img.shields.io/github/issues/sotashimozono/obsidian-remote-ssh)](https://github.com/sotashimozono/obsidian-remote-ssh/issues)
-
-[![Docs (stable)](https://img.shields.io/badge/docs-stable-7b5ea7?logo=obsidian&logoColor=white)](http://codes.sota-shimozono.com/obsidian-remote-ssh/)
-[![Docs (dev preview)](https://img.shields.io/badge/docs-dev_preview-9b7ec8?logo=obsidian&logoColor=white)](http://codes.sota-shimozono.com/obsidian-remote-ssh/dev/)
-
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Obsidian 1.5+](https://img.shields.io/badge/Obsidian-1.5+-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md)
-[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
-[![Node 20+](https://img.shields.io/badge/Node-20+-339933?logo=node.js&logoColor=white)](https://nodejs.org)
-![Platforms: linux · macOS · amd64 · arm64](https://img.shields.io/badge/platforms-linux%20%7C%20macOS%20%C2%B7%20amd64%20%7C%20arm64-555)
-
-> **A VS Code Remote-SSH-style experience for Obsidian.** Open a vault that
-> lives on a remote SSH host, edit it from a real Obsidian window. Files,
-> attachments, search, and live updates — all served from the remote,
-> transparently.
+> **Edit an Obsidian vault that lives on a remote server — over plain SSH.**
+> Think of VS Code's Remote-SSH, but for Obsidian: open a vault that sits on
+> your home server, VPS, work box, or cluster, and edit it from a real
+> Obsidian window. Files, attachments, search, and live updates — all served
+> straight from the remote, over your own SSH connection.
 >
-> _Status: 1.0 released — daemon binaries cosign-signed, end-to-end tested
-> against Linux + macOS remotes. Community-store listing pending review
-> ([obsidianmd/obsidian-releases#12390](https://github.com/obsidianmd/obsidian-releases/pull/12390));
-> install via BRAT or manual release until it lands._
+> **No cloud. No sync service. No full copy left on your laptop.** Your notes
+> stay on the machine you control; this one only ever holds what you're
+> actively looking at.
 
-> 📦 **Installing?** Grab the latest from the
-> [**Releases page**](https://github.com/sotashimozono/obsidian-remote-ssh/releases)
-> (stable artefacts, signed binaries) — or jump to the [Install](#install) section
-> below for BRAT / manual instructions. The repo's default view tracks the
-> integration branch (`next`); the [`main`](https://github.com/sotashimozono/obsidian-remote-ssh/tree/main)
-> branch holds the latest stable cut.
+![Demo: connect to a remote vault and edit it live](https://raw.githubusercontent.com/sotashimozono/obsidian-remote-ssh/media/demo.gif)
 
-![Demo: connect to a remote vault and edit](https://raw.githubusercontent.com/sotashimozono/obsidian-remote-ssh/media/demo.gif)
-
-<sub>Recorded in CI by <a href=".github/workflows/demo-capture.yml"><code>demo-capture.yml</code></a> — re-run on demand.</sub>
-
----
-
-## What you can do
-
-- **Edit a remote vault as if it were local.** SSH in to your home server,
-  cloud VPS, or work box. The vault stays on the remote; you get the full
-  Obsidian editor experience locally — no manual `rsync`, no Dropbox dance.
-- **Use the plugins you already love.** Dataview, Templater, Excalidraw,
-  Tasks, and most plugins that go through Obsidian's vault API work
-  unchanged. (Compatibility matrix:
-  [docs/en/user-guide/plugin-compatibility.md](docs/en/user-guide/plugin-compatibility.md).)
-- **Edit from multiple machines.** Live updates push between connected
-  clients via `fs.watch`; conflicting saves trigger a 3-way merge UI
-  with ancestor / mine / theirs panes.
-- **Survive flaky networks.** Disconnects spool writes into an offline
-  queue; reconnect drains them automatically. The status bar shows the
-  pending count.
-- **Bring your own SSH setup.** Password, private key, agent forwarding,
-  jump host (`ProxyJump`) — all use the same `~/.ssh/config` your
-  terminal does.
-
----
-
-## Why this plugin (vs the alternatives)
-
-Most "edit my vault from anywhere" tooling for Obsidian falls into one
-of three buckets. Each is a great fit for its own use case; this plugin
-sits in a different niche.
-
-### Obsidian Sync (official, paid)
-
-Obsidian's first-party sync service. End-to-end encrypted, zero-config,
-official support, version history. Lives on Obsidian's servers — the
-vault is replicated to every device that has Sync enabled.
-
-**Use it when** you want managed sync, are happy with the subscription,
-and don't need the vault on a specific machine you control.
-
-### File-sync tools (Syncthing, Dropbox, iCloud, OneDrive, …)
-
-The vault is a folder on disk; some external sync tool replicates that
-folder across machines. Each Obsidian instance opens a local copy.
-
-**Use it when** you already run such a tool and the vault fits
-naturally into your existing sync setup.
-
-### `obsidian-git` (community plugin)
-
-Treats the vault as a git repo and runs `git pull` / `commit` / `push`
-against it. The repo lives on your local disk; the remote is GitHub or
-a self-hosted git server.
-
-**Use it when** you want git history per save and are comfortable
-resolving merge conflicts in a terminal.
-
-### `obsidian-remote-ssh` (this plugin) — the niche
-
-The vault **only ever lives on a remote SSH host you control**. There
-is no second copy. Reads and writes go through a small Go daemon the
-plugin auto-deploys on first connect; your local Obsidian opens a
-"shadow" window showing a real-time view of the remote files.
-
-**Use it when:**
-
-- The vault is bigger than you want to replicate to every laptop or
-  phone (a 50 k-file research vault, a media-attachment-heavy vault).
-- The remote is the *source of truth* and other tools (cron jobs,
-  scripts, an LLM pipeline, the user's own `git`) operate on it
-  directly. Local sync would race those writers.
-- You don't want a third party to ever hold the vault — managed sync
-  is off the table for legal, privacy, or compliance reasons.
-- You want remote-side tooling (the integrated terminal pane,
-  Templater scripts that shell out, plugins that import `.enex` via a
-  local script) to act on the actual canonical files, not a synced
-  copy.
-
-If your needs match any of the alternatives' use-cases, those are
-simpler choices. This plugin is built for the case where "the vault
-lives over there, full stop" is the actual requirement.
+<sub>End-to-end demo, recorded in CI by <a href=".github/workflows/demo-capture.yml"><code>demo-capture.yml</code></a> — connect to a remote host and edit its vault from a normal Obsidian window.</sub>
 
 ---
 
 ## Install
 
-> ⚠️ The plugin is not yet in the Obsidian community plugin browser.
-> Install via **BRAT** (recommended for testers — auto-updates) or manually
-> from a [GitHub Release](https://github.com/sotashimozono/obsidian-remote-ssh/releases).
+**Obsidian → Settings → Community plugins → Browse → search "Remote SSH" → Install → Enable.**
 
-### Option A — BRAT (Beta Reviewers Auto-update Tool)
+That's the whole install. The first time you connect with the (recommended)
+RPC transport, the plugin fetches the matching helper daemon from its
+signed GitHub release — with a one-time confirmation, verified by sha256 —
+and uploads it to your host for you. Prefer no remote-side binary? Stay on
+the **SFTP** transport and skip the daemon entirely.
 
-[BRAT](https://github.com/TfTHacker/obsidian42-brat) is itself a community
-plugin that auto-installs and auto-updates beta releases of other plugins.
+<details>
+<summary>Other install methods (BRAT for pre-release builds · manual)</summary>
 
-1. Install **Obsidian42 - BRAT** from Settings → Community plugins → Browse.
-2. Open BRAT's settings → click **"Add Beta plugin"** (not "...with frozen version").
-3. Paste `sotashimozono/obsidian-remote-ssh`. Leave version blank.
-4. BRAT downloads `main.js` + `manifest-beta.json` + `styles.css` from the
-   most recent release on this repo and installs them under
-   `<vault>/.obsidian/plugins/remote-ssh/`.
-5. Toggle **Remote SSH** on under Community plugins.
+### BRAT (early/beta builds)
 
-You still have to drop a **daemon binary** for your remote OS/arch into
-`<vault>/.obsidian/plugins/remote-ssh/server-bin/` — see
-[Verifying the daemon](#verifying-the-daemon-optional-but-recommended) below.
-BRAT only handles the plugin itself.
+[BRAT](https://github.com/TfTHacker/obsidian42-brat) auto-installs and
+auto-updates pre-release builds straight from this repo:
 
-> **Two release channels.** This repo follows a `next` (integration) +
-> `main` (stable) branching model. Every merge to `next` advances both
-> manifests in lockstep, so BRAT's `--beta` mode (which fetches
-> `manifest-beta.json` from the repo's default branch) gives testers
-> early access to in-flight changes. Stable releases happen via
-> periodic promotion PRs that fast-forward `main` to `next`. The
-> stable channel currently leads on `1.0.x`; the `next` channel runs
-> a small lead of patch / pre-release versions ahead of stable.
+1. Install **Obsidian42 - BRAT** from Community plugins → Browse.
+2. BRAT settings → **Add Beta plugin** → paste `sotashimozono/obsidian-remote-ssh` → leave version blank.
+3. Toggle **Remote SSH** on under Community plugins.
 
-### Option B — Manual install
+### Manual
 
-#### 1 — Download the latest release
+Download `main.js`, `manifest.json`, and `styles.css` from the
+[Releases page](https://github.com/sotashimozono/obsidian-remote-ssh/releases),
+drop them into `<your-vault>/.obsidian/plugins/remote-ssh/`, and enable the
+plugin. (The daemon still auto-downloads on first RPC connect; for an
+air-gapped remote, grab the matching `obsidian-remote-server-<os>-<arch>`
+binary from the same release and place it in `…/remote-ssh/server-bin/`.)
 
-Go to the [Releases page](https://github.com/sotashimozono/obsidian-remote-ssh/releases),
-find the most recent tag, and download:
+</details>
 
-- `main.js`
-- `manifest.json`
-- `styles.css`
-- one daemon binary matching your **remote** OS + architecture:
-  - `obsidian-remote-server-linux-amd64`
-  - `obsidian-remote-server-linux-arm64`
-  - `obsidian-remote-server-darwin-amd64`
-  - `obsidian-remote-server-darwin-arm64`
+---
 
-The daemon binary is what the plugin auto-uploads to your remote on first
-connect. The OS/arch picks the binary that runs on the **remote**, not on
-the machine where Obsidian is installed.
+## Why you'd want this
 
-#### 2 — Drop the files into your vault
+You already keep your notes — or your code, or your research — on a machine
+that isn't this one. A home server. A cloud VPS. The lab cluster. You SSH in
+all the time. You'd love to use Obsidian on those files **without** copying
+the whole vault down to every laptop and phone, and without handing it to a
+sync provider.
 
-Create the plugin folder and place the files like this:
+That's the entire point of this plugin:
 
-```text
-<your-vault>/
-  .obsidian/
-    plugins/
-      remote-ssh/
-        main.js
-        manifest.json
-        styles.css
-        server-bin/
-          obsidian-remote-server-linux-amd64    ← rename / pick yours
-```
+- 🔑 **Plain SSH, your keys, your config.** Password, private key, SSH agent,
+  or a `ProxyJump` bastion — all read from the same `~/.ssh/config` your
+  terminal already uses. No account to create, no third-party server to trust.
+- ☁️ **No cloud middleman.** Files move directly between this machine and your
+  host over the encrypted SSH tunnel. Nobody else ever holds your notes — and
+  there's **no telemetry or analytics**; nothing leaves your machine except to
+  the host you typed into a profile.
+- 💻 **No full local replica.** Sync tools mirror your *entire* vault onto
+  every device. This doesn't: the vault stays on the server, and your laptop
+  only fetches the files you actually open (cached locally while you work, not
+  a synced second copy of everything).
+- 🧩 **It's still Obsidian.** The remote vault opens in a normal Obsidian
+  window — real File Explorer, search, command palette, and most of the
+  plugins you already use (Dataview, Templater, Excalidraw, Tasks, …).
 
-#### 3 — Enable in Obsidian
+---
 
-Settings → Community plugins → "Installed plugins" → toggle **Remote SSH**
-on. Reload the vault if Obsidian doesn't pick it up immediately.
+## What you can do with it
 
-### Verifying the daemon (optional but recommended)
+- **Edit a remote vault as if it were local.** SSH into your server; the vault
+  stays there, you get the full Obsidian editing experience here. No manual
+  `rsync`, no Dropbox dance.
+- **Keep huge vaults where they belong.** A 50k-file research vault or a
+  media-heavy attachment vault doesn't need to land on every device — only the
+  files you open are fetched.
+- **Let the server stay the source of truth.** Cron jobs, scripts, an LLM
+  pipeline, or your own `git` can keep operating on the canonical files; you're
+  editing the *same* files, not a copy that races those writers.
+- **Work from several machines.** Live updates push between connected clients
+  via `fs.watch`; if two saves collide, a 3-way merge UI (ancestor / mine /
+  theirs) opens instead of silently clobbering.
+- **Survive flaky networks.** Disconnects spool your writes to an offline
+  queue and drain them on reconnect; the status bar shows the pending count.
+- **Use a remote-side terminal.** An integrated terminal pane runs on the
+  remote, right next to the notes it's about.
 
-Daemon binaries are signed with [Sigstore cosign](https://www.sigstore.dev/)
-keyless OIDC. Verify any release binary independently before trusting it on
-your remote — see [SECURITY.md](SECURITY.md#verifying-release-artefacts) for
-the one-line `cosign verify-blob` command.
+### Good fits
 
-The plugin also runs a sha256 round-trip check on every deploy and refuses
-to start a daemon that doesn't match.
+- A **homelab / VPS** where your notes already live, and you want them to stay
+  there.
+- A **research / work cluster** (e.g. an HPC login node) holding data and notes
+  you SSH into anyway.
+- Vaults that are **too large or too private** to replicate everywhere or to
+  hand to a managed sync service — for legal, privacy, or compliance reasons.
 
 ---
 
@@ -212,18 +112,22 @@ to start a daemon that doesn't match.
 
 About **3 minutes** if you already have an SSH host.
 
-1. **Add a profile.** Settings → Remote SSH → "+ Add". Fill in host, port,
+1. **Add a profile.** Settings → Remote SSH → **+ Add**. Enter host, port,
    username, auth method (`privateKey` / `password` / `agent`), transport
-   (`RPC` recommended), and the **remote vault path** (relative paths
-   resolve under `$HOME` — `notes/main` → `~/notes/main`).
+   (`RPC` recommended), and the **remote vault path** (relative paths resolve
+   under `$HOME` — `notes/main` → `~/notes/main`).
 2. **Click Connect** on the profile row, or run **Remote SSH: Connect to
    remote vault** from the command palette.
-3. **A new Obsidian window appears.** That window is your "shadow vault" —
-   the same UI you know, but every file you see lives on the remote. Start
-   editing.
+3. **A new Obsidian window opens** — your "shadow vault". Same UI you know,
+   but every file in it lives on the remote. Start editing.
 
-To leave: close the shadow window, or run **Remote SSH: Disconnect from
-remote vault** inside it. The original window is never touched.
+To leave: close the shadow window, or run **Remote SSH: Disconnect** inside
+it. Your original window is never touched.
+
+> **First time connecting a brand-new profile?** Obsidian only learns about
+> the new vault at startup, so the very first connect may need one **restart**
+> of Obsidian before the window appears — then reconnect. It's a one-time step
+> per profile; every later connect opens immediately.
 
 ---
 
@@ -231,167 +135,136 @@ remote vault** inside it. The original window is never touched.
 
 | Feature | Notes |
 | --- | --- |
-| 🪟 **Shadow vault opens in a new Obsidian window** | The window you started from is untouched; the remote vault is its own first-class window with its own File Explorer, search, command palette. |
-| ⚡ **Sub-second cold-open even for 10k-file vaults** | Single `fs.walk` RPC fetches the whole tree in one round-trip. Falls back to per-folder `fs.list` for SFTP transport or older daemons. |
-| 🖼️ **Image / PDF / video rendering via ResourceBridge** | Local HTTP server (random localhost port + bearer token) serves binary content to the Obsidian webview. Image extensions go through `fs.thumbnail` with a 200 MB on-disk LRU cache. |
-| 🔁 **Live multi-client sync** | `fs.watch` notifies every connected client when another writer changes a file; the file explorer + open editors update within ~1 s. |
-| 🪢 **3-way conflict resolution** | If the remote mtime moved under your edit, the plugin opens a `ThreeWayMergeModal` with ancestor / mine / theirs panes. Plain text only; binary falls back to a 2-choice modal. |
-| 📥 **Offline write queue** | Writes during a disconnect spool to a JSONL queue under `<vault>/.obsidian/plugins/remote-ssh/queue/`; reconnect drains them automatically. Status bar shows the pending count. |
-| 🔐 **Cosign-signed daemon binaries** | Every release binary ships with a Sigstore bundle (`.bundle`). Verify provenance via `cosign verify-blob`; the plugin also runs a sha256 round-trip check on every deploy. |
-| 🩹 **Automatic reconnect with backoff** | SSH drops trigger a retry loop (default 5 attempts, exponential backoff up to 30 s). Reads served from the in-memory cache during the retry; writes spool to the offline queue. |
-| 🪪 **Per-client subtree (PathMapper)** | UI-state files (`workspace.json`, `cache/`, `graph.json`, etc) are routed to a per-device subtree on the remote so two machines don't clobber each other's tab layout. |
-| 🔌 **Jump host / `ProxyJump` support** | Multi-hop SSH through bastion hosts. Works with the same `~/.ssh/config` your terminal already uses. |
+| 🪟 **Opens in its own Obsidian window** | The window you started from is untouched; the remote vault is a first-class window with its own File Explorer, search, and command palette. |
+| ⚡ **Sub-second cold-open, even for 10k-file vaults** | A single `fs.walk` RPC fetches the whole tree in one round-trip (per-folder `fs.list` fallback for SFTP). |
+| 🖼️ **Image / PDF / video rendering** | A local-only HTTP bridge (random localhost port + bearer token) streams binary content to the Obsidian webview; images go through a `fs.thumbnail` cache (RPC transport). |
+| 🔁 **Live multi-client sync** | `fs.watch` notifies every connected client when another writer changes a file; explorer + open editors update within ~1 s. |
+| 🪢 **3-way conflict resolution** | If the remote file moved under your edit, a merge modal opens with ancestor / mine / theirs panes (plain text; binaries fall back to a 2-choice modal). |
+| 📥 **Offline write queue** | Writes during a disconnect spool to a local queue and drain automatically on reconnect; the status bar shows the pending count. |
+| 🩹 **Automatic reconnect with backoff** | SSH drops trigger a retry loop (default 5, exponential backoff to 30 s); reads come from cache during retries, writes spool to the queue. |
+| 🔌 **Jump host / `ProxyJump`** | Multi-hop SSH through bastions, from the same `~/.ssh/config` your terminal uses. |
+| 🔐 **Signed daemon binaries** | Every release daemon is Sigstore-cosign-signed; the plugin also runs a sha256 round-trip check on every deploy and refuses a mismatch. |
 
 ---
 
-## Settings
+## How it compares (the short version)
 
-| Setting | Default | What it does |
-| --- | --- | --- |
-| `Client ID` | sanitized OS hostname | Per-device subtree on the remote (`.obsidian/user/<id>/`). Holds workspace + UI state — anything not safe to share between machines. |
-| `User name` | OS username | Cosmetic — surfaces in the connect notice as `<user>@<host>`. |
-| `Reconnect attempts` | `5` | How many times to retry before giving up. Exponential backoff up to 30 s. `0` disables auto-reconnect. |
-| `Debug logging` | `false` | Adds `debug`-level lines to the JSONL log file (see Troubleshooting). |
+Most "edit my vault from anywhere" options **copy** the vault around —
+Obsidian Sync (managed, encrypted, on Obsidian's servers), file-sync tools
+(Syncthing / Dropbox / iCloud), or `obsidian-git` (a git repo you pull/push).
+Each is great when replicating the vault is what you actually want.
 
----
+**This plugin is for the opposite case:** the vault should live *only* on a
+remote host you control, with no second copy and no third party — and you
+want to edit it in place. If that's your situation, this is the niche it's
+built for; if not, one of the above is simpler.
 
-## Plugin compatibility
-
-The shadow vault patches `app.vault.adapter` so plugins that go through
-Obsidian's vault API work transparently. Plugins that **bypass** the
-adapter — typically by importing Node `fs` directly, joining paths against
-`app.vault.adapter.basePath`, or using internal Obsidian APIs we don't
-intercept — read or write the local empty shadow directory instead and
-effectively don't see your remote vault.
-
-The full matrix is in
-[docs/en/user-guide/plugin-compatibility.md](docs/en/user-guide/plugin-compatibility.md). Short summary:
-
-- ✅ **Most read-side plugins** — Dataview, Tasks, Calendar, Outliner, …
-- ✅ **Most write-side plugins** — Templater, Daily Notes, Quick Switcher++, …
-- ✅ **Image-rendering plugins** — Excalidraw, Image Toolkit (RPC transport only).
-- ⚠️ **fs-direct plugins** — Omnisearch (uses Node `fs` for indexing), some
-  media-importer plugins. These read the empty local shadow dir.
+Full breakdown (when to pick which):
+[docs → comparison](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/comparison/).
 
 ---
 
-## Troubleshooting
+## What stays on your computer
 
-The console log is the first thing to check. Path:
+By design, the canonical vault never leaves your SSH host. On the local side:
 
-```text
-<shadow-vault>/.obsidian/plugins/remote-ssh/console.log
-```
+| Capability | Why it's needed | Scope |
+|---|---|---|
+| **Network** | The SSH/SFTP connection | Only the host / port / optional jump host in your profile |
+| **Filesystem (outside the vault)** | Read your SSH key + `~/.ssh/config` to authenticate; cache the daemon binary | `~/.ssh/*` and the plugin's own `server-bin/` cache only |
+| **System identity** | Sensible defaults for the client id + remote username | `os.hostname()` / `os.userInfo().username` (both overridable); `SSH_AUTH_SOCK` etc. to find your agent/config |
+| **Process execution** | Start the daemon on the **remote** over SSH | Remote host only — no local shell execution |
+| **Clipboard (write)** | The "Copy diagnostics" button | Only on explicit click; the clipboard is never read |
 
-For a shadow vault, that's typically:
-
-```text
-~/.obsidian-remote/vaults/<profile-id>/.obsidian/plugins/remote-ssh/console.log
-```
-
-It's **JSONL** (one event per line). Pipe through `jq` for fast triage:
-
-```bash
-# Just the errors
-jq 'select(.level == "error")' console.log
-
-# Everything from a particular subsystem
-jq 'select(.fields.category == "auth")' console.log
-
-# Last 20 lines, one-line per
-tail -20 console.log | jq -c '{ts, level, msg}'
-```
-
-Common issues:
-
-- **"daemon binary not staged"** — the binary file inside `server-bin/`
-  is missing or doesn't match your remote OS / arch. Re-download from the
-  release that matches your installed plugin version.
-- **No new window opens after Connect** — the shadow vault wasn't
-  registered with Obsidian. Look for an `ObsidianRegistry` write error in
-  the source-window console log (commonly a permissions issue on the
-  Obsidian config dir). Reopen Settings and click Connect again.
-- **Shadow window opens but File Explorer is empty** — the auto-connect
-  failed. Open the shadow window's console log; look for `BulkWalker` or
-  `populateVaultFromRemote` errors. Try **Remote SSH: Reconnect to remote**
-  from the command palette inside the shadow window.
-- **Reconnect spins forever then fails** — `Reconnect attempts` is set
-  too high or the remote really is down. Set it lower (or `0` for
-  fail-fast).
-- **Images / PDFs don't render** — ResourceBridge needs `RPC` transport.
-  Check the active profile's transport setting.
-- **`N pending offline edits` won't go away** — the replay is hitting a
-  conflict on every entry. Click the status-bar indicator to open the
-  pending-edits modal and inspect; discard if appropriate.
+**No telemetry, no analytics.** Locally you keep only a working cache of the
+files you've opened — never a full replica of the vault.
 
 ---
 
 ## Security
 
-Daemon binaries are signed with Sigstore cosign keyless OIDC; the plugin
-verifies the upload with sha256 round-trip on every deploy.
+Daemon binaries are signed with [Sigstore cosign](https://www.sigstore.dev/)
+(keyless OIDC); verify any release binary yourself with the one-line
+`cosign verify-blob` in [SECURITY.md](SECURITY.md#verifying-release-artefacts).
+On every deploy the plugin re-checks the uploaded binary by sha256 and refuses
+to start a mismatch.
 
-To **report a vulnerability**, please use a private GitHub Security
-Advisory — full policy in [SECURITY.md](SECURITY.md). Do **not** open a
-public issue for security bugs.
-
----
-
-## Permissions & data access
-
-Remote SSH is **desktop-only** and, by design, reaches outside the Obsidian
-vault API to talk to the remote host you configure. Everything below is
-required for SSH/SFTP remote editing. **No telemetry, no analytics** —
-nothing leaves your machine except to the host you set up in a profile.
-
-| Capability | Why it's needed | Scope |
-|---|---|---|
-| **Network** | SSH/SFTP connection | Only the host / port / optional jump host you enter in a profile |
-| **Filesystem (outside the vault)** | Read your SSH private key and `~/.ssh/config` to authenticate; stage the daemon binary | `~/.ssh/*` and the plugin's own `server-bin/` folder only |
-| **System identity** | Pre-fill sensible defaults for the client id and remote username | `os.hostname()` and `os.userInfo().username` (both overridable in settings); `SSH_AUTH_SOCK` / `APPDATA` / `XDG_CONFIG_HOME` to locate the SSH agent and config |
-| **Process execution** | Start the daemon on the **remote** host over the SSH channel | Remote host only — no local shell execution |
-| **Clipboard (write)** | The "Copy to clipboard" button copies diagnostic logs | Only on explicit click; the clipboard is never read |
+To **report a vulnerability**, use a private GitHub Security Advisory — policy
+in [SECURITY.md](SECURITY.md). Please don't open a public issue for security
+bugs.
 
 ---
 
-## Contributing
+## Plugin compatibility
 
-Contributions welcome. Dev setup, branch + commit conventions, version-bump
-mechanic, and how to run the full test suite are in
-[CONTRIBUTING.md](CONTRIBUTING.md).
+The shadow vault patches `app.vault.adapter`, so plugins that go through
+Obsidian's vault API work transparently — Dataview, Templater, Daily Notes,
+Tasks, Calendar, Excalidraw (RPC transport), and most others. Plugins that
+**bypass** the adapter (importing Node `fs` directly, e.g. Omnisearch's
+indexer) see an empty local directory instead of your remote vault.
 
-Issues for bug reports + feature requests are at
-[github.com/sotashimozono/obsidian-remote-ssh/issues](https://github.com/sotashimozono/obsidian-remote-ssh/issues).
+Full matrix:
+[docs → plugin compatibility](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/user-guide/plugin-compatibility/).
+
+---
+
+## Troubleshooting
+
+The console log is the first thing to check (JSONL, one event per line):
+
+```text
+~/.obsidian-remote/vaults/<profile-id>/.obsidian/plugins/remote-ssh/console.log
+```
+
+```bash
+jq 'select(.level == "error")' console.log    # just the errors
+tail -20 console.log | jq -c '{ts, level, msg}'
+```
+
+A few common ones:
+
+- **No new window opens after connecting a *new* profile** — Obsidian only
+  registers new vaults at startup. Fully quit and reopen Obsidian, then
+  Connect again (one-time per profile; tracked in
+  [#411](https://github.com/sotashimozono/obsidian-remote-ssh/issues/411)).
+- **Shadow window opens but File Explorer is empty** — the auto-connect
+  failed. Check the shadow window's console log and run **Remote SSH:
+  Reconnect** from the command palette.
+- **Images / PDFs don't render** — those need the `RPC` transport; check the
+  profile's transport setting.
+- **Connect succeeds but the daemon won't come up** — the session falls back
+  to SFTP (vault read/write still work; daemon-only features are off). See the
+  daemon log: `ssh <host> 'cat ~/.obsidian-remote/server.log'`.
+
+More: [docs → troubleshooting](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/operations/troubleshooting/).
 
 ---
 
 ## How it works (technical)
 
+Obsidian doesn't expose a public way to rebuild the vault model from a
+different storage adapter mid-session, so the plugin opens a separate
+**shadow window** whose vault is constructed from the remote tree at startup —
+every plugin in that window sees a normal-looking vault from frame zero.
+
 ```mermaid
 flowchart LR
-    subgraph Original["Original window (any local vault)"]
-      U[User clicks Connect on profile P] --> M[ShadowVaultManager]
+    subgraph Original["Original window"]
+      U[Click Connect on profile P] --> M[ShadowVaultManager]
     end
-
-    M --> B["ShadowVaultBootstrap<br/>materialise ~/.obsidian-remote/vaults/&lt;P-id&gt;/<br/>per-file install of plugin<br/>seed data.json with autoConnectProfileId=P"]
-    B --> R["ObsidianRegistry<br/>register vault path in obsidian.json"]
+    M --> B["ShadowVaultBootstrap<br/>materialise ~/.obsidian-remote/vaults/&lt;P&gt;/<br/>install plugin · seed autoConnectProfileId=P"]
+    B --> R["ObsidianRegistry<br/>register vault in obsidian.json"]
     R --> W["WindowSpawner<br/>obsidian://open?path=…"]
-
-    subgraph Shadow["Shadow window (new Obsidian window)"]
-      L[onLayoutReady reads autoConnectProfileId] --> C[Connect to remote profile]
-      C --> P[Patch app.vault.adapter to remote FS client]
-      P --> WK[BulkWalker: fs.walk RPC<br/>or per-folder fs.list fallback]
-      WK --> V[VaultModelBuilder.build<br/>insert TFile / TFolder into vault.fileMap<br/>fire vault.trigger 'create']
-      V --> X[File Explorer renders the remote tree]
+    W -.spawn.-> L
+    subgraph Shadow["Shadow window"]
+      L[onLayoutReady → connect to P] --> P[Patch app.vault.adapter → remote FS client]
+      P --> WK[fs.walk RPC / fs.list fallback]
+      WK --> V[VaultModelBuilder → File Explorer]
     end
-
-    W -.spawn new window.-> L
-
-    subgraph Transport["SSH transport (in the shadow window)"]
+    subgraph Transport["SSH transport"]
       P -. fs ops .-> RPC[RpcRemoteFsClient]
       P -. or .-> SFTP[SftpRemoteFsClient]
-      RPC --> SD[ServerDeployer auto-uploads<br/>obsidian-remote-server to ~/.obsidian-remote/]
-      SD --> D[(Go daemon<br/>JSON-RPC over framed unix-socket stream)]
+      RPC --> D[(Go daemon · framed JSON-RPC over a unix-socket stream)]
       SFTP --> SSH[(ssh2 SFTP)]
       D --> FS[(Remote vault files)]
       SSH --> FS
@@ -400,33 +273,55 @@ flowchart LR
 
 Two transports per profile:
 
-- **`RPC` (recommended).** The plugin uploads a small Go daemon
-  (`obsidian-remote-server`) to `~/.obsidian-remote/` on the remote and
-  starts it via `nohup`. A local Duplex stream is forwarded to the
-  daemon's unix socket; vault FS ops flow as length-framed JSON-RPC.
-  Required for the ResourceBridge (image / PDF / video rendering),
-  `fs.walk` (sub-second cold-open), `fs.thumbnail` (image cache), and
-  `fs.watch` (live updates from other clients).
-- **`SFTP`.** Direct SFTP over `ssh2`, no daemon. Works without any
-  remote-side install but loses the daemon-only features above.
+- **`RPC` (recommended).** A small Go daemon (`obsidian-remote-server`) runs on
+  the remote; the plugin auto-fetches the signed binary, uploads it, and starts
+  it. Vault FS ops flow as length-framed JSON-RPC over a forwarded unix socket.
+  Required for image/PDF/video rendering, sub-second cold-open, thumbnails, and
+  live `fs.watch` updates.
+- **`SFTP`.** Direct SFTP over `ssh2`, no remote-side install — loses the
+  daemon-only features above.
 
-Why a separate window: Obsidian doesn't expose a public path to "rebuild
-the vault model from a different adapter mid-session." The shadow window's
-vault is constructed from the remote tree at startup, so every plugin in
-that window sees a normal-looking vault from frame zero. The full design
-and the smoke evidence behind it are in
-[docs/en/architecture/shadow-vault.md](docs/en/architecture/shadow-vault.md).
-
-The performance machinery (`BulkWalker`, `fs.thumbnail` cache) is
-documented in [docs/en/architecture/perf.md](docs/en/architecture/perf.md);
-the conflict + offline-queue design is in
-[docs/en/architecture/collab.md](docs/en/architecture/collab.md); the test
-strategy is in [docs/en/contributing/testing-strategy.md](docs/en/contributing/testing-strategy.md).
+Design deep-dives:
+[shadow-vault architecture](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/architecture/shadow-vault/) ·
+[performance](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/architecture/perf/) ·
+[conflicts & offline queue](http://codes.sota-shimozono.com/obsidian-remote-ssh/en/architecture/collab/).
 
 ---
 
-## Acknowledgements
+## Contributing
 
-Inspired by VS Code's Remote-SSH model. The wire format is an LSP-style
-framed JSON-RPC over a unix-socket-forwarded stream — the same shape
-language servers use, just for filesystem ops.
+Contributions welcome — dev setup, branch + commit conventions, and how to run
+the test suite are in [CONTRIBUTING.md](CONTRIBUTING.md). Bugs and feature
+requests: [Issues](https://github.com/sotashimozono/obsidian-remote-ssh/issues).
+
+Inspired by VS Code's Remote-SSH; the wire format is LSP-style framed JSON-RPC
+over a unix-socket-forwarded stream — the same shape language servers use, just
+for filesystem ops.
+
+---
+
+## Project status
+
+Released and available in the **Obsidian Community Plugins** store. Daemon
+binaries are cosign-signed and end-to-end tested against Linux + macOS remotes.
+
+[![release](https://img.shields.io/github/v/release/sotashimozono/obsidian-remote-ssh?display_name=tag&sort=semver)](https://github.com/sotashimozono/obsidian-remote-ssh/releases)
+[![downloads](https://img.shields.io/github/downloads/sotashimozono/obsidian-remote-ssh/total)](https://github.com/sotashimozono/obsidian-remote-ssh/releases)
+[![docs (stable)](https://img.shields.io/badge/docs-stable-7b5ea7?logo=obsidian&logoColor=white)](http://codes.sota-shimozono.com/obsidian-remote-ssh/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+<details>
+<summary>Build · coverage · platform badges (for contributors)</summary>
+
+[![CI](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/ci.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/ci.yml)
+[![Integration](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/integration.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/integration.yml)
+[![Security](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/security.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/sotashimozono/obsidian-remote-ssh/branch/next/graph/badge.svg)](https://codecov.io/gh/sotashimozono/obsidian-remote-ssh)
+[![Docs](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/docs.yml/badge.svg?branch=next)](https://github.com/sotashimozono/obsidian-remote-ssh/actions/workflows/docs.yml)
+[![docs (dev preview)](https://img.shields.io/badge/docs-dev_preview-9b7ec8?logo=obsidian&logoColor=white)](http://codes.sota-shimozono.com/obsidian-remote-ssh/dev/)
+[![Obsidian 1.5+](https://img.shields.io/badge/Obsidian-1.5+-7C3AED?logo=obsidian&logoColor=white)](https://obsidian.md)
+[![Go 1.25+](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](https://go.dev)
+[![Node 20+](https://img.shields.io/badge/Node-20+-339933?logo=node.js&logoColor=white)](https://nodejs.org)
+![Platforms: linux · macOS · amd64 · arm64](https://img.shields.io/badge/platforms-linux%20%7C%20macOS%20%C2%B7%20amd64%20%7C%20arm64-555)
+
+</details>

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.4",
+      "version": "1.1.5-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.4",
+  "version": "1.1.5-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Refreshes the README so the **value proposition leads** instead of a wall of ~15 badges. Review surface is the README diff.

## What changed
- **Lead with the pitch**: edit a remote vault over SSH — no cloud, no sync service, no full local copy (your notes stay on the server you control). The **demo GIF is now at the top**.
- **One-click install front and centre** (it's in the Community Plugins store now).
- **Usage + use-cases expanded** ("What you can do", "Good fits", Quickstart, Features).
- **vs-alternatives trimmed** to one short paragraph + a link to the full comparison on the docs site.
- **All badges moved to a "Project status" section at the bottom** — four user-facing ones (release / downloads / docs / license) visible, the build/coverage/Go/Node/platform/issues badges folded into a `<details>` for contributors.

## Stale claims fixed (were actively hurting adoption)
1. _"1.0 released — Community-store listing pending review — install via BRAT or manual"_ → **now listed in the store, one-click install** (confirmed: `remote-ssh` is in `obsidianmd/obsidian-releases/community-plugins.json`).
2. Removed _"not yet in the community plugin browser"_.
3. Manual daemon-binary drop → **the daemon auto-downloads on first RPC connect** (since the #397 work shipped in 1.1.3).

## Accuracy note
The "nothing stays on your machine" angle is framed precisely — **no full local replica / no cloud / no telemetry; only opened files are cached while you work** — rather than "nothing at all", since the shadow vault does keep a working cache of opened files. Easy to strengthen if that cache is ever made ephemeral.

(Follow-up `1.1.5-beta.1` will carry the release-flow / version-check reconciliation — "main ← next only, no `release/` branch".)
