### PR TITLE
fix(shadow): community-plugins push no-clobber + config-consistency e2e (#429, #342)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.4",
+      "version": "1.1.6-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.4",
+  "version": "1.1.6-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -481,22 +481,47 @@ export class ShadowVaultBootstrap {
   }
 
   /**
-   * Push the local enabled-plugin list to the remote, with `remote-ssh`
-   * forced on. Last-write-wins (matching the v1 no-CRDT policy); the
-   * pull's union means machines still converge toward the superset.
+   * Push the local enabled-plugin list to the remote, unioned with the
+   * remote's CURRENT list and with `remote-ssh` forced on.
+   *
+   * Self-protecting against clobber: it re-reads the remote first and
+   * unions, so a stale/minimal local list (e.g. after a transient pull
+   * read-failure earlier in the same connect) can never drop a plugin
+   * another machine enabled. If the remote HAS the file but it can't be
+   * read or parsed, it aborts rather than overwrite what it couldn't
+   * see. A genuinely-absent remote file is seeded from local.
    */
   static async pushCommunityPlugins(
-    writer: SharedConfigWriter,
+    rw: SharedConfigReader & SharedConfigWriter,
     remoteConfigDir: string,
     localConfigDir: string,
   ): Promise<{ pushed: boolean }> {
     const basename = 'community-plugins.json';
-    const localPath = path.join(localConfigDir, basename);
-    const ids = ShadowVaultBootstrap.mergePluginIds(
-      ShadowVaultBootstrap.readPluginIdList(localPath), [], ShadowVaultBootstrap.SELF_PLUGIN_ID,
-    );
+    const remoteRel = `${remoteConfigDir}/${basename}`;
+    const local = ShadowVaultBootstrap.readPluginIdList(path.join(localConfigDir, basename));
+
+    let remote: string[] = [];
     try {
-      await writer.write(`${remoteConfigDir}/${basename}`, JSON.stringify(ids) + '\n');
+      if (await rw.exists(remoteRel)) {
+        const parsed = ShadowVaultBootstrap.parsePluginIdList(await rw.read(remoteRel));
+        if (parsed === null) {
+          logger.warn('pushCommunityPlugins: remote list is not a valid id array; not pushing (avoid clobber)');
+          return { pushed: false };
+        }
+        remote = parsed;
+      }
+    } catch (e) {
+      logger.warn(`pushCommunityPlugins: cannot read remote (${errorMessage(e)}); not pushing (avoid clobber)`);
+      return { pushed: false };
+    }
+
+    const ids = ShadowVaultBootstrap.mergePluginIds(remote, local, ShadowVaultBootstrap.SELF_PLUGIN_ID);
+    // No-op when the remote already equals the union — avoid churn.
+    if (remote.length === ids.length && remote.every((id, i) => id === ids[i])) {
+      return { pushed: false };
+    }
+    try {
+      await rw.write(remoteRel, JSON.stringify(ids) + '\n');
       logger.info(`pushCommunityPlugins: pushed [${ids.join(', ')}]`);
       return { pushed: true };
     } catch (e) {

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -1053,18 +1053,56 @@ describe('ShadowVaultBootstrap community-plugins round-trip (#429 / #342)', () =
     );
   });
 
-  it('pushes the locally-enabled plugins to the remote, preserving remote-ssh', async () => {
-    const localConfigDir = makeLocalConfigDir(['remote-ssh', 'dataview']);
-    const remote: Record<string, string> = {};
-    const writer: SharedConfigWriter = {
-      write: (p, content) => { remote[p] = content; return Promise.resolve(); },
+  // Reader+writer fake backed by an in-memory store. `read` can be made
+  // to throw to simulate a transient SSH error mid-read.
+  function makeRemoteRW(initial?: string[], readThrows = false): {
+    rw: SharedConfigReader & SharedConfigWriter;
+    store: Record<string, string>;
+  } {
+    const store: Record<string, string> = {};
+    if (initial) store['.obsidian/community-plugins.json'] = JSON.stringify(initial);
+    const rw: SharedConfigReader & SharedConfigWriter = {
+      exists: (p) => Promise.resolve(p in store),
+      read: (p) => (readThrows ? Promise.reject(new Error('SSH hiccup')) : Promise.resolve(store[p])),
+      write: (p, c) => { store[p] = c; return Promise.resolve(); },
     };
+    return { rw, store };
+  }
 
-    await ShadowVaultBootstrap.pushCommunityPlugins(writer, '.obsidian', localConfigDir);
+  it('seeds the remote (union with local) when the remote has none yet', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh', 'dataview']);
+    const { rw, store } = makeRemoteRW();
+    await ShadowVaultBootstrap.pushCommunityPlugins(rw, '.obsidian', localConfigDir);
+    expect(store['.obsidian/community-plugins.json'], 'a push must seed the remote').toBeDefined();
+    expect(JSON.parse(store['.obsidian/community-plugins.json'])).toEqual(
+      expect.arrayContaining(['dataview', 'remote-ssh']),
+    );
+  });
 
-    expect(remote['.obsidian/community-plugins.json'], 'a push must write the list to the remote').toBeDefined();
-    const pushed = JSON.parse(remote['.obsidian/community-plugins.json']);
-    expect(pushed).toContain('dataview');
-    expect(pushed).toContain('remote-ssh');
+  it('unions with the remote list and never drops a plugin enabled elsewhere', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh', 'templater']);
+    const { rw, store } = makeRemoteRW(['remote-ssh', 'dataview']);
+    await ShadowVaultBootstrap.pushCommunityPlugins(rw, '.obsidian', localConfigDir);
+    const pushed = JSON.parse(store['.obsidian/community-plugins.json']);
+    expect(pushed, 'remote dataview must survive + local templater added')
+      .toEqual(expect.arrayContaining(['dataview', 'templater', 'remote-ssh']));
+  });
+
+  it('does NOT clobber the remote when the remote read fails (transient SSH error)', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh']); // minimal local
+    const { rw, store } = makeRemoteRW(['remote-ssh', 'dataview', 'obsidian-git'], /*readThrows*/ true);
+    const before = store['.obsidian/community-plugins.json'];
+    const r = await ShadowVaultBootstrap.pushCommunityPlugins(rw, '.obsidian', localConfigDir);
+    expect(r.pushed).toBe(false);
+    expect(store['.obsidian/community-plugins.json'], 'remote list must be untouched (no data loss)').toBe(before);
+  });
+
+  it('does NOT clobber the remote when the remote list is corrupt JSON', async () => {
+    const localConfigDir = makeLocalConfigDir(['remote-ssh']);
+    const { rw, store } = makeRemoteRW();
+    store['.obsidian/community-plugins.json'] = '{ not : json';
+    const r = await ShadowVaultBootstrap.pushCommunityPlugins(rw, '.obsidian', localConfigDir);
+    expect(r.pushed).toBe(false);
+    expect(store['.obsidian/community-plugins.json']).toBe('{ not : json');
   });
 });

--- a/plugin/tests/integration/config-consistency.e2e.test.ts
+++ b/plugin/tests/integration/config-consistency.e2e.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { ShadowVaultBootstrap } from '../../src/shadow/ShadowVaultBootstrap';
+import { ObsidianRegistry } from '../../src/shadow/ObsidianRegistry';
+import { setupClientPair, TEST_PRIVATE_KEY, type TestClient } from './helpers/makeAdapter';
+import type { SshProfile } from '../../src/types';
+
+/**
+ * Config consistency across connect cycles (#429 / #342).
+ *
+ * Layer 1 (integration, vitest + docker sshd, no Obsidian UI). Drives
+ * the real bootstrap + pull/push round-trip against a real SSH server,
+ * so the #429/#342 promise — "config and the enabled-plugins list stay
+ * consistent across reconnects, and a push never clobbers a list
+ * enabled on another machine" — is verified end-to-end, not just over
+ * in-memory fakes. The remote vault's `.obsidian/` is the canonical
+ * store; a fresh shadow vault is a new "session" / "machine".
+ *
+ * Runs only when the test keypair is staged (`npm run sshd:start`).
+ */
+
+if (!fs.existsSync(TEST_PRIVATE_KEY)) {
+  throw new Error(
+    `Integration test keypair missing at ${TEST_PRIVATE_KEY}. ` +
+    'Run `npm run sshd:start` from the repo root before `npm run test:integration`.',
+  );
+}
+
+const REMOTE_CFG = '.obsidian';
+const CP = `${REMOTE_CFG}/community-plugins.json`;
+const APP = `${REMOTE_CFG}/app.json`;
+
+describe('Config consistency across connect cycles (#429 / #342)', () => {
+  let pair: Awaited<ReturnType<typeof setupClientPair>>;
+  let remoteClient: TestClient;
+  let baseDir: string;
+  let sourcePluginDir: string;
+  let registryConfigPath: string;
+
+  beforeAll(async () => {
+    pair = await setupClientPair({ testLabel: 'config-consistency' });
+    remoteClient = pair.a;
+
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-consistency-base-'));
+    const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-consistency-home-'));
+    registryConfigPath = path.join(tmpHome, 'obsidian.json');
+    fs.writeFileSync(registryConfigPath, JSON.stringify({ vaults: {} }) + '\n', 'utf-8');
+
+    sourcePluginDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cfg-consistency-source-'));
+    fs.writeFileSync(path.join(sourcePluginDir, 'main.js'), '/* test stub */\n', 'utf-8');
+    fs.writeFileSync(path.join(sourcePluginDir, 'manifest.json'),
+      JSON.stringify({ id: 'remote-ssh', version: '0.0.0-test', name: 'Test', minAppVersion: '1.5.0' }) + '\n', 'utf-8');
+    fs.writeFileSync(path.join(sourcePluginDir, 'styles.css'), '/* test stub */\n', 'utf-8');
+
+    await remoteClient.adapter.mkdir(REMOTE_CFG);
+  });
+
+  afterAll(async () => {
+    if (pair) await pair.cleanup();
+    try { fs.rmSync(baseDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { fs.rmSync(sourcePluginDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+
+  /** A fresh shadow-vault session against the shared docker remote. */
+  function freshSession(): ShadowVaultBootstrap {
+    return new ShadowVaultBootstrap(baseDir, sourcePluginDir, new ObsidianRegistry(registryConfigPath));
+  }
+  function profileFor(caseId: string): SshProfile {
+    return {
+      id: `cfg-${caseId}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      name: `Config consistency (${caseId})`,
+      host: '127.0.0.1', port: 2222, username: 'tester',
+      authMethod: 'privateKey', privateKeyPath: TEST_PRIVATE_KEY,
+      remotePath: remoteClient.vaultRoot,
+      connectTimeoutMs: 10_000, keepaliveIntervalMs: 0, keepaliveCountMax: 0,
+    };
+  }
+  const readLocalCp = (dir: string): string[] =>
+    JSON.parse(fs.readFileSync(path.join(dir, 'community-plugins.json'), 'utf-8'));
+
+  it('community plugins enabled on the remote round-trip into a fresh shadow, keeping remote-ssh (#429/#342)', async () => {
+    // Remote set up "on another machine": dataview enabled.
+    await remoteClient.adapter.write(CP, JSON.stringify(['dataview']));
+
+    const profile = profileFor('cp-pull');
+    const { layout } = await freshSession().bootstrap(profile, [profile]);
+    await ShadowVaultBootstrap.pullCommunityPlugins(remoteClient.adapter, REMOTE_CFG, layout.configDir);
+
+    expect(readLocalCp(layout.configDir)).toEqual(expect.arrayContaining(['dataview', 'remote-ssh']));
+  });
+
+  it('a plugin enabled in one session is still enabled in the next (persists via the remote)', async () => {
+    // Known base so the assertion doesn't depend on case order.
+    await remoteClient.adapter.write(CP, JSON.stringify(['remote-ssh']));
+
+    // Session 1: enable templater locally, push to remote.
+    const p1 = profileFor('cycle-1');
+    const s1 = await freshSession().bootstrap(p1, [p1]);
+    fs.writeFileSync(path.join(s1.layout.configDir, 'community-plugins.json'),
+      JSON.stringify(['remote-ssh', 'templater']));
+    await ShadowVaultBootstrap.pushCommunityPlugins(remoteClient.adapter, REMOTE_CFG, s1.layout.configDir);
+
+    // Session 2: a brand-new shadow (different id → different local dir) pulls.
+    const p2 = profileFor('cycle-2');
+    const s2 = await freshSession().bootstrap(p2, [p2]);
+    await ShadowVaultBootstrap.pullCommunityPlugins(remoteClient.adapter, REMOTE_CFG, s2.layout.configDir);
+
+    expect(readLocalCp(s2.layout.configDir), 'templater enabled in session 1 must survive into session 2')
+      .toContain('templater');
+  });
+
+  it('push unions with the remote and never drops a plugin enabled elsewhere (#437, real SSH)', async () => {
+    // Remote (machine B) carries a rich list.
+    await remoteClient.adapter.write(CP, JSON.stringify(['remote-ssh', 'dataview', 'obsidian-git']));
+
+    // Machine A has only a minimal local list, then pushes.
+    const pA = profileFor('union');
+    const sA = await freshSession().bootstrap(pA, [pA]);
+    fs.writeFileSync(path.join(sA.layout.configDir, 'community-plugins.json'),
+      JSON.stringify(['remote-ssh', 'templater']));
+    await ShadowVaultBootstrap.pushCommunityPlugins(remoteClient.adapter, REMOTE_CFG, sA.layout.configDir);
+
+    const remoteAfter = JSON.parse(await remoteClient.adapter.read(CP));
+    expect(remoteAfter, 'remote dataview + obsidian-git must survive a push from a minimal local')
+      .toEqual(expect.arrayContaining(['dataview', 'obsidian-git', 'templater', 'remote-ssh']));
+  });
+
+  it('a settings change stays consistent across a write → push → fresh-pull cycle (#342 reproducer)', async () => {
+    // Session 1: seed remote app.json, pull into the shadow.
+    await remoteClient.adapter.write(APP, JSON.stringify({ useMarkdownLinks: false, theme: 'obsidian' }));
+    const p1 = profileFor('app-1');
+    const s1 = await freshSession().bootstrap(p1, [p1]);
+    await ShadowVaultBootstrap.pullSharedObsidianConfig(remoteClient.adapter, REMOTE_CFG, s1.layout.configDir);
+
+    // User changes a setting in the shadow, then it's pushed back.
+    const changed = { useMarkdownLinks: true, theme: 'things' };
+    fs.writeFileSync(path.join(s1.layout.configDir, 'app.json'), JSON.stringify(changed));
+    await ShadowVaultBootstrap.pushSharedObsidianConfig(remoteClient.adapter, REMOTE_CFG, s1.layout.configDir);
+
+    // The test holds a snapshot of the intended state.
+    const snapshot = JSON.parse(fs.readFileSync(path.join(s1.layout.configDir, 'app.json'), 'utf-8'));
+
+    // Session 2: a fresh shadow pulls — must equal the snapshot.
+    const p2 = profileFor('app-2');
+    const s2 = await freshSession().bootstrap(p2, [p2]);
+    await ShadowVaultBootstrap.pullSharedObsidianConfig(remoteClient.adapter, REMOTE_CFG, s2.layout.configDir);
+
+    const local2 = JSON.parse(fs.readFileSync(path.join(s2.layout.configDir, 'app.json'), 'utf-8'));
+    expect(local2, 'the setting changed in session 1 must be consistent in session 2').toEqual(snapshot);
+  });
+});


### PR DESCRIPTION
## Found by adversarial review of #434

A 4-agent verification pass on this session's fixes caught a **data-loss regression I introduced in #434**:

`runAutoConnect` calls `pullCommunityPlugins` then `pushCommunityPlugins`. The pull **swallows a remote read-failure internally** (logs, returns `pulled:false`, does NOT throw), so the subsequent push still ran — with a stale/minimal *local* list — and overwrote the remote `community-plugins.json`. On a transient SSH hiccup during the pull, **plugins enabled on another machine would be silently dropped from the remote**.

## Fix

`pushCommunityPlugins` is now **self-protecting**:
- re-reads the **current remote** list and unions `remote ∪ local ∪ remote-ssh` before writing — a stale local list can never drop a remotely-enabled plugin;
- **aborts without writing** if the remote file exists but can't be read or parsed (never overwrite what it couldn't see);
- still seeds an absent remote from local.

Signature now takes a reader+writer; the patched adapter already satisfies both, so the connect-flow caller is unchanged.

## Tests (ShadowVaultBootstrap, 51 pass)
- seeds remote when absent · unions and never drops a remote plugin · **no clobber on remote read-fail** · **no clobber on corrupt remote JSON**.

`tsc --noEmit`, eslint, full local suite green.

> Note: the deeper #429/#342 design (canonical shadow-vault init instead of a hash-named dir, and referencing remote `.obsidian/` config + plugins directly rather than the local mirror) + a dedicated config-consistency E2E are being discussed separately — this PR just removes the immediate data-loss risk in the shipped round-trip.

Refs #429 #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)