### PR TITLE
fix(server): build daemon fully static (CGO_ENABLED=0) — glibc-independent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,23 @@ jobs:
       - name: Build cross-platform daemon binaries
         run: make -C server cross
 
+      - name: Assert the linux/amd64 daemon is statically linked (glibc-independent)
+        # The host-native linux/amd64 target is the only one Go builds with CGO
+        # auto-ENABLED; a dynamically-linked build dies on older hosts with
+        # "GLIBC_x.y not found" — the daemon then never writes its token, RPC
+        # times out, and the client silently drops to SFTP. Fail the release
+        # loudly if a CGO regression sneaks back in (server/Makefile sets
+        # CGO_ENABLED=0 to keep it static).
+        run: |
+          set -euo pipefail
+          f=server/dist/obsidian-remote-server-linux-amd64
+          info=$(file "$f")
+          echo "$info"
+          if echo "$info" | grep -q "dynamically linked"; then
+            echo "::error::$f is dynamically linked — build with CGO_ENABLED=0 (server/Makefile)"
+            exit 1
+          fi
+
       - name: Build daemon-manifest.json (sha256 set)
         id: manifest
         working-directory: server/dist

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.12",
+  "version": "1.1.6-beta.13",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.12",
+  "version": "1.1.6-beta.13",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.12",
+  "version": "1.1.6-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.12",
+      "version": "1.1.6-beta.13",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.12",
+  "version": "1.1.6-beta.13",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/server/Makefile
+++ b/server/Makefile
@@ -5,6 +5,17 @@ CMD       := ./cmd/obsidian-remote-server
 BIN_DIR   := bin
 DIST_DIR  := dist
 
+# Fully static binaries: CGO off so the daemon links no libc and runs on
+# ANY Linux glibc version. Without this, the host-native build in `cross`
+# (linux/amd64 on a modern ubuntu-latest runner, glibc 2.35+) is the only
+# target Go builds with CGO auto-ENABLED — it links dynamically against the
+# runner's glibc and then dies on older hosts with
+# `libc.so.6: version GLIBC_2.34 not found`. The daemon never writes its
+# token, RPC times out, and the client falls back to SFTP. The cross
+# (non-host) targets already default to CGO off; exporting it here makes all
+# targets consistent and static. Mirrors plugin/scripts/build-server.mjs.
+export CGO_ENABLED := 0
+
 .PHONY: build clean cross test fmt
 
 build:


### PR DESCRIPTION
Root cause of the daemon never coming up (found via #445 dogfooding on a real remote).

## Diagnosis (remote `~/.obsidian-remote/server.log`)
```
/home/souta/.obsidian-remote/server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by …/server)
… `GLIBC_2.32' not found …
$ file …/server  → ELF 64-bit LSB executable, x86-64, dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2
$ uname -m       → x86_64
```
Arch is correct (x86-64 on x86_64). The problem is **glibc version**: the released daemon is **dynamically linked** against a newer glibc (2.32/2.34) than the remote has, so it can't start → never writes its token → RPC times out → (post-#445) connect falls back to SFTP.

## Why only the released amd64 binary
`release.yml` builds via `make -C server cross` on **ubuntu-latest (glibc 2.35+)**. Go enables CGO **only for the host-native target** (linux/amd64), so that one links dynamically against the runner's glibc. The cross targets (linux/arm64, darwin/*) already default to CGO-off → static. `plugin/scripts/build-server.mjs` (dev) already sets `CGO_ENABLED=0`, which is why dev never hit this.

## Fix
- **`server/Makefile`**: `export CGO_ENABLED := 0` → all targets build **fully static** (no libc dependency; runs on any Linux glibc).
- **`release.yml`**: after the build, assert the linux/amd64 binary is **not** dynamically linked — a CGO regression now **fails the release loudly** instead of shipping a daemon that only starts on new distros.

## Verification
- Static build is verifiable in CI on merge (the new guard). Locally unbuildable here (no Go toolchain); the guard is the durable proof.
- No plugin code changed → plugin tests unaffected (1187 green as of beta.12). Bumps **1.1.6-beta.13**.

## After merge → BRAT beta.13
On the reporter's host (older glibc), the daemon should finally **start and write its token** → **RPC comes up** → fast walk / live watch / thumbnails / inline image+PDF return. If anything else surfaces, `server.log` will show it.

Not auto-merging — review + smoke by @sotashimozono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)