### PR TITLE
fix(shadow): round-trip community-plugins so installed plugins persist (#429, #342)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.1",
+      "version": "1.1.6-beta.2",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.1",
+  "version": "1.1.6-beta.2",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -593,6 +593,25 @@ export default class RemoteSshPlugin extends Plugin {
         );
       }
 
+      // #429 / #342 residual: round-trip the enabled community-plugins
+      // list. Pull first so plugins set up on the remote load in the
+      // shadow vault (the marketplace installer then fetches any missing
+      // binaries); then push the merged result so a plugin present only
+      // locally reaches the remote for other machines. Pushing *after*
+      // the pull is safe — the local list is now the union, so it can
+      // never drop a plugin the remote already had. Kept out of the
+      // verbatim shared-config set because `remote-ssh` must be
+      // force-preserved through the merge (a verbatim copy of a remote
+      // list omitting it would disable this very plugin).
+      try {
+        await ShadowVaultBootstrap.pullCommunityPlugins(da, remoteConfigDir, localConfigDir);
+        await ShadowVaultBootstrap.pushCommunityPlugins(da, remoteConfigDir, localConfigDir);
+      } catch (e) {
+        logger.warn(
+          `runAutoConnect(${tag}): community-plugins round-trip failed: ${errorMessage(e)}`,
+        );
+      }
+
       // #342 push half: pull only brought remote→local. Without this,
       // a settings change made HERE never reaches the remote, so the
       // next session's pull finds nothing and the change evaporates.

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -422,6 +422,131 @@ export class ShadowVaultBootstrap {
     return { pushed, skipped, errored };
   }
 
+  // ─── community-plugins list round-trip (#429 / #342) ─────────────────────
+  //
+  // `community-plugins.json` is the *enabled community plugins* list.
+  // It deliberately does NOT join SHARED_OBSIDIAN_CONFIG_FILES (whose
+  // pull/push copy bytes verbatim): a remote list that omitted
+  // `remote-ssh` would, written verbatim, disable the very plugin doing
+  // the sync. Instead these two methods round-trip the list with a
+  // forced `remote-ssh` union, so a plugin enabled on one machine
+  // reaches another machine's shadow vault and reopening no longer
+  // "loses" installed plugins. The marketplace installer re-fetches any
+  // binaries the list names but that aren't staged locally yet.
+
+  /** The plugin's own id — always kept enabled across a round-trip. */
+  static readonly SELF_PLUGIN_ID = 'remote-ssh';
+
+  /**
+   * Pull the remote enabled-plugin list into the shadow vault, merged
+   * with the local list and with `remote-ssh` forced on. A remote list
+   * that's absent or not a valid id array leaves the local list
+   * untouched (never clobbered).
+   */
+  static async pullCommunityPlugins(
+    reader: SharedConfigReader,
+    remoteConfigDir: string,
+    localConfigDir: string,
+  ): Promise<{ pulled: boolean; merged: string[] }> {
+    const basename = 'community-plugins.json';
+    const remoteRel = `${remoteConfigDir}/${basename}`;
+    const localPath = path.join(localConfigDir, basename);
+
+    fs.mkdirSync(localConfigDir, { recursive: true });
+    const local = ShadowVaultBootstrap.readPluginIdList(localPath);
+
+    let remote: string[] | null = null;
+    try {
+      if (await reader.exists(remoteRel)) {
+        remote = ShadowVaultBootstrap.parsePluginIdList(await reader.read(remoteRel));
+        if (remote === null) {
+          logger.warn(
+            `pullCommunityPlugins: remote ${basename} is not a valid id array; keeping local list`,
+          );
+        }
+      }
+    } catch (e) {
+      logger.warn(`pullCommunityPlugins: ${basename} skipped (${errorMessage(e)})`);
+    }
+
+    const merged = ShadowVaultBootstrap.mergePluginIds(
+      local, remote ?? [], ShadowVaultBootstrap.SELF_PLUGIN_ID,
+    );
+    const changed =
+      merged.length !== local.length || merged.some((id, i) => id !== local[i]);
+    if (changed) ShadowVaultBootstrap.writePluginIdListAtomic(localPath, merged);
+
+    logger.info(`pullCommunityPlugins: merged [${merged.join(', ')}] (changed=${changed})`);
+    return { pulled: remote !== null, merged };
+  }
+
+  /**
+   * Push the local enabled-plugin list to the remote, with `remote-ssh`
+   * forced on. Last-write-wins (matching the v1 no-CRDT policy); the
+   * pull's union means machines still converge toward the superset.
+   */
+  static async pushCommunityPlugins(
+    writer: SharedConfigWriter,
+    remoteConfigDir: string,
+    localConfigDir: string,
+  ): Promise<{ pushed: boolean }> {
+    const basename = 'community-plugins.json';
+    const localPath = path.join(localConfigDir, basename);
+    const ids = ShadowVaultBootstrap.mergePluginIds(
+      ShadowVaultBootstrap.readPluginIdList(localPath), [], ShadowVaultBootstrap.SELF_PLUGIN_ID,
+    );
+    try {
+      await writer.write(`${remoteConfigDir}/${basename}`, JSON.stringify(ids) + '\n');
+      logger.info(`pushCommunityPlugins: pushed [${ids.join(', ')}]`);
+      return { pushed: true };
+    } catch (e) {
+      logger.warn(`pushCommunityPlugins: push failed (${errorMessage(e)})`);
+      return { pushed: false };
+    }
+  }
+
+  /** Parse a community-plugins.json body into a string-id array, or null if malformed. */
+  private static parsePluginIdList(content: string): string[] | null {
+    try {
+      const parsed: unknown = JSON.parse(content);
+      if (!Array.isArray(parsed)) return null;
+      return (parsed as unknown[]).filter((s): s is string => typeof s === 'string');
+    } catch {
+      return null;
+    }
+  }
+
+  /** Read a local community-plugins.json into an id array ([] when absent/malformed). */
+  private static readPluginIdList(localPath: string): string[] {
+    try {
+      return ShadowVaultBootstrap.parsePluginIdList(fs.readFileSync(localPath, 'utf-8')) ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Order-preserving union of `local` + `remote`, with `required` guaranteed present. */
+  private static mergePluginIds(local: string[], remote: string[], required: string): string[] {
+    const out: string[] = [];
+    const seen = new Set<string>();
+    for (const id of [...local, ...remote, required]) {
+      if (!seen.has(id)) { seen.add(id); out.push(id); }
+    }
+    return out;
+  }
+
+  /** Atomic (tmp + rename) write of an id array as JSON. */
+  private static writePluginIdListAtomic(localPath: string, ids: string[]): void {
+    const tmp = `${localPath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(ids) + '\n', 'utf-8');
+    try {
+      fs.renameSync(tmp, localPath);
+    } catch (e) {
+      try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+      throw e;
+    }
+  }
+
   // ─── internals ──────────────────────────────────────────────────────────
 
   /**

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { ShadowVaultBootstrap } from '../src/shadow/ShadowVaultBootstrap';
+import type { SharedConfigReader, SharedConfigWriter } from '../src/shadow/ShadowVaultBootstrap';
 import { ObsidianRegistry } from '../src/shadow/ObsidianRegistry';
 import type { SshProfile, PendingPluginSuggestion } from '../src/types';
 
@@ -954,5 +955,116 @@ describe('ShadowVaultBootstrap — seedObsidianFirstRunState', () => {
 
     await r.bootstrap(profile, [profile]);
     expect(fs.readFileSync(corePath, 'utf-8')).toBe(custom);
+  });
+});
+
+// ─── community-plugins round-trip (#429 / #342 residual) ────────────────
+//
+// app/appearance/core-plugins/hotkeys already round-trip via
+// pull/pushSharedObsidianConfig, but the *enabled community-plugins*
+// list does NOT: it is only ever seeded locally as ["remote-ssh"]
+// (see the bootstrap suite above). So a plugin enabled on machine A
+// never reaches machine B's shadow vault, and reopening the vault
+// "loses" installed plugins — exactly kazink's #429 follow-up and the
+// #342 residual.
+//
+// community-plugins.json must NOT join the verbatim
+// SHARED_OBSIDIAN_CONFIG_FILES set: a remote list that happens to omit
+// `remote-ssh` would, written verbatim, disable the very plugin doing
+// the sync. The fix is a dedicated pull/push pair that round-trips the
+// list while always keeping `remote-ssh` enabled. These fail today —
+// the methods do not exist yet.
+describe('ShadowVaultBootstrap community-plugins round-trip (#429 / #342)', () => {
+  function makeLocalConfigDir(seed: string[] = ['remote-ssh']): string {
+    const dir = path.join(
+      os.tmpdir(),
+      `cp-roundtrip-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      '.obsidian',
+    );
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'community-plugins.json'), JSON.stringify(seed), 'utf-8');
+    return dir;
+  }
+  function readLocal(dir: string): string[] {
+    return JSON.parse(fs.readFileSync(path.join(dir, 'community-plugins.json'), 'utf-8'));
+  }
+
+  it('pulls the remote enabled-plugin list into the shadow vault, keeping remote-ssh enabled', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh']);
+    const remote: Record<string, string> = {
+      '.obsidian/community-plugins.json': JSON.stringify(['dataview', 'templater']),
+    };
+    const reader: SharedConfigReader = {
+      exists: (p) => Promise.resolve(p in remote),
+      read: (p) => Promise.resolve(remote[p]),
+    };
+
+    await ShadowVaultBootstrap.pullCommunityPlugins(reader, '.obsidian', localConfigDir);
+
+    expect(readLocal(localConfigDir)).toEqual(
+      expect.arrayContaining(['dataview', 'templater', 'remote-ssh']),
+    );
+  });
+
+  it('keeps remote-ssh enabled even when the remote list omits it', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh']);
+    const remote: Record<string, string> = {
+      '.obsidian/community-plugins.json': JSON.stringify(['dataview']),
+    };
+    const reader: SharedConfigReader = {
+      exists: (p) => Promise.resolve(p in remote),
+      read: (p) => Promise.resolve(remote[p]),
+    };
+
+    await ShadowVaultBootstrap.pullCommunityPlugins(reader, '.obsidian', localConfigDir);
+
+    const local = readLocal(localConfigDir);
+    expect(local, 'remote-ssh must survive a pull that omits it').toContain('remote-ssh');
+    expect(local).toContain('dataview');
+  });
+
+  it('is a benign no-op when the remote has no community-plugins.json yet', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh']);
+    const reader: SharedConfigReader = {
+      exists: () => Promise.resolve(false),
+      read: () => Promise.reject(new Error('must not read an absent file')),
+    };
+
+    await expect(
+      ShadowVaultBootstrap.pullCommunityPlugins(reader, '.obsidian', localConfigDir),
+    ).resolves.toBeDefined();
+    expect(readLocal(localConfigDir)).toEqual(['remote-ssh']);
+  });
+
+  it('does not clobber a healthy local list when the remote list is corrupt JSON', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh', 'dataview']);
+    const remote: Record<string, string> = {
+      '.obsidian/community-plugins.json': '{ this is : not json',
+    };
+    const reader: SharedConfigReader = {
+      exists: (p) => Promise.resolve(p in remote),
+      read: (p) => Promise.resolve(remote[p]),
+    };
+
+    await ShadowVaultBootstrap.pullCommunityPlugins(reader, '.obsidian', localConfigDir);
+
+    expect(readLocal(localConfigDir)).toEqual(
+      expect.arrayContaining(['remote-ssh', 'dataview']),
+    );
+  });
+
+  it('pushes the locally-enabled plugins to the remote, preserving remote-ssh', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh', 'dataview']);
+    const remote: Record<string, string> = {};
+    const writer: SharedConfigWriter = {
+      write: (p, content) => { remote[p] = content; return Promise.resolve(); },
+    };
+
+    await ShadowVaultBootstrap.pushCommunityPlugins(writer, '.obsidian', localConfigDir);
+
+    expect(remote['.obsidian/community-plugins.json'], 'a push must write the list to the remote').toBeDefined();
+    const pushed = JSON.parse(remote['.obsidian/community-plugins.json']);
+    expect(pushed).toContain('dataview');
+    expect(pushed).toContain('remote-ssh');
   });
 });


### PR DESCRIPTION
## Problem (#429 / #342 residual)

`app.json` / `appearance.json` / `core-plugins.json` / `hotkeys.json` already round-trip between the remote and the local shadow vault (#342). The **enabled community-plugins list** (`community-plugins.json`) does not — it's only ever seeded locally as `["remote-ssh"]`. Consequences reported in #429 / the #342 thread:

- Plugins set up on the remote vault are shown in the file explorer but **not loaded** in the shadow vault.
- Reopening the vault appears to "lose" installed plugins.

## Why it's not just "add it to the shared set"

`pull/pushSharedObsidianConfig` copy bytes **verbatim**. If the remote `community-plugins.json` happened to omit `remote-ssh`, a verbatim copy would **disable the very plugin doing the sync**. So the list needs a merge that always keeps `remote-ssh`, not a verbatim copy.

## Fix

New `ShadowVaultBootstrap.pullCommunityPlugins` / `pushCommunityPlugins`:

- **pull** merges remote → local with `remote-ssh` forced on; an absent or malformed remote list leaves the local list untouched (never clobbered). The existing marketplace installer fetches any binaries the merged list names.
- **push** writes the local list to the remote with `remote-ssh` forced on (last-write-wins, matching the v1 no-CRDT policy).

The connect flow (`runAutoConnect`) **pulls then pushes** — pushing after the merge can never drop a plugin the remote already had, so machines converge toward the union.

## Tests (RED → GREEN)

`tests/ShadowVaultBootstrap.test.ts` gains a community-plugins round-trip block (5 cases): pull merges + keeps remote-ssh, keeps remote-ssh when the remote omits it, benign no-op when the remote has none, no-clobber on corrupt remote JSON, and push preserves remote-ssh. All green; `tsc --noEmit`, eslint, and the shadow/watcher suites (71 tests) pass.

## Known follow-ups (not in this PR)
- Mid-session live push (the `SharedConfigWatcher` filters strictly to the verbatim shared set; community-plugins is round-tripped at connect granularity here).
- The marketplace installer runs once before the pull, so a brand-new remote plugin's **binary** downloads on the *next* startup (the list is correct immediately).

Refs #429 #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)