### PR TITLE
fix(vault): reflect drag-into-fresh-folder moves so files don't vanish (#423)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.5",
+      "version": "1.1.6-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.5",
+  "version": "1.1.6-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -305,11 +305,20 @@ export class VaultModelBuilder {
    * Returns `true` if the rename happened, `false` if the source
    * wasn't in the model or the destination's parent is missing.
    */
-  renameOne(oldPath: string, newPath: string): boolean {
+  renameOne(oldPath: string, newPath: string, opts: { ensureParents?: boolean } = {}): boolean {
     if (!oldPath || !newPath || oldPath === newPath) return false;
     const target = this.vault.getAbstractFileByPath(oldPath);
     if (!target) return false;
-    const newParent = this.resolveParent(newPath);
+    // The destination subtree may not be modelled yet — e.g. a note
+    // dragged into a freshly-created folder (#423). On the writer-reflect
+    // path we synthesise the missing parent chain instead of bailing,
+    // symmetric with `insertOne({ ensureParents: true })`. The bulk
+    // `build()` path and remote-echo `FsChangeListener` leave
+    // `ensureParents` off so a missing parent stays a sanity-check error.
+    let newParent = this.resolveParent(newPath);
+    if (!newParent && opts.ensureParents) {
+      newParent = this.ensureParentFolder(newPath);
+    }
     if (!newParent) {
       logger.warn(`VaultModelBuilder.renameOne: parent missing for "${newPath}"`);
       return false;
@@ -436,7 +445,17 @@ export class VaultModelBuilder {
 
   /** Reflect a writer-side `adapter.rename`. */
   reflectRename(oldPath: string, newPath: string): void {
-    if (!this.renameOne(oldPath, newPath)) {
+    // Obsidian's own `Vault.rename` may have already relocated the entry
+    // to the new path before this writer-reflect runs. The desired end
+    // state already holds, so it's a benign no-op — not the #341/#423
+    // divergence — and must not log a misleading "stale" warning.
+    if (!this.vault.getAbstractFileByPath(oldPath) && this.vault.getAbstractFileByPath(newPath)) {
+      return;
+    }
+    // `ensureParents`: a move into a not-yet-modelled folder (#423) must
+    // synthesise the destination subtree rather than drop the file from
+    // the model (which makes it vanish from File Explorer until reopen).
+    if (!this.renameOne(oldPath, newPath, { ensureParents: true })) {
       // The open editor tab stays bound to the stale TFile — this is
       // the core #341 failure. renameOne already warns with the
       // specific cause; add the reflect context.

--- a/plugin/tests/VaultModelBuilder.test.ts
+++ b/plugin/tests/VaultModelBuilder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { VaultModelBuilder, type RemoteEntry, type ObsidianClassDeps } from '../src/vault/VaultModelBuilder';
+import { logger } from '../src/util/logger';
 
 /**
  * Minimal stubs that mirror the structural shape of TFile / TFolder
@@ -613,5 +614,93 @@ describe('VaultModelBuilder.reflect* (#341 writer self-reflect)', () => {
 
     expect(() => builder.reflectRemove('never-seen.md')).not.toThrow();
     expect(triggers).toEqual([]);
+  });
+});
+
+// ─── #423: move into a folder the writer model hasn't caught up to ──────────
+//
+// Field repro (issue #423): a user creates a folder and drags several
+// top-level notes into it. The destination folder exists on the remote
+// but the writer's vault model is momentarily stale, so `renameOne`'s
+// strict `resolveParent` returns null and the reflect bails with
+// "writer vault model is stale". The notes then vanish from File
+// Explorer (detached from the old path, never attached to the new one)
+// until a full reopen re-populates the model.
+//
+// `reflectRename` is the writer-reflect entry point and MUST tolerate a
+// stale destination subtree — exactly as `reflectWrite` already does via
+// `insertOne({ ensureParents: true })`. The low-level `renameOne` keeps
+// its strict contract for the bulk-build sanity check; only the
+// writer-reflect path synthesises. These cases fail today.
+describe('VaultModelBuilder.reflectRename — stale destination subtree (#423)', () => {
+  it('synthesises the destination folder and moves the file when the target folder is not modelled', () => {
+    const { vault, fileMap, triggers } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+
+    builder.reflectWrite('note.md');           // source exists at top level
+    triggers.length = 0;
+
+    // "Folder" exists on the remote but the writer model hasn't caught
+    // up yet — the #423 drag-into-a-fresh-folder race.
+    builder.reflectRename('note.md', 'Folder/note.md');
+
+    expect(fileMap['note.md']).toBeUndefined();
+    expect(fileMap['Folder']).toBeInstanceOf(FakeTFolder);
+    expect(fileMap['Folder/note.md']).toBeDefined();
+    expect((fileMap['Folder/note.md'] as FakeTFile).path).toBe('Folder/note.md');
+    const renameEvt = triggers.find((t) => t.event === 'rename');
+    expect(renameEvt, 'a rename trigger must fire so File Explorer relocates the item').toBeDefined();
+    expect(renameEvt?.args[1]).toBe('note.md');
+  });
+
+  it('moves several top-level notes into the same fresh folder (exact #423 field-log shape)', () => {
+    const { vault, fileMap } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+    builder.reflectMkdir('Zettelkasten');
+    builder.reflectWrite('Zettelkasten/a.md');
+    builder.reflectWrite('Zettelkasten/b.md');
+    builder.reflectWrite('Zettelkasten/c.md');
+
+    // "Baza" is created, then the three notes are dragged into it.
+    builder.reflectRename('Zettelkasten/a.md', 'Zettelkasten/Baza/a.md');
+    builder.reflectRename('Zettelkasten/b.md', 'Zettelkasten/Baza/b.md');
+    builder.reflectRename('Zettelkasten/c.md', 'Zettelkasten/Baza/c.md');
+
+    expect(fileMap['Zettelkasten/Baza']).toBeInstanceOf(FakeTFolder);
+    for (const f of ['a', 'b', 'c']) {
+      expect(fileMap[`Zettelkasten/Baza/${f}.md`], `${f}.md should land in Baza`).toBeDefined();
+      expect(fileMap[`Zettelkasten/${f}.md`], `${f}.md should leave its old location`).toBeUndefined();
+    }
+  });
+
+  it('renames into a deeply nested fresh subtree by synthesising the whole chain', () => {
+    const { vault, fileMap } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+    builder.reflectWrite('note.md');
+
+    builder.reflectRename('note.md', 'a/b/c/note.md');
+
+    expect(fileMap['a']).toBeInstanceOf(FakeTFolder);
+    expect(fileMap['a/b']).toBeInstanceOf(FakeTFolder);
+    expect(fileMap['a/b/c']).toBeInstanceOf(FakeTFolder);
+    expect(fileMap['a/b/c/note.md']).toBeDefined();
+    expect(fileMap['note.md']).toBeUndefined();
+  });
+
+  it('does not log "writer vault model is stale" when Obsidian already moved the file (benign echo)', () => {
+    const { vault, fileMap } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+    builder.reflectMkdir('Folder');
+    builder.reflectWrite('Folder/note.md');    // file already at the destination
+
+    const warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+    // Source key already gone — Obsidian's own rename ran first.
+    builder.reflectRename('note.md', 'Folder/note.md');
+    // Capture before restoring: mockRestore() also clears mock.calls.
+    const staleWarnings = warn.mock.calls.filter((c) => String(c[0]).includes('writer vault model is stale'));
+    warn.mockRestore();
+
+    expect(fileMap['Folder/note.md']).toBeDefined();
+    expect(staleWarnings, 'a no-op move must not be reported as a stale-model divergence').toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Problem (#423)

Dragging a note into a freshly-created folder makes it **disappear from File Explorer** — gone from the old location, never shown in the target — until the vault is closed and reopened. The field log shows:

```
VaultModelBuilder.reflectRename: "Zettelkasten/X.md" → "Zettelkasten/Baza/X.md" not reflected; writer vault model is stale (editor may still point at the old path)
```

## Root cause

The writer-reflect rename bailed whenever the destination folder was not yet in the vault model. `renameOne` resolved the new parent **strictly** (`resolveParent` → `null` when the folder isn't modelled yet) and returned `false`, so the entry was detached from the old path but never re-attached to the new one — it fell out of `vault.fileMap` entirely.

This is asymmetric with `reflectWrite`, which already synthesises a missing parent chain via `insertOne({ ensureParents: true })`. The rename path never gained the same tolerance, so the #341 fix (synchronous writer reflect) didn't cover drag-into-a-new-folder — which is why #423 was reported *after* that fix shipped.

## Fix

- `reflectRename` now asks `renameOne` to synthesise the destination parent chain (`ensureParents`), mirroring `reflectWrite`. The move lands even when the destination subtree is stale.
- It also returns early — **without** a misleading "stale" warning — when Obsidian's own `Vault.rename` already relocated the entry (benign echo).
- The low-level `renameOne` stays **strict by default**: the bulk-`build()` path and the remote-echo `FsChangeListener` keep their missing-parent sanity check (`ensureParents` is opt-in, only the writer-reflect path uses it).

## Tests

`tests/VaultModelBuilder.test.ts` gains a `reflectRename — stale destination subtree (#423)` block (4 cases) that was **RED before this change**:

- move into a not-yet-modelled folder synthesises the parent
- several notes into one fresh folder (exact field-log shape)
- a deeply nested fresh subtree
- a benign echo (Obsidian moved the file first) must not warn "stale"

Full suite: 40/40 green; `tsc --noEmit`, eslint, and the rename-adjacent suites (FsChangeListener ×2, RenameLeafFollower) all pass.

Refs #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)