### PR TITLE
docs: purge the stale "shadow vault syncs fs writes to remote" misconception (#429)

### DIFF
--- a/docs/en/architecture/index.md
+++ b/docs/en/architecture/index.md
@@ -11,7 +11,7 @@ Design specs for the major subsystems — the **why** behind decisions, not just
 
 | Doc | What it covers |
 |---|---|
-| [[shadow-vault\|Shadow vault]] | The "local Obsidian vault that mirrors remote" model — shadow lifecycle, file routing, sync events |
+| [[shadow-vault\|Shadow vault]] | The shadow-vault model (a local vault whose patched adapter serves the remote virtually) — lifecycle, file routing, change events |
 | [[perf\|Performance]] | Sync latency budget, perf bench, the per-merge baseline tracking on `perf-baseline` branch |
 | [[collab\|Collaboration]] | Multi-client editing, conflict handling, the per-client `.obsidian/user/<id>/` workspace partition |
 | [[release-pipeline\|Release & deploy pipeline]] | Two-channel release model, `release.yml` signing flow, sync workflow, branch-aware lint/version-check, plugin-side deploy lifecycle |
@@ -28,9 +28,9 @@ The daemon is the only thing that touches the actual vault files. The plugin nev
 
 ### "Shadow vault is a real local vault"
 
-Obsidian's plugin API is opinionated about vault paths. Rather than forking Obsidian's vault layer to be remote-aware (a multi-month investment), the shadow vault model just creates a real vault on your local disk and syncs files. Every Obsidian feature works without modification.
+Obsidian's plugin API is opinionated about vault paths. Rather than forking Obsidian's vault layer to be remote-aware (a multi-month investment), the shadow vault model creates a real local vault but patches its adapter so every file op goes to the remote — the notes are never copied to local disk (only `.obsidian/` lives there). Every Obsidian feature works without modification.
 
-The cost: storage on your local machine grows with what you have opened. The plugin keeps a hot cache of recently-touched files; LRU eviction frees space for files not opened in N days.
+The cost: file ops need the remote reachable and pay per-op SSH/RPC latency. An in-memory cache (capped) speeds re-reads of recently-touched files.
 
 ### v1.x stability promises
 

--- a/docs/en/getting-started/first-connect.md
+++ b/docs/en/getting-started/first-connect.md
@@ -8,13 +8,13 @@ description: "What happens when you click Connect: SSH handshake, daemon auto-de
 
 ## The shadow vault model
 
-obsidian-remote-ssh does not edit your remote files directly through Obsidian's vault layer. Instead it:
+obsidian-remote-ssh doesn't keep a synced copy of your vault — the remote is the single source of truth. Instead it:
 
-1. Creates a **local shadow vault** under `~/.obsidian-remote/vaults/<profile-id>/`. This is a real Obsidian vault on your local disk.
-2. Mirrors the remote vault's files into that shadow vault (lazily — large files are fetched on first open).
-3. Watches both sides for changes and syncs them through the SSH-tunneled daemon RPC.
+1. Creates a **local shadow vault** under `~/.obsidian-remote/vaults/<profile-id>/` — a real Obsidian vault dir, but only `.obsidian/` config lives on disk.
+2. Patches that vault's file adapter so every read/write goes **directly to the remote** over the SSH-tunneled daemon (or SFTP). Your notes are served virtually — never copied to local disk.
+3. The daemon's `fs.watch` pushes remote changes back, so the file explorer and open editors update live (~1 s).
 
-Result: Obsidian thinks it's editing a local vault. All Obsidian features (Dataview, Templater, Excalidraw, …) work because they ARE working against a local vault. The "remote-ness" lives in the sync layer, invisible to most plugins.
+Result: Obsidian thinks it's editing a local vault, so all features (Dataview, Templater, Excalidraw, …) work — but every file op actually hits the remote. (Plugins that bypass the vault API and use Node `fs` directly are the exception — see #429.)
 
 See [[shadow-vault|Shadow vault architecture]] for the full design.
 

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -95,7 +95,7 @@ The default-recommended transport mode — plugin auto-deploys the daemon and sp
 The current factory default transport — uses SSH's SFTP subsystem directly (no daemon). Higher per-op latency, no `fs.watch`, but works on hosts where you cannot deploy a binary.
 
 **Shadow vault**
-A local Obsidian vault under `~/.obsidian-remote/vaults/<profile-id>/` whose file adapter is patched so reads and writes go **directly to the remote** over SSH. It is **not** a synced local copy: only `.obsidian/` config + plugin binaries live on local disk, while the notes are served *virtually* from the remote — the single source of truth, with no local copy to diverge (so no `(conflicted copy)`). Obsidian treats it as a normal local vault. (Plugins that bypass the vault API and hit Node `fs` directly are the exception — their writes stay local; see #429.) See [[en/architecture/shadow-vault|Shadow vault architecture]].
+A local Obsidian vault under `~/.obsidian-remote/vaults/<profile-id>/` whose adapter sends every read/write straight to the remote — the single source of truth, **not** a synced copy. Only `.obsidian/` is on disk; notes are virtual. Exception: plugins writing via raw Node `fs` instead of the vault API stay local (#429). See [[en/architecture/shadow-vault|Shadow vault architecture]].
 
 **Sync workflow** — *`.github/workflows/sync-main-to-next.yml`*
 After every push to `main`, opens a PR `main → next` and enables auto-merge so the histories rejoin. Prevents drift between channels.

--- a/docs/en/glossary.md
+++ b/docs/en/glossary.md
@@ -95,7 +95,7 @@ The default-recommended transport mode — plugin auto-deploys the daemon and sp
 The current factory default transport — uses SSH's SFTP subsystem directly (no daemon). Higher per-op latency, no `fs.watch`, but works on hosts where you cannot deploy a binary.
 
 **Shadow vault**
-A local-disk Obsidian vault under `~/.obsidian-remote/vaults/<profile-id>/` that mirrors the remote vault. Obsidian thinks it's editing local files; the plugin syncs them to the remote via the daemon. See [[en/architecture/shadow-vault|Shadow vault architecture]].
+A local Obsidian vault under `~/.obsidian-remote/vaults/<profile-id>/` whose file adapter is patched so reads and writes go **directly to the remote** over SSH. It is **not** a synced local copy: only `.obsidian/` config + plugin binaries live on local disk, while the notes are served *virtually* from the remote — the single source of truth, with no local copy to diverge (so no `(conflicted copy)`). Obsidian treats it as a normal local vault. (Plugins that bypass the vault API and hit Node `fs` directly are the exception — their writes stay local; see #429.) See [[en/architecture/shadow-vault|Shadow vault architecture]].
 
 **Sync workflow** — *`.github/workflows/sync-main-to-next.yml`*
 After every push to `main`, opens a PR `main → next` and enables auto-merge so the histories rejoin. Prevents drift between channels.

--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -38,8 +38,8 @@ Numbers in the table reflect a `~/work/VaultDev`-class remote
 | Plugin | Access pattern | Status | Notes |
 |---|---|---|---|
 | Dataview | reads every MD file via `app.vault.cachedRead` for the index, then queries against `app.metadataCache` | ✅ verified-by-harness (#124 F11) | Initial index build does N reads on connect. ReadCache absorbs subsequent queries. Watch for noticeable startup delay on bigger vaults. F11 harness scenario (`plugin/tests/compat/dataview.test.ts`) drives `dv.pages()`-shape queries against a 5-page fixture and asserts frontmatter scalars + aggregations round-trip through `metadataCache.getFileCache()`. |
-| Templater | reads templates from a configured folder, evaluates JS, writes through `app.vault.modify` / `create`. `tp.file.path(false)` and the `child_process.exec` cwd path read `adapter.basePath`. | ✅ verified-by-harness (#124 F12) | `basePath` now resolves to the shadow-vault local root via #170, so `tp.file.path(false)` returns a path whose `fs.readFileSync` finds mirrored content. JS user functions that import Node `fs` and write under `basePath` land in the shadow dir, which propagates to the remote. F12 harness scenario (`plugin/tests/compat/templater.test.ts`) drives `tp.file.create_new` against 3 fixture templates (date placeholder, frontmatter + title, no-date) and asserts `vault.create` + `vault.modify` round-trip with `metadataCache` reflecting the new frontmatter. |
-| Kanban | stores boards as MD files with YAML frontmatter; standard vault read/write on every drag. Clipboard image paste joins `(adapter as any).basePath` with the attachment path and calls `fs.copyFile`. | 🟡 expected (smoke pending after #170) | Each card move = 1 write. Network latency may show as a noticeable lag on big boards; otherwise fine. Clipboard paste is fixed by #170: `basePath` now resolves to the shadow-vault local root, so `fs.copyFile` lands in the shadow dir. |
+| Templater | reads templates from a configured folder, evaluates JS, writes through `app.vault.modify` / `create`. `tp.file.path(false)` and the `child_process.exec` cwd path read `adapter.basePath`. | ✅ verified-by-harness (#124 F12) | `basePath` now resolves to the shadow-vault local root via #170, so `tp.file.path(false)` no longer returns `undefined` and `child_process.exec`'s cwd is valid. **Caveat:** the vault tree is served virtually from the remote (not mirrored to local disk — see *Direct-disk / agentic plugins* below, #429), so a Templater JS user script that reads/writes vault notes through Node `fs` only sees the local shadow copy: such reads can miss remote notes and such writes do **not** reach the remote. The `vault.create` / `vault.modify` path *does* round-trip — F12 harness scenario (`plugin/tests/compat/templater.test.ts`) drives `tp.file.create_new` against 3 fixture templates (date placeholder, frontmatter + title, no-date) and asserts `vault.create` + `vault.modify` round-trip with `metadataCache` reflecting the new frontmatter. |
+| Kanban | stores boards as MD files with YAML frontmatter; standard vault read/write on every drag. Clipboard image paste joins `(adapter as any).basePath` with the attachment path and calls `fs.copyFile`. | 🟡 expected (smoke pending after #170) | Each card move = 1 write. Network latency may show as a noticeable lag on big boards; otherwise fine. Clipboard paste no longer crashes after #170 (`basePath` resolves to the shadow-vault local root), but `fs.copyFile` lands in the **local shadow copy only** — the pasted image does not reach the remote (the vault tree is served virtually, not mirrored; see *Direct-disk / agentic plugins*, #429). Board edits made through the vault API (card moves) do round-trip. |
 | Thino | reads/writes daily-note-style files; standard vault API | 🟡 expected | Pure vault API user. No special concerns. |
 | Commander | UI plugin: ribbon icons, hotkeys, command macros. Doesn't touch vault files for its own state (uses plugin data via `loadData`/`saveData`, which goes through the patched adapter) | 🟡 expected | If a custom command invokes a different plugin, the wrapped plugin's compatibility applies. |
 | Emoji Shortcodes | pure UI typing helper. No filesystem access | ✅ verified-by-architecture | Not affected by adapter patching at all. |
@@ -47,7 +47,7 @@ Numbers in the table reflect a `~/work/VaultDev`-class remote
 | Meta Bind | input bindings on YAML / inline frontmatter; reads / writes via vault API | 🟡 expected | Each input change writes the host note. Latency is noticeable but functional. |
 | Omnisearch | full-text indexer: reads every file in the vault on init + on changes | ⚠️ degraded (expected) | This is the most network-bound plugin in the list. Initial index build on a remote vault can take seconds-to-minutes depending on size. After the warm cache, queries are local. Recommendation: only enable Omnisearch when the connection is stable. |
 | QuickLatex | renders LaTeX inline. Pure UI, no FS access | ✅ verified-by-architecture | Not affected. |
-| Importer | converts external formats (Evernote `.enex`, etc.) to MD using `path.join(getBasePath(), folder.path)` as `outputDir` for the Yarle Evernote converter (Node `fs.writeFile`) | 🟡 expected (smoke pending after #170) | `getBasePath()` now returns the shadow-vault local root via #170, so the converter writes files into the shadow dir; the file-watcher propagates them to the remote. Initial conversion of a large `.enex` may produce many writes; watch for queue lag. |
+| Importer | converts external formats (Evernote `.enex`, etc.) to MD using `path.join(getBasePath(), folder.path)` as `outputDir` for the Yarle Evernote converter (Node `fs.writeFile`) | 🟡 expected (smoke pending after #170) | `getBasePath()` now returns the shadow-vault local root via #170, so the Yarle converter no longer crashes — but its Node `fs` writes land in the **local shadow copy only** and do **not** reach the remote (the vault tree is served virtually, not mirrored; see *Direct-disk / agentic plugins*, #429). To import into a remote vault, run the converter against a local vault and move the result over, or import via a plugin that uses the Obsidian vault API. |
 | Copilot | reads `getBasePath?.()` then falls back to `basePath` for local-context AI indexing (`src/miyo/miyoUtils.ts`) | 🟡 expected (smoke pending after #170) | Either form now resolves to the shadow-vault local root via #170, so Copilot's local-context indexing operates against the synced copy. The remote is the source of truth; the index reflects whatever has been mirrored to the shadow dir. |
 | Git (Vinzent03) | desktop hardcodes `SimpleGit` (spawns local `git` against `getBasePath()`); mobile uses `IsomorphicGit` via `MyAdapter(vault.adapter)` (pure JS, no shell-out) | ❌ broken on desktop / fixable upstream | The desktop path silently mis-routes commits to the shadow git repo, not the remote. The isomorphic-git path *would* work transparently against our remote adapter but is gated behind `Platform.isDesktopApp` with no toggle. **We won't ship a workaround** — see [#150](https://github.com/sotashimozono/obsidian-remote-ssh/issues/150) for the rationale. Users wanting git on a remote vault should use the integrated terminal pane ([#149](https://github.com/sotashimozono/obsidian-remote-ssh/issues/149)) or file a feature request at Vinzent03/obsidian-git for a `forceIsomorphicGit` toggle. |
 | Excalidraw | drawings stored as `.excalidraw.md` (JSON) or embedded markdown; embedded images go through `getResourcePath`. `pathToFileURL(adapter.basePath)` is used as a vault-membership prefix check (`src/utils/fileUtils.ts:343`). | ✅ verified-by-harness (#124 F13) | The `RPC` transport is required for the ResourceBridge to serve images. On `SFTP` transport, embedded images fall back to a broken `data:` URL. First read of a large `.excalidraw.md` pulls the whole JSON; subsequent edits stream cleanly. After #170 the prefix check stays internally consistent (both sides see the shadow path). F13 harness scenario (`plugin/tests/compat/excalidraw.test.ts`) covers `.excalidraw.md` text round-trip + binary attachment CRUD with byte-exact equality on a 1 KB cyclic blob and a 4 KB PNG-magic + xorshift32 payload. |
@@ -130,15 +130,23 @@ Things that aren't a specific plugin but trip plugins in general:
 
 - **`app.vault.adapter.basePath` and `getBasePath()`** resolve to the
   **shadow vault's** local root (e.g. `~/.obsidian-remote/vaults/<P-id>/`),
-  not the remote SSH path. Plugins that join paths against `basePath`
-  and feed them to Node `fs` directly read mirrored content and write
-  into the shadow dir; the file-watcher then propagates writes back to
-  the remote. This is the natural value of `FileSystemAdapter.basePath`
-  in the shadow window, and #170 patches both forms onto the
-  replacement adapter explicitly so the contract is stable across
-  Obsidian version upgrades. See the **basePath compat survey** section
-  below (#133, 2026-04-29) for the top-20 plugin survey, and #170 for
-  the implementation. **Exception:** plugins that shell out to a local
+  not the remote SSH path. #170 patches both forms onto the
+  replacement adapter so plugins that read `basePath` no longer crash
+  on `undefined`, and the contract is stable across Obsidian version
+  upgrades. **However, the vault tree (your notes) is served *virtually*
+  from the remote — it is NOT mirrored to local disk** (only `.obsidian/`
+  config + the plugin binaries live under that local root). So a plugin
+  that joins a vault path against `basePath` and hands it to Node `fs`
+  only ever touches the local shadow copy: reads of existing remote
+  notes won't find them, and writes create local-only files that do
+  **not** reach the remote. Only operations through the Obsidian vault
+  API (`vault.read/create/modify/...`, routed through the patched
+  adapter) round-trip; `.obsidian/` shared config round-trips via a
+  dedicated watcher (#342/#434). See *Direct-disk / agentic plugins*
+  below (#429) and the **basePath compat survey** (#133, 2026-04-29) —
+  but note the survey's "syncs up to the remote" mitigations assumed a
+  vault-tree file-watcher that was never built (see the correction in
+  that section). **Exception:** plugins that shell out to a local
   binary (notably obsidian-Git's `SimpleGit` desktop path) operate on
   the shadow git repo rather than the remote one — patching can't fix
   this from our side. obsidian-Git's bundled `IsomorphicGit` mode
@@ -163,6 +171,20 @@ Things that aren't a specific plugin but trip plugins in general:
   image-processing plugins outside the top-20 use this pattern
   (see survey section below). No webview-side URL rewriting is
   needed at this time.
+- **Direct-disk / agentic plugins** (e.g. Claude Code-style wrappers
+  such as "Claudian") — plugins that create or edit files by calling
+  Node `fs` directly, or by shelling out to a child process, bypass the
+  patched adapter entirely. Their writes land in the **local shadow
+  copy** (`~/.obsidian-remote/vaults/<id>/…`) and never reach the
+  remote — this is [#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429).
+  There is no automatic local→remote reconciler for the vault tree
+  (only `.obsidian/` shared config and the enabled-plugins list
+  round-trip, via #342/#434); adding one would reintroduce the
+  sync/reconcile model this plugin's single-source-of-truth design
+  deliberately avoids. **Recommendation:** drive note creation through
+  plugins that use the Obsidian vault API (`vault.create` / `modify`);
+  treat direct-disk / agentic tools as operating on a *local-only* copy
+  when pointed at a remote vault.
 
 ## Why we can't auto-test all of this
 
@@ -273,6 +295,20 @@ compare, child-process cwd, etc.).
 - **Smoke verification** of Templater / Kanban / Importer / Copilot
   in a real dev vault remains a manual step; the matrix above keeps
   these at `🟡 expected (smoke pending after #170)` until run.
+
+> **⚠️ Correction (2026-06-30, #429).** The survey's recommendations
+> above repeatedly say Node-`fs` writes under `basePath` "land in the
+> shadow vault, which the file-watcher syncs up to the remote." That
+> shadow→remote file-watcher **was never built for the vault tree** —
+> the only local→remote watcher that exists is `SharedConfigWatcher`,
+> scoped to `.obsidian/` shared config (#342) and the enabled-plugins
+> list (#434). #170 made `basePath` *return* the shadow-vault local
+> root (so plugins stop crashing on `undefined`), but it did **not**
+> create a local mirror of the vault tree or a sync path. The vault
+> tree is served virtually from the remote; a plugin's `fs` write to
+> `basePath` therefore stays in the local shadow copy and does not
+> reach the remote (this is #429). Read the per-plugin "fixed by #170"
+> notes as "no longer crashes," **not** "round-trips to the remote."
 
 ### Method
 

--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -38,8 +38,8 @@ Numbers in the table reflect a `~/work/VaultDev`-class remote
 | Plugin | Access pattern | Status | Notes |
 |---|---|---|---|
 | Dataview | reads every MD file via `app.vault.cachedRead` for the index, then queries against `app.metadataCache` | ✅ verified-by-harness (#124 F11) | Initial index build does N reads on connect. ReadCache absorbs subsequent queries. Watch for noticeable startup delay on bigger vaults. F11 harness scenario (`plugin/tests/compat/dataview.test.ts`) drives `dv.pages()`-shape queries against a 5-page fixture and asserts frontmatter scalars + aggregations round-trip through `metadataCache.getFileCache()`. |
-| Templater | reads templates from a configured folder, evaluates JS, writes through `app.vault.modify` / `create`. `tp.file.path(false)` and the `child_process.exec` cwd path read `adapter.basePath`. | ✅ verified-by-harness (#124 F12) | `basePath` now resolves to the shadow-vault local root via #170, so `tp.file.path(false)` no longer returns `undefined` and `child_process.exec`'s cwd is valid. **Caveat:** the vault tree is served virtually from the remote (not mirrored to local disk — see *Direct-disk / agentic plugins* below, #429), so a Templater JS user script that reads/writes vault notes through Node `fs` only sees the local shadow copy: such reads can miss remote notes and such writes do **not** reach the remote. The `vault.create` / `vault.modify` path *does* round-trip — F12 harness scenario (`plugin/tests/compat/templater.test.ts`) drives `tp.file.create_new` against 3 fixture templates (date placeholder, frontmatter + title, no-date) and asserts `vault.create` + `vault.modify` round-trip with `metadataCache` reflecting the new frontmatter. |
-| Kanban | stores boards as MD files with YAML frontmatter; standard vault read/write on every drag. Clipboard image paste joins `(adapter as any).basePath` with the attachment path and calls `fs.copyFile`. | 🟡 expected (smoke pending after #170) | Each card move = 1 write. Network latency may show as a noticeable lag on big boards; otherwise fine. Clipboard paste no longer crashes after #170 (`basePath` resolves to the shadow-vault local root), but `fs.copyFile` lands in the **local shadow copy only** — the pasted image does not reach the remote (the vault tree is served virtually, not mirrored; see *Direct-disk / agentic plugins*, #429). Board edits made through the vault API (card moves) do round-trip. |
+| Templater | reads templates from a configured folder, evaluates JS, writes through `app.vault.modify` / `create`. `tp.file.path(false)` and the `child_process.exec` cwd path read `adapter.basePath`. | ✅ verified-by-harness (#124 F12) | `vault.create` / `vault.modify` round-trips — F12 harness (`plugin/tests/compat/templater.test.ts`) drives `tp.file.create_new` against 3 fixtures and asserts frontmatter round-trips via `metadataCache`. #170 makes `tp.file.path(false)` / `exec` cwd non-`undefined`, but a JS user script using Node `fs` only sees the local shadow copy — those writes don't reach the remote (#429). |
+| Kanban | stores boards as MD files with YAML frontmatter; standard vault read/write on every drag. Clipboard image paste joins `(adapter as any).basePath` with the attachment path and calls `fs.copyFile`. | 🟡 expected (smoke pending after #170) | Each card move = 1 write (vault API → round-trips; latency may lag big boards). Clipboard image paste uses `fs.copyFile` → local shadow copy only, doesn't reach the remote (#429). |
 | Thino | reads/writes daily-note-style files; standard vault API | 🟡 expected | Pure vault API user. No special concerns. |
 | Commander | UI plugin: ribbon icons, hotkeys, command macros. Doesn't touch vault files for its own state (uses plugin data via `loadData`/`saveData`, which goes through the patched adapter) | 🟡 expected | If a custom command invokes a different plugin, the wrapped plugin's compatibility applies. |
 | Emoji Shortcodes | pure UI typing helper. No filesystem access | ✅ verified-by-architecture | Not affected by adapter patching at all. |
@@ -47,7 +47,7 @@ Numbers in the table reflect a `~/work/VaultDev`-class remote
 | Meta Bind | input bindings on YAML / inline frontmatter; reads / writes via vault API | 🟡 expected | Each input change writes the host note. Latency is noticeable but functional. |
 | Omnisearch | full-text indexer: reads every file in the vault on init + on changes | ⚠️ degraded (expected) | This is the most network-bound plugin in the list. Initial index build on a remote vault can take seconds-to-minutes depending on size. After the warm cache, queries are local. Recommendation: only enable Omnisearch when the connection is stable. |
 | QuickLatex | renders LaTeX inline. Pure UI, no FS access | ✅ verified-by-architecture | Not affected. |
-| Importer | converts external formats (Evernote `.enex`, etc.) to MD using `path.join(getBasePath(), folder.path)` as `outputDir` for the Yarle Evernote converter (Node `fs.writeFile`) | 🟡 expected (smoke pending after #170) | `getBasePath()` now returns the shadow-vault local root via #170, so the Yarle converter no longer crashes — but its Node `fs` writes land in the **local shadow copy only** and do **not** reach the remote (the vault tree is served virtually, not mirrored; see *Direct-disk / agentic plugins*, #429). To import into a remote vault, run the converter against a local vault and move the result over, or import via a plugin that uses the Obsidian vault API. |
+| Importer | converts external formats (Evernote `.enex`, etc.) to MD using `path.join(getBasePath(), folder.path)` as `outputDir` for the Yarle Evernote converter (Node `fs.writeFile`) | 🟡 expected (smoke pending after #170) | Yarle converter writes via Node `fs` → local shadow copy only, doesn't reach the remote (#429). To import to a remote vault, convert in a local vault and move the result over. |
 | Copilot | reads `getBasePath?.()` then falls back to `basePath` for local-context AI indexing (`src/miyo/miyoUtils.ts`) | 🟡 expected (smoke pending after #170) | Either form now resolves to the shadow-vault local root via #170, so Copilot's local-context indexing operates against the synced copy. The remote is the source of truth; the index reflects whatever has been mirrored to the shadow dir. |
 | Git (Vinzent03) | desktop hardcodes `SimpleGit` (spawns local `git` against `getBasePath()`); mobile uses `IsomorphicGit` via `MyAdapter(vault.adapter)` (pure JS, no shell-out) | ❌ broken on desktop / fixable upstream | The desktop path silently mis-routes commits to the shadow git repo, not the remote. The isomorphic-git path *would* work transparently against our remote adapter but is gated behind `Platform.isDesktopApp` with no toggle. **We won't ship a workaround** — see [#150](https://github.com/sotashimozono/obsidian-remote-ssh/issues/150) for the rationale. Users wanting git on a remote vault should use the integrated terminal pane ([#149](https://github.com/sotashimozono/obsidian-remote-ssh/issues/149)) or file a feature request at Vinzent03/obsidian-git for a `forceIsomorphicGit` toggle. |
 | Excalidraw | drawings stored as `.excalidraw.md` (JSON) or embedded markdown; embedded images go through `getResourcePath`. `pathToFileURL(adapter.basePath)` is used as a vault-membership prefix check (`src/utils/fileUtils.ts:343`). | ✅ verified-by-harness (#124 F13) | The `RPC` transport is required for the ResourceBridge to serve images. On `SFTP` transport, embedded images fall back to a broken `data:` URL. First read of a large `.excalidraw.md` pulls the whole JSON; subsequent edits stream cleanly. After #170 the prefix check stays internally consistent (both sides see the shadow path). F13 harness scenario (`plugin/tests/compat/excalidraw.test.ts`) covers `.excalidraw.md` text round-trip + binary attachment CRUD with byte-exact equality on a 1 KB cyclic blob and a 4 KB PNG-magic + xorshift32 payload. |
@@ -130,23 +130,15 @@ Things that aren't a specific plugin but trip plugins in general:
 
 - **`app.vault.adapter.basePath` and `getBasePath()`** resolve to the
   **shadow vault's** local root (e.g. `~/.obsidian-remote/vaults/<P-id>/`),
-  not the remote SSH path. #170 patches both forms onto the
-  replacement adapter so plugins that read `basePath` no longer crash
-  on `undefined`, and the contract is stable across Obsidian version
-  upgrades. **However, the vault tree (your notes) is served *virtually*
-  from the remote — it is NOT mirrored to local disk** (only `.obsidian/`
-  config + the plugin binaries live under that local root). So a plugin
-  that joins a vault path against `basePath` and hands it to Node `fs`
-  only ever touches the local shadow copy: reads of existing remote
-  notes won't find them, and writes create local-only files that do
-  **not** reach the remote. Only operations through the Obsidian vault
-  API (`vault.read/create/modify/...`, routed through the patched
-  adapter) round-trip; `.obsidian/` shared config round-trips via a
-  dedicated watcher (#342/#434). See *Direct-disk / agentic plugins*
-  below (#429) and the **basePath compat survey** (#133, 2026-04-29) —
-  but note the survey's "syncs up to the remote" mitigations assumed a
-  vault-tree file-watcher that was never built (see the correction in
-  that section). **Exception:** plugins that shell out to a local
+  not the remote SSH path; #170 patches both so readers don't crash on
+  `undefined`. But the vault tree is **virtual** — served from the
+  remote, not mirrored to disk (only `.obsidian/` lives there). So
+  `basePath` + Node `fs` only touches the local shadow copy: `fs` reads
+  miss remote notes, `fs` writes don't reach the remote. Only the vault
+  API round-trips (`.obsidian/` config via a dedicated watcher,
+  #342/#434). See *Direct-disk / agentic plugins* (#429) and the
+  **basePath survey** (#133) — its "syncs up to the remote" mitigations
+  assumed a vault-tree watcher that was never built. **Exception:** plugins that shell out to a local
   binary (notably obsidian-Git's `SimpleGit` desktop path) operate on
   the shadow git repo rather than the remote one — patching can't fix
   this from our side. obsidian-Git's bundled `IsomorphicGit` mode
@@ -171,20 +163,13 @@ Things that aren't a specific plugin but trip plugins in general:
   image-processing plugins outside the top-20 use this pattern
   (see survey section below). No webview-side URL rewriting is
   needed at this time.
-- **Direct-disk / agentic plugins** (e.g. Claude Code-style wrappers
-  such as "Claudian") — plugins that create or edit files by calling
-  Node `fs` directly, or by shelling out to a child process, bypass the
-  patched adapter entirely. Their writes land in the **local shadow
-  copy** (`~/.obsidian-remote/vaults/<id>/…`) and never reach the
-  remote — this is [#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429).
-  There is no automatic local→remote reconciler for the vault tree
-  (only `.obsidian/` shared config and the enabled-plugins list
-  round-trip, via #342/#434); adding one would reintroduce the
-  sync/reconcile model this plugin's single-source-of-truth design
-  deliberately avoids. **Recommendation:** drive note creation through
-  plugins that use the Obsidian vault API (`vault.create` / `modify`);
-  treat direct-disk / agentic tools as operating on a *local-only* copy
-  when pointed at a remote vault.
+- **Direct-disk / agentic plugins** (e.g. Claude Code wrappers like
+  "Claudian") write via Node `fs` / child processes, bypassing the
+  adapter — so their files stay in the local shadow copy and never
+  reach the remote ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
+  No local→remote reconciler exists for the vault tree (adding one =
+  the sync model this single-source-of-truth design avoids). Use
+  plugins that go through the vault API.
 
 ## Why we can't auto-test all of this
 
@@ -296,19 +281,13 @@ compare, child-process cwd, etc.).
   in a real dev vault remains a manual step; the matrix above keeps
   these at `🟡 expected (smoke pending after #170)` until run.
 
-> **⚠️ Correction (2026-06-30, #429).** The survey's recommendations
-> above repeatedly say Node-`fs` writes under `basePath` "land in the
-> shadow vault, which the file-watcher syncs up to the remote." That
-> shadow→remote file-watcher **was never built for the vault tree** —
-> the only local→remote watcher that exists is `SharedConfigWatcher`,
-> scoped to `.obsidian/` shared config (#342) and the enabled-plugins
-> list (#434). #170 made `basePath` *return* the shadow-vault local
-> root (so plugins stop crashing on `undefined`), but it did **not**
-> create a local mirror of the vault tree or a sync path. The vault
-> tree is served virtually from the remote; a plugin's `fs` write to
-> `basePath` therefore stays in the local shadow copy and does not
-> reach the remote (this is #429). Read the per-plugin "fixed by #170"
-> notes as "no longer crashes," **not** "round-trips to the remote."
+> **⚠️ Correction (2026-06-30, #429).** The "syncs up to the remote"
+> mitigations below assumed a shadow→remote file-watcher that was
+> **never built** for the vault tree (the only local→remote watcher is
+> `SharedConfigWatcher`, `.obsidian/`-only, #342/#434). #170 made
+> `basePath` *return* the local root (stops `undefined` crashes) but
+> created no mirror or sync path — `fs` writes stay local (#429). Read
+> "fixed by #170" as "no longer crashes," not "round-trips."
 
 ### Method
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.2",
+  "version": "1.1.6-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.2",
+  "version": "1.1.6-beta.3",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.2",
+  "version": "1.1.6-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.2",
+      "version": "1.1.6-beta.3",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.2",
+  "version": "1.1.6-beta.3",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -119,9 +119,15 @@ export class SftpDataAdapter {
      * `getBasePath()` method return this value, so plugins that read
      * `adapter.basePath` (Templater's `tp.file.path`, Kanban's clipboard
      * paste, Importer, Copilot — see `docs/en/user-guide/plugin-compatibility.md`)
-     * receive a path on the shadow vault. Reads against that path
-     * succeed against files mirrored locally by the file watcher;
-     * writes land in the shadow dir and propagate to the remote.
+     * receive a path on the shadow vault, so they no longer crash on
+     * an `undefined` base. NOTE: the vault tree is served *virtually*
+     * from the remote — it is NOT mirrored to local disk (only
+     * `.obsidian/` config + plugin binaries live there). So a Node `fs`
+     * read of an existing note via this path won't find it, and an `fs`
+     * write lands in the local shadow copy only — it does NOT reach the
+     * remote. Only the Obsidian vault API round-trips. See #429 and the
+     * "Direct-disk / agentic plugins" footgun in
+     * docs/en/user-guide/plugin-compatibility.md.
      *
      * Defaults to `''` for tests that never exercise these members. The
      * production wiring in `main.ts` always passes the real shadow
@@ -143,10 +149,13 @@ export class SftpDataAdapter {
 
   /**
    * Mirror of `FileSystemAdapter.basePath`. Returns the absolute path
-   * of the shadow vault's local root. Plugins that join paths against
-   * this value and call Node `fs` directly read mirrored content and
-   * write into the shadow dir, where the file watcher propagates to
-   * the remote.
+   * of the shadow vault's local root. The vault tree is served
+   * virtually from the remote (not mirrored to local disk), so plugins
+   * that join paths against this value and call Node `fs` directly only
+   * ever touch the local shadow copy: reads miss remote notes and
+   * writes do NOT reach the remote (#429). Only the vault API
+   * round-trips. Returning a defined path keeps those plugins from
+   * crashing (#170); it does not make their `fs` operations sync.
    */
   get basePath(): string {
     return this.shadowBasePath;

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -119,15 +119,11 @@ export class SftpDataAdapter {
      * `getBasePath()` method return this value, so plugins that read
      * `adapter.basePath` (Templater's `tp.file.path`, Kanban's clipboard
      * paste, Importer, Copilot — see `docs/en/user-guide/plugin-compatibility.md`)
-     * receive a path on the shadow vault, so they no longer crash on
-     * an `undefined` base. NOTE: the vault tree is served *virtually*
-     * from the remote — it is NOT mirrored to local disk (only
-     * `.obsidian/` config + plugin binaries live there). So a Node `fs`
-     * read of an existing note via this path won't find it, and an `fs`
-     * write lands in the local shadow copy only — it does NOT reach the
-     * remote. Only the Obsidian vault API round-trips. See #429 and the
-     * "Direct-disk / agentic plugins" footgun in
-     * docs/en/user-guide/plugin-compatibility.md.
+     * receive the shadow-vault root (so they don't crash on
+     * `undefined`). But the vault tree is virtual — served from the
+     * remote, not mirrored to disk — so raw Node `fs` here only touches
+     * the local shadow copy: reads miss remote notes, writes don't
+     * reach the remote. Only the vault API round-trips (#429).
      *
      * Defaults to `''` for tests that never exercise these members. The
      * production wiring in `main.ts` always passes the real shadow
@@ -148,14 +144,11 @@ export class SftpDataAdapter {
   ) {}
 
   /**
-   * Mirror of `FileSystemAdapter.basePath`. Returns the absolute path
-   * of the shadow vault's local root. The vault tree is served
-   * virtually from the remote (not mirrored to local disk), so plugins
-   * that join paths against this value and call Node `fs` directly only
-   * ever touch the local shadow copy: reads miss remote notes and
-   * writes do NOT reach the remote (#429). Only the vault API
-   * round-trips. Returning a defined path keeps those plugins from
-   * crashing (#170); it does not make their `fs` operations sync.
+   * Mirror of `FileSystemAdapter.basePath`: the shadow-vault local
+   * root. The vault tree is virtual (not mirrored to disk), so raw
+   * `fs` against this path only touches the local shadow copy — writes
+   * don't reach the remote (#429); only the vault API round-trips.
+   * #170 returns a defined path so plugins don't crash.
    */
   get basePath(): string {
     return this.shadowBasePath;


### PR DESCRIPTION
## Why

Clarifying #429 (Claudian writes land in the local folder, not the remote) surfaced a **misconception baked into both docs and code comments**: that Node-`fs` writes under the shadow `basePath` are *"mirrored locally by the file watcher"* and *"propagate to the remote."*

**That vault-tree mirror + watcher was never built.** Verified against current code:
- `populateVaultFromRemote` → `VaultModelBuilder.build` builds the **in-memory** model only; never writes notes to disk.
- `SftpDataAdapter.read` returns remote bytes via the SSH/RPC client + an **in-memory** `ReadCache` `Map`; no disk write.
- No whole-vault prefetch/mirror on connect; the only `fs.writeFileSync` in `shadow/` targets `.obsidian/`.
- The only local→remote watcher is `SharedConfigWatcher`, scoped to `.obsidian/` shared config (#342) + the enabled-plugins list (#434). No `vault.on('create'/'modify')`→push, no vault-tree watcher.

So the vault tree is served **virtually** from the remote (single source of truth, no local copy to diverge — which is exactly what makes the no-`(conflicted copy)` guarantee hold). `#170` made `basePath` *return* the local root (stops `undefined` crashes); it never created a mirror or a sync path. A plugin's `fs` write therefore stays in the local shadow copy and never reaches the remote — #429.

## What this corrects (docs + comments only, no behaviour change)

- **`plugin-compatibility.md`**: the basePath "Known footguns" bullet, the Templater / Kanban / Importer matrix notes, a new **"Direct-disk / agentic plugins"** footgun (#429), and a dated correction note on the #133 basePath survey (historical text kept, but flagged that the assumed shadow→remote watcher was never built).
- **`SftpDataAdapter.ts`**: the `shadowBasePath` constructor-param doc + the `basePath` getter doc (both said `fs` writes "propagate to the remote").
- **`glossary.md`**: the canonical **Shadow vault** definition (it called it a local mirror that "the plugin syncs to the remote"). Restated as single-source-of-truth / direct-ops.

Bumped to `1.1.6-beta.3` for the `version-check` gate.

## Core value note

This does **not** weaken the core value — it states it precisely. "Virtual notes, no local mirror" *is* the single-source-of-truth / direct-operation design (a local mirror + reconciler would be the v0.4 sync model that was deliberately killed). The correction draws the boundary honestly: vault-API ops = direct ops on the remote (the value); raw `fs` = outside the model (#429). The old "fs propagates too" wording was the part that actually contradicted the no-sync design.

Left for your review (it edits your own #133 survey wording). The product calls — #429(b) plugin-binary round-trip and #429(c) whether to ever add an opt-in local→remote push — are still open and untouched.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)