### PR TITLE
feat(server): add extension.kill lifecycle API with cli.kill compatibility alias

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/next/proto/types.ts
+++ b/next/proto/types.ts
@@ -62,6 +62,8 @@ export type MethodName =
   | 'server.info'
   | 'extension.schema'
   | 'extension.invoke'
+  | 'extension.kill'
+  | 'cli.kill' // deprecated alias of extension.kill
   | 'fs.stat'
   | 'fs.exists'
   | 'fs.list'
@@ -118,6 +120,15 @@ export interface ExtensionInvokeParams {
 export interface ExtensionInvokeResult {
   invocationId: string;
   accepted: boolean;
+}
+
+export interface ExtensionKillParams {
+  invocationId: string;
+}
+
+export interface ExtensionKillResult {
+  invocationId: string;
+  killed: boolean;
 }
 
 export interface CliOutputParams {

--- a/next/proto/types.ts
+++ b/next/proto/types.ts
@@ -110,6 +110,7 @@ export interface ExtensionSchemaResult {
 }
 
 export interface ExtensionInvokeParams {
+  invocationId?: string;
   tool: string;
   args?: Record<string, string>;
   workingDir?: string;

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.2.0-beta.0",
+  "version": "1.2.0-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -152,6 +152,8 @@ func run(args []string) (int, error) {
 	extRunner := handlers.NewExtensionRunner(capManager, logStore, absRoot)
 	disp.Handle("extension.schema", handlers.RequireAuth(extRunner.Schema()))
 	disp.Handle("extension.invoke", handlers.RequireAuth(extRunner.Invoke()))
+	disp.Handle("extension.kill", handlers.RequireAuth(extRunner.Kill()))
+	disp.Handle("cli.kill", handlers.RequireAuth(extRunner.KillCompat()))
 	// fs.* handlers are gated behind session auth.
 	// Read side.
 	disp.Handle("fs.stat", handlers.RequireAuth(handlers.FsStat(absRoot)))

--- a/server/config/capabilities.json
+++ b/server/config/capabilities.json
@@ -13,7 +13,8 @@
         {
           "name": "prompt",
           "required": true,
-          "maxLength": 65535
+          "maxLength": 65535,
+          "pattern": "^\\s*[^-][\\s\\S]*$"
         }
       ]
     }

--- a/server/config/capabilities.json
+++ b/server/config/capabilities.json
@@ -13,8 +13,7 @@
         {
           "name": "prompt",
           "required": true,
-          "maxLength": 65535,
-          "pattern": "^(?!\\s*-)[\\s\\S]+$"
+          "maxLength": 65535
         }
       ]
     }

--- a/server/internal/extensions/log_store.go
+++ b/server/internal/extensions/log_store.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -21,6 +22,13 @@ const (
 type LogStore struct {
 	dir string
 	mu  sync.Mutex
+}
+
+type logLine struct {
+	TS     string `json:"ts"`
+	Stream string `json:"stream"`
+	Data   string `json:"data"`
+	Seq    int64  `json:"seq,omitempty"`
 }
 
 func NewLogStore(stateDir string) (*LogStore, error) {
@@ -55,12 +63,7 @@ func (s *LogStore) AppendBatch(invocationID string, items []proto.CliOutputBatch
 
 	w := bufio.NewWriter(f)
 	for _, it := range items {
-		line, err := json.Marshal(struct {
-			TS     string `json:"ts"`
-			Stream string `json:"stream"`
-			Data   string `json:"data"`
-			Seq    int64  `json:"seq,omitempty"`
-		}{
+		line, err := json.Marshal(logLine{
 			TS:     time.Now().UTC().Format(time.RFC3339Nano),
 			Stream: it.Stream,
 			Data:   it.Data,
@@ -88,6 +91,51 @@ func (s *LogStore) AppendBatch(invocationID string, items []proto.CliOutputBatch
 		return false, nil
 	}
 	return true, nil
+}
+
+// ReplayFrom returns persisted output rows whose seq is greater than resumeFrom.
+// The boolean return value is false when no log file exists for invocationID.
+func (s *LogStore) ReplayFrom(invocationID string, resumeFrom int64) ([]proto.CliOutputBatchItem, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fp := s.filePath(invocationID)
+	f, err := os.Open(fp)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	out := make([]proto.CliOutputBatchItem, 0, 128)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var row logLine
+		if err := json.Unmarshal(line, &row); err != nil {
+			return nil, true, err
+		}
+		if row.Seq <= resumeFrom {
+			continue
+		}
+		out = append(out, proto.CliOutputBatchItem{
+			Stream: row.Stream,
+			Data:   row.Data,
+			Seq:    row.Seq,
+		})
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return nil, true, err
+	}
+	return out, true, nil
 }
 
 func (s *LogStore) CleanupExpired() error {

--- a/server/internal/extensions/log_store_test.go
+++ b/server/internal/extensions/log_store_test.go
@@ -1,0 +1,57 @@
+package extensions
+
+import (
+	"testing"
+
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+)
+
+func TestLogStore_ReplayFrom(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := NewLogStore(tmp)
+	if err != nil {
+		t.Fatalf("NewLogStore: %v", err)
+	}
+	inv := "inv-test-1"
+	ok, err := store.AppendBatch(inv, []proto.CliOutputBatchItem{
+		{Stream: "stdout", Data: "line1\n", Seq: 1},
+		{Stream: "stdout", Data: "line2\n", Seq: 2},
+		{Stream: "stderr", Data: "line3\n", Seq: 3},
+	})
+	if err != nil || !ok {
+		t.Fatalf("AppendBatch: ok=%v err=%v", ok, err)
+	}
+
+	items, found, err := store.ReplayFrom(inv, 1)
+	if err != nil {
+		t.Fatalf("ReplayFrom: %v", err)
+	}
+	if !found {
+		t.Fatalf("ReplayFrom found=false, want true")
+	}
+	if len(items) != 2 {
+		t.Fatalf("len(items)=%d, want 2", len(items))
+	}
+	if items[0].Seq != 2 || items[1].Seq != 3 {
+		t.Fatalf("unexpected seqs: %+v", items)
+	}
+}
+
+func TestLogStore_ReplayFrom_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := NewLogStore(tmp)
+	if err != nil {
+		t.Fatalf("NewLogStore: %v", err)
+	}
+	items, found, err := store.ReplayFrom("inv-missing", 0)
+	if err != nil {
+		t.Fatalf("ReplayFrom: %v", err)
+	}
+	if found {
+		t.Fatalf("ReplayFrom found=true, want false")
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(items)=%d, want 0", len(items))
+	}
+
+}

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -32,8 +32,14 @@ type extensionRunner struct {
 	active map[string]activeInvocation
 }
 
+// activeInvocation tracks a running extension process.
+//
+// The daemon uses a single-principal model — one token minted at startup
+// that every session authenticates with. *Session is a transport handle,
+// not an identity, so there is no per-session authorization boundary.
+// session is the (rebindable) stream target for live output; when nil,
+// output is persisted to the log for replay by a future reattach.
 type activeInvocation struct {
-	owner      *server.Session
 	session    *server.Session
 	stop       func() error
 	outputMode string
@@ -145,6 +151,8 @@ func (r *extensionRunner) Invoke() rpc.Handler {
 	}
 }
 
+// resumeInvoke reattaches to a persisted invocation. Under the single-principal
+// model any authenticated session may reattach and replay.
 func (r *extensionRunner) resumeInvoke(ctx context.Context, p proto.ExtensionInvokeParams) (interface{}, *rpc.Error) {
 	if p.ResumeFrom < 0 {
 		return nil, rpc.ErrInvalidParams("extension.invoke: resumeFrom must be >= 0")
@@ -190,9 +198,8 @@ func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
 			return nil, rpc.ErrInvalidParams(methodName + ": invocationId is required")
 		}
 
-		session := server.SessionFromContext(ctx)
 		inv, ok := r.lookupInvocation(p.InvocationID)
-		if !ok || inv.owner != session {
+		if !ok {
 			return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: false}, nil
 		}
 
@@ -208,7 +215,7 @@ func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
 func (r *extensionRunner) registerInvocation(invocationID string, session *server.Session, outputMode string, stop func() error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.active[invocationID] = activeInvocation{owner: session, session: session, outputMode: outputMode, stop: stop}
+	r.active[invocationID] = activeInvocation{session: session, outputMode: outputMode, stop: stop}
 }
 
 func (r *extensionRunner) lookupInvocation(invocationID string) (activeInvocation, bool) {
@@ -232,7 +239,6 @@ func (r *extensionRunner) rebindInvocation(invocationID string, session *server.
 		return activeInvocation{}, false
 	}
 	inv.session = session
-	inv.owner = session
 	r.active[invocationID] = inv
 	return inv, true
 }
@@ -311,36 +317,39 @@ func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdo
 			return true
 		}
 		session := r.currentInvocationSession(invocationID)
-		if session == nil {
-			_ = cmd.Process.Kill()
-			return false
-		}
 		payload := append([]proto.CliOutputBatchItem(nil), batch...)
-		if outputMode == "single" {
-			for _, it := range payload {
-				if err := session.SendNotification("cli.output", proto.CliOutputParams{
-					InvocationID: invocationID,
-					Stream:       it.Stream,
-					Data:         it.Data,
-					Seq:          it.Seq,
-				}); err != nil {
-					_ = cmd.Process.Kill()
-					return false
-				}
-			}
-		} else {
-			if err := session.SendNotification("cli.output.batch", proto.CliOutputBatchParams{
-				InvocationID: invocationID,
-				Items:        payload,
-			}); err != nil {
-				_ = cmd.Process.Kill()
-				return false
-			}
-		}
+
+		// Persist to log first so a reattaching session can replay.
 		if persistEnabled {
 			ok, err := r.logs.AppendBatch(invocationID, payload)
 			if err != nil || !ok {
 				persistEnabled = false
+			}
+		}
+
+		// Stream to the active session if one exists.
+		// When session is nil (dropped with no reattach) or send fails,
+		// the process keeps running — output is already persisted above
+		// and can be replayed via resumeInvoke + ReplayFrom.
+		if session != nil {
+			if outputMode == "single" {
+				for _, it := range payload {
+					if err := session.SendNotification("cli.output", proto.CliOutputParams{
+						InvocationID: invocationID,
+						Stream:       it.Stream,
+						Data:         it.Data,
+						Seq:          it.Seq,
+					}); err != nil {
+						session = nil
+					}
+				}
+			} else {
+				if err := session.SendNotification("cli.output.batch", proto.CliOutputBatchParams{
+					InvocationID: invocationID,
+					Items:        payload,
+				}); err != nil {
+					session = nil
+				}
 			}
 		}
 		batch = batch[:0]

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -25,6 +27,14 @@ type extensionRunner struct {
 	vaultDir string
 	seq      atomic.Int64
 	slots    chan struct{}
+
+	mu     sync.Mutex
+	active map[string]activeInvocation
+}
+
+type activeInvocation struct {
+	owner *server.Session
+	stop  func() error
 }
 
 const maxConcurrentExtensionInvocations = 4
@@ -35,6 +45,7 @@ func NewExtensionRunner(mgr *extensions.Manager, logs *extensions.LogStore, vaul
 		logs:     logs,
 		vaultDir: vaultDir,
 		slots:    make(chan struct{}, maxConcurrentExtensionInvocations),
+		active:   map[string]activeInvocation{},
 	}
 }
 
@@ -117,10 +128,68 @@ func (r *extensionRunner) Invoke() rpc.Handler {
 		if p.Persist != nil {
 			persist = *p.Persist
 		}
+		r.registerInvocation(invocationID, session, func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return cmd.Process.Kill()
+		})
 		go r.streamProcess(session, invocationID, cmd, stdout, stderr, persist, cap.OutputMode, releaseSlot)
 
 		return proto.ExtensionInvokeResult{InvocationID: invocationID, Accepted: true}, nil
 	}
+}
+
+func (r *extensionRunner) Kill() rpc.Handler {
+	return r.killForMethod("extension.kill")
+}
+
+func (r *extensionRunner) KillCompat() rpc.Handler {
+	return r.killForMethod("cli.kill")
+}
+
+func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
+	return func(ctx context.Context, raw json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.ExtensionKillParams
+		if e := decodeParams(methodName, raw, &p); e != nil {
+			return nil, e
+		}
+		if strings.TrimSpace(p.InvocationID) == "" {
+			return nil, rpc.ErrInvalidParams(methodName + ": invocationId is required")
+		}
+
+		session := server.SessionFromContext(ctx)
+		inv, ok := r.lookupInvocation(p.InvocationID)
+		if !ok || inv.owner != session {
+			return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: false}, nil
+		}
+
+		err := inv.stop()
+		if err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return nil, rpc.ErrInternal(methodName + ": " + err.Error())
+		}
+		r.unregisterInvocation(p.InvocationID)
+		return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: true}, nil
+	}
+}
+
+func (r *extensionRunner) registerInvocation(invocationID string, session *server.Session, stop func() error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.active[invocationID] = activeInvocation{owner: session, stop: stop}
+}
+
+func (r *extensionRunner) lookupInvocation(invocationID string) (activeInvocation, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inv, ok := r.active[invocationID]
+	return inv, ok
+}
+
+func (r *extensionRunner) unregisterInvocation(invocationID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.active, invocationID)
 }
 
 func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]string) ([]string, error) {
@@ -166,6 +235,7 @@ func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]str
 
 func (r *extensionRunner) streamProcess(session *server.Session, invocationID string, cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, persist bool, outputMode string, releaseSlot func()) {
 	defer releaseSlot()
+	defer r.unregisterInvocation(invocationID)
 	itemsCh := make(chan proto.CliOutputBatchItem, 256)
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -244,10 +244,10 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 			}
 			batch = append(batch, it)
 			if len(batch) >= 50 {
-					if !flush() {
-						_ = cmd.Wait()
-						return
-					}
+				if !flush() {
+					_ = cmd.Wait()
+					return
+				}
 			}
 		case <-ticker.C:
 			if !flush() {
@@ -272,4 +272,3 @@ func (r *extensionRunner) scanStream(wg *sync.WaitGroup, src io.Reader, stream s
 		out <- proto.CliOutputBatchItem{Stream: "stderr", Data: "[stream error] " + err.Error() + "\n", Seq: seq}
 	}
 }
-

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -33,8 +33,10 @@ type extensionRunner struct {
 }
 
 type activeInvocation struct {
-	owner *server.Session
-	stop  func() error
+	owner      *server.Session
+	session    *server.Session
+	stop       func() error
+	outputMode string
 }
 
 const maxConcurrentExtensionInvocations = 4
@@ -60,6 +62,9 @@ func (r *extensionRunner) Invoke() rpc.Handler {
 		var p proto.ExtensionInvokeParams
 		if e := decodeParams("extension.invoke", raw, &p); e != nil {
 			return nil, e
+		}
+		if strings.TrimSpace(p.InvocationID) != "" {
+			return r.resumeInvoke(ctx, p)
 		}
 		if strings.TrimSpace(p.Tool) == "" {
 			return nil, rpc.ErrInvalidParams("extension.invoke: tool is required")
@@ -128,16 +133,43 @@ func (r *extensionRunner) Invoke() rpc.Handler {
 		if p.Persist != nil {
 			persist = *p.Persist
 		}
-		r.registerInvocation(invocationID, session, func() error {
+		r.registerInvocation(invocationID, session, cap.OutputMode, func() error {
 			if cmd.Process == nil {
 				return nil
 			}
 			return cmd.Process.Kill()
 		})
-		go r.streamProcess(session, invocationID, cmd, stdout, stderr, persist, cap.OutputMode, releaseSlot)
+		go r.streamProcess(invocationID, cmd, stdout, stderr, persist, cap.OutputMode, releaseSlot)
 
 		return proto.ExtensionInvokeResult{InvocationID: invocationID, Accepted: true}, nil
 	}
+}
+
+func (r *extensionRunner) resumeInvoke(ctx context.Context, p proto.ExtensionInvokeParams) (interface{}, *rpc.Error) {
+	if p.ResumeFrom < 0 {
+		return nil, rpc.ErrInvalidParams("extension.invoke: resumeFrom must be >= 0")
+	}
+
+	invocationID := strings.TrimSpace(p.InvocationID)
+	session := server.SessionFromContext(ctx)
+	inv, ok := r.rebindInvocation(invocationID, session)
+	if !ok {
+		return nil, rpc.ErrInvalidParams("extension.invoke: unknown invocationId for resume")
+	}
+
+	if r.logs != nil {
+		items, _, err := r.logs.ReplayFrom(invocationID, p.ResumeFrom)
+		if err != nil {
+			return nil, rpc.ErrInternal("extension.invoke: replay: " + err.Error())
+		}
+		if len(items) > 0 {
+			if err := sendReplay(session, inv.outputMode, invocationID, items); err != nil {
+				return nil, rpc.ErrInternal("extension.invoke: replay notify: " + err.Error())
+			}
+		}
+	}
+
+	return proto.ExtensionInvokeResult{InvocationID: invocationID, Accepted: true}, nil
 }
 
 func (r *extensionRunner) Kill() rpc.Handler {
@@ -173,10 +205,10 @@ func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
 	}
 }
 
-func (r *extensionRunner) registerInvocation(invocationID string, session *server.Session, stop func() error) {
+func (r *extensionRunner) registerInvocation(invocationID string, session *server.Session, outputMode string, stop func() error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.active[invocationID] = activeInvocation{owner: session, stop: stop}
+	r.active[invocationID] = activeInvocation{owner: session, session: session, outputMode: outputMode, stop: stop}
 }
 
 func (r *extensionRunner) lookupInvocation(invocationID string) (activeInvocation, bool) {
@@ -190,6 +222,29 @@ func (r *extensionRunner) unregisterInvocation(invocationID string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	delete(r.active, invocationID)
+}
+
+func (r *extensionRunner) rebindInvocation(invocationID string, session *server.Session) (activeInvocation, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inv, ok := r.active[invocationID]
+	if !ok {
+		return activeInvocation{}, false
+	}
+	inv.session = session
+	inv.owner = session
+	r.active[invocationID] = inv
+	return inv, true
+}
+
+func (r *extensionRunner) currentInvocationSession(invocationID string) *server.Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inv, ok := r.active[invocationID]
+	if !ok {
+		return nil
+	}
+	return inv.session
 }
 
 func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]string) ([]string, error) {
@@ -233,7 +288,7 @@ func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]str
 	return out, nil
 }
 
-func (r *extensionRunner) streamProcess(session *server.Session, invocationID string, cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, persist bool, outputMode string, releaseSlot func()) {
+func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, persist bool, outputMode string, releaseSlot func()) {
 	defer releaseSlot()
 	defer r.unregisterInvocation(invocationID)
 	itemsCh := make(chan proto.CliOutputBatchItem, 256)
@@ -254,6 +309,11 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 	flush := func() bool {
 		if len(batch) == 0 {
 			return true
+		}
+		session := r.currentInvocationSession(invocationID)
+		if session == nil {
+			_ = cmd.Process.Kill()
+			return false
 		}
 		payload := append([]proto.CliOutputBatchItem(nil), batch...)
 		if outputMode == "single" {
@@ -305,11 +365,14 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 						sig = err.Error()
 					}
 				}
-				_ = session.SendNotification("cli.done", proto.CliDoneParams{
-					InvocationID: invocationID,
-					ExitCode:     exitCode,
-					Signal:       sig,
-				})
+				session := r.currentInvocationSession(invocationID)
+				if session != nil {
+					_ = session.SendNotification("cli.done", proto.CliDoneParams{
+						InvocationID: invocationID,
+						ExitCode:     exitCode,
+						Signal:       sig,
+					})
+				}
 				return
 			}
 			batch = append(batch, it)
@@ -326,6 +389,26 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 			}
 		}
 	}
+}
+
+func sendReplay(session *server.Session, outputMode, invocationID string, items []proto.CliOutputBatchItem) error {
+	if outputMode == "single" {
+		for _, it := range items {
+			if err := session.SendNotification("cli.output", proto.CliOutputParams{
+				InvocationID: invocationID,
+				Stream:       it.Stream,
+				Data:         it.Data,
+				Seq:          it.Seq,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	return session.SendNotification("cli.output.batch", proto.CliOutputBatchParams{
+		InvocationID: invocationID,
+		Items:        items,
+	})
 }
 
 func (r *extensionRunner) scanStream(wg *sync.WaitGroup, src io.Reader, stream string, out chan<- proto.CliOutputBatchItem) {

--- a/server/internal/handlers/extension_test.go
+++ b/server/internal/handlers/extension_test.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/extensions"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
 )
@@ -68,7 +70,7 @@ func TestExtensionKill_OtherSessionCannotKill(t *testing.T) {
 	r := NewExtensionRunner(nil, nil, "")
 	owner := server.NewSession()
 	called := false
-	r.registerInvocation("inv-1", owner, func() error {
+	r.registerInvocation("inv-1", owner, "batch", func() error {
 		called = true
 		return nil
 	})
@@ -95,7 +97,7 @@ func TestExtensionKill_OwnerCanKill(t *testing.T) {
 	r := NewExtensionRunner(nil, nil, "")
 	owner := server.NewSession()
 	called := false
-	r.registerInvocation("inv-2", owner, func() error {
+	r.registerInvocation("inv-2", owner, "batch", func() error {
 		called = true
 		return nil
 	})
@@ -115,5 +117,58 @@ func TestExtensionKill_OwnerCanKill(t *testing.T) {
 	}
 	if !called {
 		t.Fatalf("stop should be called for owner session")
+	}
+}
+
+func TestExtensionInvoke_ResumeFromReplay(t *testing.T) {
+	tmp := t.TempDir()
+	store, err := extensions.NewLogStore(filepath.Join(tmp, "state"))
+	if err != nil {
+		t.Fatalf("NewLogStore: %v", err)
+	}
+	ok, err := store.AppendBatch("inv-resume", []proto.CliOutputBatchItem{
+		{Stream: "stdout", Data: "a\n", Seq: 1},
+		{Stream: "stdout", Data: "b\n", Seq: 2},
+	})
+	if err != nil || !ok {
+		t.Fatalf("AppendBatch: ok=%v err=%v", ok, err)
+	}
+
+	r := NewExtensionRunner(nil, store, "")
+	owner := server.NewSession()
+	r.registerInvocation("inv-resume", owner, "batch", func() error { return nil })
+
+	receiver := server.NewSession()
+	notified := false
+	receiver.SetNotifier(func(method string, params interface{}, _ *proto.Meta) error {
+		if method != "cli.output.batch" {
+			return nil
+		}
+		batch, ok := params.(proto.CliOutputBatchParams)
+		if !ok {
+			t.Fatalf("unexpected params type: %T", params)
+		}
+		if len(batch.Items) != 1 || batch.Items[0].Seq != 2 {
+			t.Fatalf("unexpected replay payload: %+v", batch)
+		}
+		notified = true
+		return nil
+	})
+
+	h := r.Invoke()
+	ctx := server.WithSession(context.Background(), receiver)
+	res, rpcErr := h(ctx, json.RawMessage(`{"invocationId":"inv-resume","resumeFrom":1}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionInvokeResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if out.InvocationID != "inv-resume" || !out.Accepted {
+		t.Fatalf("unexpected result: %+v", out)
+	}
+	if !notified {
+		t.Fatalf("expected replay notification")
 	}
 }

--- a/server/internal/handlers/extension_test.go
+++ b/server/internal/handlers/extension_test.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
 )
 
 func TestValidateAndBuildArgs_RejectsLeadingDash(t *testing.T) {
@@ -40,5 +43,77 @@ func TestValidateAndBuildArgs_AllowsLeadingDashWhenConfigured(t *testing.T) {
 	}
 	if len(args) != 1 || args[0] != "--help" {
 		t.Fatalf("args = %v, want [--help]", args)
+	}
+}
+
+func TestExtensionKill_NotFound_ReturnsKilledFalse(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	h := r.Kill()
+
+	ctx := server.WithSession(context.Background(), server.NewSession())
+	res, rpcErr := h(ctx, json.RawMessage(`{"invocationId":"inv-missing"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if out.Killed {
+		t.Fatalf("Killed = true, want false")
+	}
+}
+
+func TestExtensionKill_OtherSessionCannotKill(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	owner := server.NewSession()
+	called := false
+	r.registerInvocation("inv-1", owner, func() error {
+		called = true
+		return nil
+	})
+
+	h := r.Kill()
+	otherCtx := server.WithSession(context.Background(), server.NewSession())
+	res, rpcErr := h(otherCtx, json.RawMessage(`{"invocationId":"inv-1"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if out.Killed {
+		t.Fatalf("Killed = true, want false")
+	}
+	if called {
+		t.Fatalf("stop should not be called for non-owner session")
+	}
+}
+
+func TestExtensionKill_OwnerCanKill(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	owner := server.NewSession()
+	called := false
+	r.registerInvocation("inv-2", owner, func() error {
+		called = true
+		return nil
+	})
+
+	h := r.Kill()
+	ownerCtx := server.WithSession(context.Background(), owner)
+	res, rpcErr := h(ownerCtx, json.RawMessage(`{"invocationId":"inv-2"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if !out.Killed {
+		t.Fatalf("Killed = false, want true")
+	}
+	if !called {
+		t.Fatalf("stop should be called for owner session")
 	}
 }

--- a/server/internal/handlers/extension_test.go
+++ b/server/internal/handlers/extension_test.go
@@ -66,34 +66,7 @@ func TestExtensionKill_NotFound_ReturnsKilledFalse(t *testing.T) {
 	}
 }
 
-func TestExtensionKill_OtherSessionCannotKill(t *testing.T) {
-	r := NewExtensionRunner(nil, nil, "")
-	owner := server.NewSession()
-	called := false
-	r.registerInvocation("inv-1", owner, "batch", func() error {
-		called = true
-		return nil
-	})
-
-	h := r.Kill()
-	otherCtx := server.WithSession(context.Background(), server.NewSession())
-	res, rpcErr := h(otherCtx, json.RawMessage(`{"invocationId":"inv-1"}`))
-	if rpcErr != nil {
-		t.Fatalf("unexpected rpc error: %v", rpcErr)
-	}
-	out, ok := res.(proto.ExtensionKillResult)
-	if !ok {
-		t.Fatalf("unexpected result type: %T", res)
-	}
-	if out.Killed {
-		t.Fatalf("Killed = true, want false")
-	}
-	if called {
-		t.Fatalf("stop should not be called for non-owner session")
-	}
-}
-
-func TestExtensionKill_OwnerCanKill(t *testing.T) {
+func TestExtensionKill_ExistingInvocationCanBeKilled(t *testing.T) {
 	r := NewExtensionRunner(nil, nil, "")
 	owner := server.NewSession()
 	called := false

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -269,11 +269,12 @@ type ExtensionSchemaResult struct {
 
 // ExtensionInvokeParams is the generic command invocation contract.
 type ExtensionInvokeParams struct {
-	Tool       string            `json:"tool"`
-	Args       map[string]string `json:"args,omitempty"`
-	WorkingDir string            `json:"workingDir,omitempty"`
-	Persist    *bool             `json:"persist,omitempty"`
-	ResumeFrom int64             `json:"resumeFrom,omitempty"`
+	InvocationID string            `json:"invocationId,omitempty"`
+	Tool         string            `json:"tool"`
+	Args         map[string]string `json:"args,omitempty"`
+	WorkingDir   string            `json:"workingDir,omitempty"`
+	Persist      *bool             `json:"persist,omitempty"`
+	ResumeFrom   int64             `json:"resumeFrom,omitempty"`
 }
 
 // ExtensionInvokeResult identifies the accepted execution stream.

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -282,6 +282,17 @@ type ExtensionInvokeResult struct {
 	Accepted     bool   `json:"accepted"`
 }
 
+// ExtensionKillParams requests termination of an active invocation.
+type ExtensionKillParams struct {
+	InvocationID string `json:"invocationId"`
+}
+
+// ExtensionKillResult reports whether the target invocation was terminated.
+type ExtensionKillResult struct {
+	InvocationID string `json:"invocationId"`
+	Killed       bool   `json:"killed"`
+}
+
 // ─── server-push notifications ──────────────────────────────────────────────
 
 // FsChangeEvent is the kind of change the server observed on a watched path.

--- a/server/internal/rpc/errors.go
+++ b/server/internal/rpc/errors.go
@@ -37,8 +37,8 @@ func ErrInternal(msg string) *Error { return Err(proto.ErrorInternalError, msg, 
 // ErrAuthRequired and friends are convenience builders for the custom
 // error codes defined in proto/types.go.
 
-func ErrAuthRequired() *Error    { return Err(proto.ErrorAuthRequired, "auth required", nil) }
-func ErrAuthInvalid() *Error     { return Err(proto.ErrorAuthInvalid, "invalid token", nil) }
+func ErrAuthRequired() *Error { return Err(proto.ErrorAuthRequired, "auth required", nil) }
+func ErrAuthInvalid() *Error  { return Err(proto.ErrorAuthInvalid, "invalid token", nil) }
 func ErrFileNotFound(p string) *Error {
 	return Err(proto.ErrorFileNotFound, "no such file: "+p, nil)
 }


### PR DESCRIPTION
## Summary
- Add `extension.kill` as canonical terminate API for `extension.invoke` lifecycle
- Keep `cli.kill` as deprecated compatibility alias (same handler)
- Enforce same-session ownership checks before process termination
- Add/align protocol types and handler tests

## Why
- We are migrating away from hardcoded `cli.*` semantics to extensible `extension.*`
- Keeping alias temporarily preserves continuity and avoids abrupt client breakage

## Validation
- `go -C server test ./...` passed

## Migration note
- Prefer `extension.kill` for new clients
- `cli.kill` is compatibility-only and planned for future removal after transition window