### PR TITLE
feat(shadow): friendly vault name (<name>--<short-id>) + legacy migration (#429, #342)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.6",
+  "version": "1.1.6-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.6",
+  "version": "1.1.6-beta.7",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.6",
+  "version": "1.1.6-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.6",
+      "version": "1.1.6-beta.7",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.5",
+      "version": "1.1.6-beta.6",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.6",
+  "version": "1.1.6-beta.7",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.5",
+  "version": "1.1.6-beta.6",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -979,24 +979,26 @@ export default class RemoteSshPlugin extends Plugin {
 
       const result = await manager.openShadowFor(profile, this.settings.profiles);
       const how = result.pluginInstallMethod;
-      const reg = result.registryCreated ? 'newly registered' : 'reused';
+      const reg = result.registryCreated ? 'newly registered' : result.migrated ? 'migrated' : 'reused';
       logger.info(
         `openShadowVaultFor: profile=${profile.name}, vault=${result.layout.vaultDir}, ` +
         `registry id=${result.registryId} (${reg}), plugin=${how}`,
       );
-      if (result.registryCreated) {
-        // First-ever open of this profile: the vault was just added to
-        // obsidian.json, but the already-running Obsidian only reads that
-        // file at startup — so the obsidian://open we just fired is a no-op
-        // and no window appears. Surface a PERSISTENT notice (duration 0)
-        // telling the user to restart, rather than the misleading "opened in
-        // new window" that never actually opened. Only happens once per
-        // profile (subsequent connects hit the `reused` branch).
+      if (result.registryCreated || result.migrated) {
+        // The vault's path in obsidian.json is new to the already-running
+        // Obsidian (it only reads that file at startup), so the
+        // obsidian://open we just fired is a no-op and no window appears.
+        // This happens on a profile's first-ever open (registryCreated) and
+        // the one-time legacy→friendly dir rename (migrated). Surface a
+        // PERSISTENT notice (duration 0) telling the user to restart, rather
+        // than the misleading "opened in new window" that never opened.
+        const why = result.registryCreated
+          ? `"${profile.name}" is a newly registered vault.`
+          : `"${profile.name}" was renamed to a friendlier vault name.`;
         new Notice(
-          `Remote SSH: "${profile.name}" is a newly registered vault. Obsidian only ` +
-          'loads new vaults at startup, so it cannot open it this session — fully ' +
-          'quit and reopen Obsidian, then click Connect again. (Only needed the ' +
-          'first time you open a profile.)',
+          `Remote SSH: ${why} Obsidian only loads vaults at startup, so it cannot ` +
+          'open it this session — fully quit and reopen Obsidian, then click Connect ' +
+          'again. (One-time.)',
           0,
         );
       } else {

--- a/plugin/src/shadow/ObsidianRegistry.ts
+++ b/plugin/src/shadow/ObsidianRegistry.ts
@@ -105,6 +105,27 @@ export class ObsidianRegistry {
   }
 
   /**
+   * Repoint an existing vault entry from `oldPath` to `newPath`,
+   * keeping the same Obsidian vault id. Used by the transitional
+   * shadow-dir rename (legacy UUID name → friendly name) so the
+   * registration follows the moved directory instead of leaving a
+   * dead entry pointing at the old path. No-op (returns false) when no
+   * entry matches `oldPath`.
+   */
+  updatePath(oldPath: string, newPath: string): boolean {
+    const cfg = this.read();
+    const target = canonicalisePath(oldPath);
+    for (const [id, entry] of Object.entries(cfg.vaults)) {
+      if (canonicalisePath(entry.path) === target) {
+        cfg.vaults[id] = { ...entry, path: newPath };
+        this.writeAtomic(cfg);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * Atomic write: serialise to a sibling temp file, then rename.
    * Limits the window during which Obsidian could read a half-written
    * `obsidian.json`. Not a full-blown lock — Obsidian could still

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -52,6 +52,13 @@ export interface BootstrapResult {
   registryId: string;
   /** True if the vault entry was newly added (false = was already registered). */
   registryCreated: boolean;
+  /**
+   * True if a legacy UUID-named shadow dir was renamed to the friendly
+   * name on this bootstrap. Like a newly-registered vault, the renamed
+   * path isn't in the running Obsidian's cached vault list, so the
+   * connect flow surfaces the one-time "restart Obsidian" notice.
+   */
+  migrated: boolean;
   /** How the plugin source landed in the shadow vault. */
   pluginInstallMethod: 'symlink' | 'copy';
 }
@@ -121,7 +128,9 @@ export class ShadowVaultBootstrap {
    * is `fs.*Sync` and JSON arithmetic, no I/O actually awaits.
    */
   private bootstrapSync(profile: SshProfile, allProfiles: ReadonlyArray<SshProfile>): BootstrapResult {
-    const layout = this.layoutFor(profile.id);
+    // Friendly-named shadow dir, migrating a legacy UUID-named one if
+    // present (transitional — see resolveLayout).
+    const { layout, migrated } = this.resolveLayout(profile);
 
     fs.mkdirSync(layout.vaultDir, { recursive: true });
     fs.mkdirSync(layout.configDir, { recursive: true });
@@ -209,7 +218,7 @@ export class ShadowVaultBootstrap {
       `at ${layout.vaultDir} (registry id=${registryId}, plugin=${pluginInstallMethod})`,
     );
 
-    return { layout, registryId, registryCreated: created, pluginInstallMethod };
+    return { layout, registryId, registryCreated: created, migrated, pluginInstallMethod };
   }
 
   /**
@@ -217,8 +226,12 @@ export class ShadowVaultBootstrap {
    * Useful for callers that need the layout up-front (e.g. the
    * spawner needs `vaultDir` for the open URL).
    */
-  layoutFor(profileId: string): ShadowVaultLayout {
-    const vaultDir = path.join(this.baseDir, sanitiseProfileId(profileId));
+  layoutFor(profile: Pick<SshProfile, 'id' | 'name'>): ShadowVaultLayout {
+    return this.layoutForDir(path.join(this.baseDir, friendlyVaultDirName(profile)));
+  }
+
+  /** Derive the `.obsidian/...` sub-paths for a concrete vault dir. */
+  private layoutForDir(vaultDir: string): ShadowVaultLayout {
     // The shadow vault is freshly created on disk by us before Obsidian
     // ever opens it; there's no live `App` instance whose
     // `vault.configDir` we could query, so we build the directory name
@@ -231,6 +244,75 @@ export class ShadowVaultBootstrap {
     const pluginDir = path.join(configDir, 'plugins', 'remote-ssh');
     const pluginDataFile = path.join(pluginDir, 'data.json');
     return { vaultDir, configDir, pluginDir, pluginDataFile };
+  }
+
+  /**
+   * Resolve the shadow layout to use, migrating a legacy `<uuid>`-named
+   * dir to the friendly name once (transitional; added 2026-06,
+   * removable after a few releases once installs have migrated).
+   *
+   * Runs during bootstrap — before the shadow window is spawned — so
+   * the vault is never open while we move it. If the rename fails
+   * (perms / cross-device / a stray lock), we fall back to the legacy
+   * dir for this session so the existing config/plugins are never
+   * orphaned; the migration retries on the next bootstrap.
+   */
+  private resolveLayout(
+    profile: Pick<SshProfile, 'id' | 'name'>,
+  ): { layout: ShadowVaultLayout; migrated: boolean } {
+    const desired = this.layoutFor(profile);
+    // The desired friendly dir already exists → reuse it.
+    if (fs.existsSync(desired.vaultDir)) return { layout: desired, migrated: false };
+
+    // A friendly dir from a PRIOR profile name (same id → same `--<id8>`
+    // suffix) — e.g. the user renamed the profile. Reuse it AS-IS rather
+    // than churn the dir name on every rename; the id is the stable key,
+    // the displayed name just reflects the name at creation.
+    const prior = this.findPriorFriendlyDir(profile.id, desired.vaultDir);
+    if (prior) return { layout: this.layoutForDir(prior), migrated: false };
+
+    // A legacy UUID-named dir (older builds) → rename to the friendly
+    // name once, carrying its config/plugins. The vault is not open
+    // during bootstrap, so the rename is safe; if it fails, fall back to
+    // the legacy dir this session so nothing is orphaned.
+    const legacyDir = path.join(this.baseDir, sanitiseProfileId(profile.id));
+    if (legacyDir !== desired.vaultDir && fs.existsSync(legacyDir)) {
+      try {
+        fs.renameSync(legacyDir, desired.vaultDir);
+        this.registry.updatePath(legacyDir, desired.vaultDir);
+        logger.info(`ShadowVaultBootstrap: migrated legacy shadow ${legacyDir} → ${desired.vaultDir}`);
+        return { layout: desired, migrated: true };
+      } catch (e) {
+        logger.warn(
+          `ShadowVaultBootstrap: legacy shadow migration failed (${errorMessage(e)}); using ${legacyDir} this session`,
+        );
+        return { layout: this.layoutForDir(legacyDir), migrated: false };
+      }
+    }
+    // Brand-new profile.
+    return { layout: desired, migrated: false };
+  }
+
+  /**
+   * Find an existing shadow dir for this profile under a *different*
+   * friendly name (same `--<id8>` suffix), if any. Used so a profile
+   * rename reuses the existing shadow instead of stranding its config.
+   */
+  private findPriorFriendlyDir(profileId: string, desiredVaultDir: string): string | null {
+    const suffix = `--${sanitiseProfileId(profileId).slice(0, 8)}`;
+    let entries: string[];
+    try {
+      entries = fs.readdirSync(this.baseDir);
+    } catch {
+      return null; // baseDir not created yet
+    }
+    for (const entry of entries) {
+      const full = path.join(this.baseDir, entry);
+      if (entry.endsWith(suffix) && full !== desiredVaultDir) {
+        try { if (fs.statSync(full).isDirectory()) return full; } catch { /* skip */ }
+      }
+    }
+    return null;
   }
 
   // ─── shared-config round-trip (#342) ────────────────────────────────────
@@ -910,4 +992,33 @@ function sanitiseProfileId(id: string): string {
   // parent; force them into something benign.
   if (!cleaned || cleaned === '.' || cleaned === '..') return '_invalid';
   return cleaned;
+}
+
+/**
+ * Filesystem-safe form of a profile *name* for the friendly vault-dir
+ * name. Obsidian shows a vault by its directory basename, so this is
+ * what the user sees instead of a raw UUID. Spaces are kept (valid in
+ * dir names on every OS); anything path-dangerous is collapsed to `_`;
+ * length-capped; never `.`/`..`/empty.
+ */
+function sanitiseVaultName(name: string): string {
+  const cleaned = (name ?? '')
+    .replace(/[^a-zA-Z0-9._ -]/g, '_')
+    .replace(/_{2,}/g, '_')
+    .trim()
+    .slice(0, 40)
+    .trim();
+  if (!cleaned || cleaned === '.' || cleaned === '..') return 'vault';
+  return cleaned;
+}
+
+/**
+ * The shadow vault's directory name: a friendly profile name plus a
+ * short stable slice of the profile id for collision-safety. The id
+ * (a UUID) stays the backend key — it lives in the profile / data.json
+ * — but the *directory* is named so Obsidian displays something
+ * recognisable (e.g. `My Homelab--a1b2c3d4`) rather than a bare UUID.
+ */
+function friendlyVaultDirName(profile: Pick<SshProfile, 'id' | 'name'>): string {
+  return `${sanitiseVaultName(profile.name)}--${sanitiseProfileId(profile.id).slice(0, 8)}`;
 }

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -279,15 +279,30 @@ export class ShadowVaultBootstrap {
     if (legacyDir !== desired.vaultDir && fs.existsSync(legacyDir)) {
       try {
         fs.renameSync(legacyDir, desired.vaultDir);
-        this.registry.updatePath(legacyDir, desired.vaultDir);
-        logger.info(`ShadowVaultBootstrap: migrated legacy shadow ${legacyDir} → ${desired.vaultDir}`);
-        return { layout: desired, migrated: true };
       } catch (e) {
+        // The MOVE itself failed — the config is still at legacyDir, so
+        // use it this session; the migration retries next bootstrap.
         logger.warn(
           `ShadowVaultBootstrap: legacy shadow migration failed (${errorMessage(e)}); using ${legacyDir} this session`,
         );
         return { layout: this.layoutForDir(legacyDir), migrated: false };
       }
+      // The dir (with all its config/plugins) now lives at desired.vaultDir.
+      // Updating obsidian.json is SECONDARY: if it throws (e.g. the file is
+      // briefly locked on Windows), the path is still correct and bootstrap's
+      // later register(desired.vaultDir) re-adds it. Crucially we must NOT
+      // fall back to legacyDir here — bootstrap would recreate it empty and
+      // open a blank vault while the real config sits orphaned at desired.
+      try {
+        this.registry.updatePath(legacyDir, desired.vaultDir);
+      } catch (e) {
+        logger.warn(
+          `ShadowVaultBootstrap: registry path update failed post-migration (${errorMessage(e)}); ` +
+          `config is at ${desired.vaultDir}, registry self-heals on register()`,
+        );
+      }
+      logger.info(`ShadowVaultBootstrap: migrated legacy shadow ${legacyDir} → ${desired.vaultDir}`);
+      return { layout: desired, migrated: true };
     }
     // Brand-new profile.
     return { layout: desired, migrated: false };
@@ -302,7 +317,10 @@ export class ShadowVaultBootstrap {
     const suffix = `--${sanitiseProfileId(profileId).slice(0, 8)}`;
     let entries: string[];
     try {
-      entries = fs.readdirSync(this.baseDir);
+      // Sorted so that if (degenerately) more than one dir matches the
+      // suffix, the pick is deterministic across machines/runs rather
+      // than dependent on readdir order.
+      entries = fs.readdirSync(this.baseDir).sort();
     } catch {
       return null; // baseDir not created yet
     }

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -83,29 +83,44 @@ function makeScratch(): {
 }
 
 describe('ShadowVaultBootstrap.layoutFor', () => {
-  it('returns a layout under baseDir/profileId for a clean id', () => {
+  it('names the vault dir <friendly-name>--<short-id> so Obsidian shows a recognisable name', () => {
     const scratch = makeScratch();
     try {
       const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
-      const layout = r.layoutFor('abc-123');
-      expect(layout.vaultDir).toBe(path.join(scratch.baseDir, 'abc-123'));
-      expect(layout.configDir).toBe(path.join(scratch.baseDir, 'abc-123', '.obsidian'));
-      expect(layout.pluginDir).toBe(path.join(scratch.baseDir, 'abc-123', '.obsidian', 'plugins', 'remote-ssh'));
+      const layout = r.layoutFor({ id: 'abcdef12-3456-7890-aaaa-bbbbbbbbbbbb', name: 'My Homelab' });
+      expect(path.basename(layout.vaultDir)).toBe('My Homelab--abcdef12');
+      expect(layout.configDir).toBe(path.join(layout.vaultDir, '.obsidian'));
+      expect(layout.pluginDir).toBe(path.join(layout.vaultDir, '.obsidian', 'plugins', 'remote-ssh'));
       expect(layout.pluginDataFile).toBe(path.join(layout.pluginDir, 'data.json'));
     } finally { scratch.cleanup(); }
   });
 
-  it('sanitises ids that contain path separators or traversal so vaultDir stays inside baseDir', () => {
+  it('falls back to a generic name when the profile name is empty', () => {
     const scratch = makeScratch();
     try {
       const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
-      // `../etc` would escape baseDir if not sanitised.
-      const lo = r.layoutFor('../etc');
+      const layout = r.layoutFor({ id: 'abcdef12-3456', name: '' });
+      expect(path.basename(layout.vaultDir)).toBe('vault--abcdef12');
+    } finally { scratch.cleanup(); }
+  });
+
+  it('different ids with the same name produce different dirs (collision-safe)', () => {
+    const scratch = makeScratch();
+    try {
+      const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+      const a = r.layoutFor({ id: 'aaaaaaaa-1111', name: 'Vault' });
+      const b = r.layoutFor({ id: 'bbbbbbbb-2222', name: 'Vault' });
+      expect(a.vaultDir).not.toBe(b.vaultDir);
+    } finally { scratch.cleanup(); }
+  });
+
+  it('sanitises name + id so the dir never escapes baseDir', () => {
+    const scratch = makeScratch();
+    try {
+      const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+      const lo = r.layoutFor({ id: '../etc', name: '../../evil/name' });
       expect(path.dirname(lo.vaultDir)).toBe(scratch.baseDir);
       expect(path.resolve(lo.vaultDir).startsWith(path.resolve(scratch.baseDir) + path.sep)).toBe(true);
-      // Slashes inside an id should not introduce nested directories.
-      const slash = r.layoutFor('a/b/c');
-      expect(path.dirname(slash.vaultDir)).toBe(scratch.baseDir);
     } finally { scratch.cleanup(); }
   });
 });
@@ -320,7 +335,7 @@ describe('ShadowVaultBootstrap.bootstrap', () => {
     // sourceDir. installPlugin must replace this with a real dir
     // without deleting any of the source files.
     const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
-    const layout = r.layoutFor('p1');
+    const layout = r.layoutFor({ id: 'p1', name: 'P' });
     fs.mkdirSync(path.dirname(layout.pluginDir), { recursive: true });
     try {
       const linkType = process.platform === 'win32' ? 'junction' : 'dir';
@@ -338,7 +353,7 @@ describe('ShadowVaultBootstrap.bootstrap', () => {
     const sourceCanary = path.join(scratch.sourceDir, 'CANARY.txt');
     fs.writeFileSync(sourceCanary, 'do-not-delete', 'utf-8');
 
-    const profile = makeProfile({ id: 'p1' });
+    const profile = makeProfile({ id: 'p1', name: 'P' });
     await r.bootstrap(profile, [profile]);
 
     // Source file still there.
@@ -1104,5 +1119,81 @@ describe('ShadowVaultBootstrap community-plugins round-trip (#429 / #342)', () =
     const r = await ShadowVaultBootstrap.pushCommunityPlugins(rw, '.obsidian', localConfigDir);
     expect(r.pushed).toBe(false);
     expect(store['.obsidian/community-plugins.json']).toBe('{ not : json');
+  });
+});
+
+// ─── legacy → friendly shadow-dir migration (transitional) ──────────────
+//
+// Older builds named the shadow dir by the raw profile UUID. The vault
+// dir is now `<friendly-name>--<short-id>` so Obsidian shows a
+// recognisable name; the first bootstrap renames the legacy dir,
+// carrying its config/plugins, and repoints obsidian.json. For a clean
+// UUID id, `sanitiseProfileId(id) === id`, so the legacy dir is just
+// `<baseDir>/<id>`.
+describe('ShadowVaultBootstrap legacy→friendly migration', () => {
+  let scratch: ReturnType<typeof makeScratch>;
+  beforeEach(() => { scratch = makeScratch(); });
+  afterEach(() => { scratch.cleanup(); });
+
+  function seedLegacyShadow(id: string, cp: string[]): string {
+    const legacyDir = path.join(scratch.baseDir, id);
+    fs.mkdirSync(path.join(legacyDir, '.obsidian'), { recursive: true });
+    fs.writeFileSync(path.join(legacyDir, '.obsidian', 'community-plugins.json'), JSON.stringify(cp));
+    return legacyDir;
+  }
+
+  it('renames the legacy UUID dir to the friendly name, carries config, and repoints obsidian.json', async () => {
+    const id = 'dddddddd-1111-2222-3333-444444444444';
+    const profile = makeProfile({ id, name: 'My Homelab' });
+    const legacyDir = seedLegacyShadow(id, ['remote-ssh', 'dataview']);
+    const registry = new ObsidianRegistry(scratch.configPath);
+    const { id: regId } = registry.register(legacyDir);
+
+    const result = await new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, registry)
+      .bootstrap(profile, [profile]);
+
+    expect(result.migrated).toBe(true);
+    expect(path.basename(result.layout.vaultDir)).toBe('My Homelab--dddddddd');
+    expect(fs.existsSync(legacyDir)).toBe(false);                       // legacy moved, not left behind
+    expect(JSON.parse(fs.readFileSync(path.join(result.layout.configDir, 'community-plugins.json'), 'utf-8')))
+      .toEqual(expect.arrayContaining(['remote-ssh', 'dataview']));     // config carried over
+    const cfg = JSON.parse(fs.readFileSync(scratch.configPath, 'utf-8'));
+    expect(cfg.vaults[regId].path).toBe(result.layout.vaultDir);       // same registry id, new path
+  });
+
+  it('is idempotent: a second bootstrap does not re-migrate', async () => {
+    const id = 'eeeeeeee-1111-2222-3333-444444444444';
+    const profile = makeProfile({ id, name: 'Vault' });
+    seedLegacyShadow(id, ['remote-ssh']);
+    const r = new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath));
+    const first = await r.bootstrap(profile, [profile]);
+    expect(first.migrated).toBe(true);
+    const second = await r.bootstrap(profile, [profile]);
+    expect(second.migrated).toBe(false);
+    expect(second.layout.vaultDir).toBe(first.layout.vaultDir);
+  });
+
+  it('does not migrate a brand-new profile (no legacy dir)', async () => {
+    const profile = makeProfile({ id: 'ffffffff-1111', name: 'Fresh' });
+    const result = await new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath))
+      .bootstrap(profile, [profile]);
+    expect(result.migrated).toBe(false);
+    expect(path.basename(result.layout.vaultDir)).toBe('Fresh--ffffffff');
+  });
+
+  it('falls back to the legacy dir (no data loss) when the rename fails', async () => {
+    const id = 'aaaa1111-2222-3333-4444-555555555555';
+    const profile = makeProfile({ id, name: 'Locked' });
+    const legacyDir = seedLegacyShadow(id, ['remote-ssh', 'keepme']);
+    // First renameSync call in bootstrap is the migration rename; make it throw.
+    const renameSpy = vi.spyOn(fs, 'renameSync').mockImplementationOnce(() => { throw new Error('EBUSY'); });
+    try {
+      const result = await new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, new ObsidianRegistry(scratch.configPath))
+        .bootstrap(profile, [profile]);
+      expect(result.migrated).toBe(false);
+      expect(result.layout.vaultDir).toBe(legacyDir);                  // fell back to legacy this session
+      expect(JSON.parse(fs.readFileSync(path.join(legacyDir, '.obsidian', 'community-plugins.json'), 'utf-8')))
+        .toContain('keepme');                                          // config NOT lost
+    } finally { renameSpy.mockRestore(); }
   });
 });

--- a/plugin/tests/ShadowVaultBootstrap.test.ts
+++ b/plugin/tests/ShadowVaultBootstrap.test.ts
@@ -1196,4 +1196,30 @@ describe('ShadowVaultBootstrap legacy→friendly migration', () => {
         .toContain('keepme');                                          // config NOT lost
     } finally { renameSpy.mockRestore(); }
   });
+
+  it('still migrates to the friendly dir when the registry update throws AFTER a successful rename', async () => {
+    // Review regression: rename succeeds (config physically moves to the
+    // friendly dir) but updatePath throws (obsidian.json briefly locked).
+    // The session must use the migrated dir — NOT fall back to legacyDir,
+    // which bootstrap would recreate empty, opening a blank vault while the
+    // real config sits orphaned.
+    const id = 'bbbb2222-3333-4444-5555-666666666666';
+    const profile = makeProfile({ id, name: 'Homelab' });
+    const legacyDir = seedLegacyShadow(id, ['remote-ssh', 'keepme']);
+    const registry = new ObsidianRegistry(scratch.configPath);
+    registry.register(legacyDir);
+    const updateSpy = vi.spyOn(registry, 'updatePath').mockImplementation(() => { throw new Error('EBUSY'); });
+    try {
+      const result = await new ShadowVaultBootstrap(scratch.baseDir, scratch.sourceDir, registry)
+        .bootstrap(profile, [profile]);
+
+      expect(result.migrated, 'rename succeeded → migration committed').toBe(true);
+      expect(path.basename(result.layout.vaultDir)).toBe('Homelab--bbbb2222');
+      expect(fs.existsSync(legacyDir), 'legacy dir was moved, not recreated empty').toBe(false);
+      expect(
+        JSON.parse(fs.readFileSync(path.join(result.layout.configDir, 'community-plugins.json'), 'utf-8')),
+        'config must live at the migrated dir, never orphaned',
+      ).toContain('keepme');
+    } finally { updateSpy.mockRestore(); }
+  });
 });


### PR DESCRIPTION
## Why

The shadow vault directory was named by a bare UUID (`crypto.randomUUID()`), and Obsidian shows a vault by its **directory basename** (there's no display-name field in `obsidian.json`) — so the vault appeared with a cryptic hash name, which read as "re-initialised every connect." (The dir was actually stable; the name was just unrecognisable.)

This is the **cosmetic** half of the #429/#342 work the maintainer asked for — the substantive config/plugin persistence is the round-trip (#434/#437) and the pending pre-spawn-pull (Phase B). The key was never the bug.

## What

- Shadow dir is now `<profile-name>--<short-id>` (e.g. `My Homelab--a1b2c3d4`). The profile id (UUID) stays the stable backend key, embedded in the local `data.json` as before.
- `layoutFor(profile)` derives the friendly name; `resolveLayout` chooses the dir.
- **Transitional migration** (clearly marked, removable after a few releases): a legacy `<uuid>` dir is renamed once to the friendly name, carrying its config/plugins, and `obsidian.json` is repointed with the **same vault id** via the new `ObsidianRegistry.updatePath`. The rename happens during bootstrap — before the shadow window opens — so the vault is never open while it moves; on failure it falls back to the legacy dir (no data loss).
- A profile **rename** reuses the existing `--<short-id>` dir as-is (no churn).
- The renamed/new path isn't in the running Obsidian's startup-cached vault list (the #411 cache), so the connect flow shows the existing **one-time "restart Obsidian" notice** for `migrated` too.

## Cost (transparent)

Existing shadows get a **one-time restart** after upgrading (the renamed path is "new" to the running Obsidian, surfaced by the existing notice). Accepted as a transitional migration per the maintainer.

## Tests (ShadowVaultBootstrap, 57 pass)

friendly naming · empty-name fallback · collision-safety · path-escape safety · migration (rename + config carried + obsidian.json repointed, same id) · idempotent re-bootstrap · fresh profile · **rename-failure fallback (no data loss)**.

`tsc --noEmit`, eslint, full local suite (1155) green.

Refs #429 #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)