### PR TITLE
ci(release): main ← next only — no release branch, conflict-free sync — 1.1.5-beta.1

### DIFF
--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -10,6 +10,10 @@ name: Version check
 #                       (root) and versions.json must stay pinned to the
 #                       last stable so the Obsidian Community Plugins store
 #                       isn't accidentally advanced to a prerelease.
+#                       EXCEPTION: a plain `X.Y.Z` head on a `next` PR is a
+#                       stable promotion-staging bump — `main` only ever merges
+#                       from `next`, so the stable bump lives on `next` first
+#                       (validated by the STABLE shape rule, not the beta one).
 #
 #   • PR into `main`  → STABLE channel.  head version must be plain
 #                       `X.Y.Z` (no -beta suffix), strictly greater than
@@ -95,6 +99,12 @@ jobs:
           echo "base_manifest=$base_manifest"     >> "$GITHUB_OUTPUT"
           echo "base_root=$base_root"             >> "$GITHUB_OUTPUT"
 
+          # A `-beta.N` head is a beta-channel bump; a plain X.Y.Z head on a
+          # `next` PR is a stable promotion-staging bump (the stable bump lives
+          # on next first because main only ever merges from next).
+          if [[ "$head_manifest" == *-beta.* ]]; then head_is_beta=true; else head_is_beta=false; fi
+          echo "head_is_beta=$head_is_beta"       >> "$GITHUB_OUTPUT"
+
           echo "base manifest.json (plugin):     $base_manifest"
           echo "head manifest.json (plugin):     $head_manifest"
           echo "head package.json:               $head_package"
@@ -132,9 +142,10 @@ jobs:
       - name: BETA channel (PR → next) — root manifest.json must stay pinned
         # On a beta PR the Obsidian Community Plugins store manifest must NOT
         # move; only manifest-beta.json + plugin/manifest.json may advance.
-        # Also exclude sync-shape PRs since those legitimately carry main's
-        # stable version state into next.
-        if: github.base_ref == 'next' && steps.sync_check.outputs.is_sync != 'true'
+        # Exclude sync-shape PRs (they carry main's stable state into next) and
+        # stable promotion-staging PRs (a plain X.Y.Z bump on next, validated by
+        # the STABLE shape step below) — both legitimately advance root manifest.
+        if: github.base_ref == 'next' && steps.sync_check.outputs.is_sync != 'true' && steps.versions.outputs.head_is_beta == 'true'
         run: |
           if [ "${{ steps.versions.outputs.head_root }}" != "${{ steps.versions.outputs.base_root }}" ]; then
             echo "::error::Beta PRs must not modify root manifest.json."\
@@ -151,8 +162,12 @@ jobs:
             exit 1
           fi
 
-      - name: STABLE channel (PR → main) — head version must be plain X.Y.Z
-        if: github.base_ref == 'main' && steps.sync_check.outputs.is_sync != 'true'
+      - name: STABLE shape — head plain X.Y.Z, all manifests agree
+        # Applies to main PRs AND to a stable promotion-staging bump that lands
+        # on next first (head_is_beta == false). main only ever merges from
+        # next, so the stable bump lives on next, gets validated here, then the
+        # next → main promotion carries it.
+        if: steps.sync_check.outputs.is_sync != 'true' && (github.base_ref == 'main' || steps.versions.outputs.head_is_beta == 'false')
         run: |
           head="${{ steps.versions.outputs.head_manifest }}"
           if [[ "$head" == *-beta.* ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,8 @@ This repo runs a two-channel release model. Pick the right base for your PR:
 | You're doing… | Base your PR on | Version shape |
 |---|---|---|
 | New feature / refactor / bug fix / docs / chore | **`next`** ← almost everything | `X.Y.Z-beta.N` |
-| Emergency hotfix for a shipped stable release | **`main`** (then back-port to `next`) | `X.Y.Z` |
-| Promotion of accumulated betas to stable (release cut) | **`main`** ← `next` | `X.Y.Z` (suffix dropped) |
+| Emergency hotfix for a shipped stable release | **`next`** (fast-tracked, then promote) | `X.Y.Z` |
+| Promotion of accumulated betas to stable (release cut) | **`next`** (bump to stable, then `next` → `main`) | `X.Y.Z` (suffix dropped) |
 
 Why this exists:
 
@@ -93,26 +93,38 @@ Why this exists:
 
 #### Cutting a promotion (next → main)
 
-When `next` has accumulated enough verified work to ship, do the version bump on a **release branch**, not directly on `next`. This keeps every commit lint-checked + CI-validated without requiring branch-protection bypass:
+**`main` only ever merges from `next` — there is no `release/*` branch.** Bump
+`next` to the stable version first (on a normal branch, PR'd **into `next`**),
+then promote `next` to `main`:
 
 ```bash
-git checkout -b release/X.Y.Z next
+# 1. Bump next to the stable version.
+git checkout -b release-X.Y.Z next
 cd plugin
-npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops -beta suffix)
-git commit -am "release: prepare X.Y.Z promotion"
-git push origin release/X.Y.Z
-gh pr create --base main --head release/X.Y.Z \
-  --title "release: promote next → main (X.Y.Z)"
+npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops the -beta suffix)
+git commit -am "release: X.Y.Z (stable)"
+git push origin release-X.Y.Z
+gh pr create --base next --head release-X.Y.Z --title "release: X.Y.Z (stable)"
 ```
 
-CI runs the full suite (commitlint, version-check, lint, type-check, tests) on the release branch's head before merge — no admin override.
+The bump runs the full suite (commitlint, version-check, lint, type-check,
+tests) on its PR **into `next`** — `version-check.yml` accepts a plain `X.Y.Z`
+on `next` as a promotion-staging shape, and `release.yml` skips publishing a
+stable version pushed to `next` (the `main` push is what releases). No admin
+override, no separate release branch.
 
-After CI green and merge:
-- `release.yml` fires on the main push → publishes **v X.Y.Z** stable + cosign-signed binaries.
-- `sync-main-to-next.yml` fires on the main push → opens + auto-merges `sync: main → next` so `next` gets the merge commit.
-- Your next beta cycle starts with `npm run bump:beta:start` (`X.Y.Z → X.Y.(Z+1)-beta.0`) on a normal `feat/...` branch.
+After it merges (`next` now carries the stable `X.Y.Z`), promote directly:
 
-> Why a release branch? Pre-2026-05 the docs said "push directly to `next`, then PR next → main". That worked but required admin bypass on `next`'s branch protection (the bump commit hadn't been through CI yet). Branch protection on `main` and `next` now disallows admin bypass, so the bump must live on its own branch + go through CI.
+```bash
+gh pr create --base main --head next --title "promote: next → main (X.Y.Z)"
+```
+
+On the main push: `release.yml` publishes **vX.Y.Z** stable + cosign-signed
+binaries; `sync-main-to-next.yml` opens + auto-merges `main → next`. Because
+`next` and `main` are now the **same** `X.Y.Z`, that sync has **no version
+conflict** — which is exactly why the bump lives on `next` and not on a branch
+that diverges from it. Then start the next cycle with `npm run bump:beta:start`
+(`X.Y.Z → X.Y.(Z+1)-beta.0`) on a `feat/...` branch.
 
 ### Commit messages — Conventional Commits, enforced
 
@@ -159,7 +171,7 @@ Each script:
 
 Commit the staged files alongside your code change.
 
-`version-check.yml` is **branch-aware**: PRs into `next` must keep `manifest.json` (root) pinned to the last stable, and PRs into `main` must carry a plain `X.Y.Z` (no beta suffix) with all manifests in agreement. If your PR sits open while another lands on the same base, rebase + run the same `bump:` script again.
+`version-check.yml` is **branch-aware**: beta PRs into `next` must keep `manifest.json` (root) pinned to the last stable — **except a stable promotion-staging bump (a plain `X.Y.Z` landed on `next`), which is validated with the same all-manifests-agree rule as a `main` PR**. PRs into `main` must carry a plain `X.Y.Z` (no beta suffix) with all manifests in agreement. If your PR sits open while another lands on the same base, rebase + run the same `bump:` script again.
 
 ## Pull request etiquette
 

--- a/docs/en/contributing/release-flow.md
+++ b/docs/en/contributing/release-flow.md
@@ -21,27 +21,50 @@ Every merge to `next` becomes a beta release. As a contributor you do not run an
 3. Commit, push, get review, merge.
 4. `release.yml` fires on the `next` push and publishes `vX.Y.Z-beta.N` as a GitHub prerelease with cosign-signed daemon binaries. BRAT consumers pick it up on next launch.
 
-## Stable releases — promotion via release branch
+## Stable releases — promote `next` → `main`
 
-When `next` has accumulated enough verified work to ship as the next stable, the **promotion flow** is:
+**`main` only ever receives merges from `next`. There is no `release/*` branch.**
+To cut a stable release you bump `next` to the stable version *first*, then
+promote `next` to `main` directly.
 
 ```bash
-git checkout -b release/X.Y.Z next
+# 1. Bump next to the stable version — a normal branch, PR'd INTO next.
+git checkout -b release-X.Y.Z next
 cd plugin
-npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops -beta suffix)
-git commit -am "release: prepare X.Y.Z promotion"
-git push origin release/X.Y.Z
-gh pr create --base main --head release/X.Y.Z \
-  --title "release: promote next → main (X.Y.Z)"
+npm run bump:stable          # 1.0.44-beta.5 → 1.0.44 (drops the -beta suffix)
+git commit -am "release: X.Y.Z (stable)"
+git push origin release-X.Y.Z
+gh pr create --base next --head release-X.Y.Z --title "release: X.Y.Z (stable)"
 ```
 
-The release branch is critical — it gives the bump commit a place to be CI-validated (commitlint, version-check, lint, type-check, tests, integration) **before** it reaches `main`. No admin override on `next` or `main` is needed.
+The bump is fully CI-validated by its PR **into `next`** — commitlint,
+version-check (which accepts a plain `X.Y.Z` on `next` as a *promotion-staging*
+shape), lint, type-check, tests. No admin override needed. `release.yml` does
+**not** publish on this `next` push: a stable version on `next` is recognised
+as a staging commit and skipped; the `main` push is what releases.
 
-After the PR is reviewed and merged into `main`:
+Once it merges (`next` now carries the stable `X.Y.Z`), promote:
 
-1. `release.yml` fires on the main push → publishes **vX.Y.Z** stable + cosign-signed binaries + GitHub Release marked latest.
-2. `sync-main-to-next.yml` fires on the same main push → opens an auto-merging PR `main → next` so the merge commit rejoins.
-3. The next beta cycle starts on a normal `feat/...` branch with `npm run bump:beta:start` (`X.Y.Z → X.Y.(Z+1)-beta.0`).
+```bash
+gh pr create --base main --head next --title "promote: next → main (X.Y.Z)"
+```
+
+After the promotion merges into `main`:
+
+1. `release.yml` fires on the main push → publishes **vX.Y.Z** stable +
+   cosign-signed binaries + the GitHub Release (notes auto-generated across the
+   whole beta cycle).
+2. `sync-main-to-next.yml` opens an auto-merging `main → next` PR. Because
+   `next` and `main` are now the **same** `X.Y.Z`, it merges with **no version
+   conflict**.
+3. Start the next beta cycle with `npm run bump:beta:start`
+   (`X.Y.Z → X.Y.(Z+1)-beta.0`) on the first feature branch.
+
+> **Why bump on `next` rather than a `release/` branch → `main`?** Keeping the
+> stable bump on `next` means `main` and `next` never diverge on the version
+> files, so the post-release `main → next` sync is a clean auto-merge instead of
+> a manual version-file conflict on every release. The bump still goes through
+> full CI (via its PR into `next`), and `main` only ever merges from `next`.
 
 ## What `bump:stable` does
 
@@ -60,14 +83,19 @@ graph LR
 
 The script (`plugin/scripts/bump-stable.mjs`) reads the current `-beta.N` suffix, strips it, runs `npm version <stripped>`. The `version` lifecycle hook calls `bump-version.mjs` which detects the plain version and updates **all** five manifest files (vs. a beta bump which only touches the bundled manifest + the BRAT mirror — see [[en/architecture/release-pipeline|Release pipeline]] for why).
 
-## Hot-fixing main without going through next
+## Hot-fixing a shipped stable release
 
-If `main` has a critical bug that can't wait for the next promotion:
+`main` only ever merges from `next`, so even an urgent fix goes through
+`next` — just fast-tracked, not branched off `main`:
 
-1. Branch off `main` directly: `git checkout -b hotfix/X.Y.Z main`
-2. Make the fix + bump: `npm version patch --no-git-tag-version` to go `1.0.44 → 1.0.45`. (`bump:stable` won't help here — there's no `-beta` suffix to strip.)
-3. PR into `main`. version-check requires the head version to be plain `X.Y.Z` strictly greater than base — same rule as a normal promotion.
-4. After merge, the `sync-main-to-next.yml` workflow back-syncs to `next` automatically.
+1. Branch off `next`: `git checkout -b hotfix-X.Y.Z next`.
+2. Make the fix and bump to the patch stable: `cd plugin && npm version patch
+   --no-git-tag-version` (`1.0.44 → 1.0.45`; `bump:stable` doesn't apply —
+   there's no `-beta` suffix to strip).
+3. PR **into `next`** (version-check accepts the plain `X.Y.Z` promotion-staging
+   shape), merge, then immediately promote `next → main` as above.
+4. The `main → next` sync afterwards is a clean auto-merge — same version on
+   both branches.
 
 ## Pre-release sanity checks
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.5-beta.0",
+  "version": "1.1.5-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.5-beta.0",
+  "version": "1.1.5-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.5-beta.0",
+  "version": "1.1.5-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.5-beta.0",
+      "version": "1.1.5-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.5-beta.0",
+  "version": "1.1.5-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
**Fixes the recurring main→next sync conflict** that hit every stable release (1.1.3, 1.1.4). Stacked on #415 (README, beta.0) — base auto-rebases to `next` once #415 merges; the diff here is just the flow change.

## The problem
The documented `release/X.Y.Z → main` promotion bumped the stable version on a side branch that merged into `main`, leaving `next` on `-beta.N`. So `main` (stable) and `next` (beta) diverged on the version files, and the automatic `sync-main-to-next` PR hit a version-file **conflict** every release — requiring manual resolution.

## The fix — `main` only ever merges from `next`
Bump `next` to the stable version **via a PR into `next`**, then promote `next → main` directly. No `release/*` branch. `main` and `next` never diverge on version files, so the post-release sync is a clean auto-merge.

- **`version-check.yml`**: a plain `X.Y.Z` head on a `next` PR is now accepted as a **promotion-staging** shape (validated by the same all-manifests-agree rule as a `main` PR). The beta root-pinned rule now applies only to `-beta.N` heads. **Backward compatible** — normal beta PRs are unaffected (verified: YAML valid, the two channel steps gate on `head_is_beta`).
- **`release-flow.md` + `CONTRIBUTING.md`**: rewrite the promotion + hotfix flow to "bump on `next` → promote `next → main`"; drop the `release/` branch; route hotfixes through `next` too.

## Why this is safe
`release.yml`'s precheck already treats a stable version on `next` as a "promotion-staging commit; main push will release" (skips publishing). This PR just makes `version-check` agree, so the bump can live on `next` where it belongs.

> Note: this changes the flow for the **next** stable release (1.1.5 onward). The `version-check` relaxation is the load-bearing bit; it's gated so existing beta PRs behave exactly as before.
