### PR TITLE
feat(daemon): version-aware provisioning — auto-refresh daemon on plugin upgrade

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.13",
+  "version": "1.1.6-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.13",
+  "version": "1.1.6-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.13",
+  "version": "1.1.6-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.13",
+      "version": "1.1.6-beta.14",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.13",
+  "version": "1.1.6-beta.14",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/scripts/build-server.mjs
+++ b/plugin/scripts/build-server.mjs
@@ -82,6 +82,13 @@ if (result.status !== 0) {
 
 console.log(`build-server: staged ${path.relative(repoRoot, outPath)} (${prettySize(fs.statSync(outPath).size)})`);
 
+// Mark the staged binary as a DEV build so the plugin's locateDaemonBinary
+// trusts it over a download (it now requires this marker). dev-install.mjs and
+// the E2E vault-scaffold copy server-bin/ verbatim, so the marker rides along;
+// build:server on its own (the E2E path, no dev-install) would otherwise leave
+// the daemon unmarked → gated out → RPC unavailable in the Obsidian smoke run.
+fs.writeFileSync(path.join(stageDir, '.dev-daemon'), '');
+
 function locateGo() {
   const fromPath = which('go') ?? which('go.exe');
   if (fromPath) return fromPath;

--- a/plugin/scripts/dev-install.mjs
+++ b/plugin/scripts/dev-install.mjs
@@ -70,9 +70,10 @@ if (fs.existsSync(serverBinDir)) {
     console.log(`copied server-bin/${f} -> ${dst}`);
   }
   // Mark this as a DEV-staged daemon so the plugin trusts it over a
-  // downloaded binary. locateDaemonBinary requires this marker; without it a
-  // downloaded binary at the same filename would be re-validated (sha) and
-  // replaced on a version bump instead of being treated as a dev build.
+  // downloaded binary: locateDaemonBinary returns a staged binary only when
+  // this marker is present. Without it, a *downloaded* binary at the same
+  // filename would masquerade as a dev build and skip the version/sha
+  // re-check (so a changed daemon would never get refreshed).
   fs.writeFileSync(path.join(binTarget, '.dev-daemon'), '');
   console.log('wrote server-bin/.dev-daemon marker');
 } else {

--- a/plugin/scripts/dev-install.mjs
+++ b/plugin/scripts/dev-install.mjs
@@ -69,6 +69,12 @@ if (fs.existsSync(serverBinDir)) {
     fs.copyFileSync(src, dst);
     console.log(`copied server-bin/${f} -> ${dst}`);
   }
+  // Mark this as a DEV-staged daemon so the plugin trusts it over a
+  // downloaded binary. locateDaemonBinary requires this marker; without it a
+  // downloaded binary at the same filename would be re-validated (sha) and
+  // replaced on a version bump instead of being treated as a dev build.
+  fs.writeFileSync(path.join(binTarget, '.dev-daemon'), '');
+  console.log('wrote server-bin/.dev-daemon marker');
 } else {
   console.log('server-bin/ not present — skipping daemon staging (run `npm run build:server` to build it)');
 }

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -44,6 +44,7 @@ import {
   ensureDaemonBinary as downloadDaemonBinary,
   resolveDaemonConsent,
   DaemonVerificationError,
+  binaryFilename,
 } from './transport/DaemonDownloader';
 import { TransferTracker } from "./util/TransferTracker";
 import { LargeTransferBar } from "./ui/LargeTransferBar";
@@ -1288,7 +1289,14 @@ export default class RemoteSshPlugin extends Plugin {
   private locateDaemonBinary(): string | null {
     const pluginDir = this.pluginDir();
     if (!pluginDir) return null;
-    const candidate = path.join(pluginDir, 'server-bin', 'obsidian-remote-server-linux-amd64');
+    const serverBin = path.join(pluginDir, 'server-bin');
+    // Only treat a staged binary as a genuine DEV build when dev-install
+    // marked it (`.dev-daemon`). Without this, a *downloaded* binary at the
+    // same filename would masquerade as a dev build and bypass the version /
+    // sha refresh in ensureDaemonBinary — the exact reason a plugin upgrade
+    // kept re-deploying a stale (dynamically-linked) daemon.
+    if (!fs.existsSync(path.join(serverBin, '.dev-daemon'))) return null;
+    const candidate = path.join(serverBin, 'obsidian-remote-server-linux-amd64');
     return fs.existsSync(candidate) ? candidate : null;
   }
 
@@ -1363,6 +1371,17 @@ export default class RemoteSshPlugin extends Plugin {
       logger.warn(`ensureDaemonBinary: repaired a stale server-bin link at ${cacheDir}`);
     }
 
+    // Fast path: the cached binary was already validated for THIS plugin
+    // version, so reuse it without a GitHub round-trip (and it keeps working
+    // offline). A version mismatch or absence falls through to the sha
+    // re-check / download below, so a plugin upgrade always refreshes a
+    // changed daemon and a legacy/unmarked binary is re-validated.
+    const dest = path.join(cacheDir, binaryFilename(target));
+    if (this.settings.daemonBinaryVersion === this.manifest.version && fs.existsSync(dest)) {
+      logger.info(`ensureDaemonBinary: cached daemon already validated for ${this.manifest.version}; reusing`);
+      return dest;
+    }
+
     // Consent gate (asked once; the decision — accept OR decline — is
     // persisted so a decline doesn't re-prompt on every connect / restart).
     const consented = await resolveDaemonConsent(
@@ -1381,11 +1400,14 @@ export default class RemoteSshPlugin extends Plugin {
           fetchBinary: async (url) => new Uint8Array((await requestUrl({ url })).arrayBuffer),
           fetchText: async (url) => (await requestUrl({ url })).text,
           cacheDir,
-          cacheHit: (abs) => fs.existsSync(abs),
+          readCached: async (abs) => {
+            try { return new Uint8Array(await fs.promises.readFile(abs)); }
+            catch { return null; }
+          },
           writeExecutable: async (abs, bytes) => {
             // Atomic: write a temp sibling, chmod, then rename. A crash
-            // mid-write can't then leave a torn binary that a later cacheHit
-            // would hand back unverified (#406 review).
+            // mid-write can't then leave a torn binary that a later sha
+            // re-check would hand back unverified (#406 review).
             await fs.promises.mkdir(path.dirname(abs), { recursive: true });
             const tmp = `${abs}.${process.pid}.tmp`;
             await fs.promises.writeFile(tmp, bytes);
@@ -1397,7 +1419,11 @@ export default class RemoteSshPlugin extends Plugin {
         },
         target,
       );
-      new Notice(`Remote SSH: downloaded daemon for ${target.os}/${target.arch}.`);
+      // Record the version this cached binary is validated for, so the next
+      // same-version connect takes the network-free fast path above.
+      this.settings.daemonBinaryVersion = this.manifest.version;
+      await this.saveSettings();
+      new Notice(`Remote SSH: daemon ready for ${target.os}/${target.arch}.`);
       return local;
     } catch (e) {
       // A sha256 mismatch / malformed manifest (DaemonVerificationError) is a

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -46,6 +46,7 @@ import {
   DaemonVerificationError,
   binaryFilename,
 } from './transport/DaemonDownloader';
+import { createHash } from 'crypto';
 import { TransferTracker } from "./util/TransferTracker";
 import { LargeTransferBar } from "./ui/LargeTransferBar";
 import { OnboardingModal } from "./ui/OnboardingModal";
@@ -1301,6 +1302,21 @@ export default class RemoteSshPlugin extends Plugin {
   }
 
   /**
+   * sha256 (hex) of a cached daemon binary, or null if it can't be read.
+   * Used by the connect fast-path to re-validate the cached bytes without a
+   * network round-trip. Reads the whole file (a daemon binary is a few MB) —
+   * cheap next to the SSH connect it gates.
+   */
+  private async sha256File(abs: string): Promise<string | null> {
+    try {
+      const buf = await fs.promises.readFile(abs);
+      return createHash('sha256').update(buf).digest('hex');
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Acquire a daemon binary for the REMOTE's os/arch when one isn't staged
    * locally. Community-store installs don't ship `server-bin/`, so we probe
    * the remote with `uname`, download the matching binary from this plugin's
@@ -1371,14 +1387,20 @@ export default class RemoteSshPlugin extends Plugin {
       logger.warn(`ensureDaemonBinary: repaired a stale server-bin link at ${cacheDir}`);
     }
 
-    // Fast path: the cached binary was already validated for THIS plugin
-    // version, so reuse it without a GitHub round-trip (and it keeps working
-    // offline). A version mismatch or absence falls through to the sha
-    // re-check / download below, so a plugin upgrade always refreshes a
-    // changed daemon and a legacy/unmarked binary is re-validated.
+    // Fast path: reuse the cached binary without a GitHub round-trip when it
+    // was provisioned for THIS plugin version AND its bytes still hash to the
+    // recorded sha. The sha re-check upholds the "never deploy an unverified
+    // binary" invariant even here — a file corrupted/truncated after its
+    // verified download is caught (network-free) and re-fetched below. A
+    // version mismatch, missing marker, or sha mismatch falls through to the
+    // manifest sha re-check / download.
     const dest = path.join(cacheDir, binaryFilename(target));
-    if (this.settings.daemonBinaryVersion === this.manifest.version && fs.existsSync(dest)) {
-      logger.info(`ensureDaemonBinary: cached daemon already validated for ${this.manifest.version}; reusing`);
+    if (
+      this.settings.daemonBinaryVersion === this.manifest.version &&
+      this.settings.daemonBinarySha &&
+      (await this.sha256File(dest)) === this.settings.daemonBinarySha
+    ) {
+      logger.info(`ensureDaemonBinary: cached daemon validated for ${this.manifest.version}; reusing`);
       return dest;
     }
 
@@ -1419,10 +1441,21 @@ export default class RemoteSshPlugin extends Plugin {
         },
         target,
       );
-      // Record the version this cached binary is validated for, so the next
-      // same-version connect takes the network-free fast path above.
-      this.settings.daemonBinaryVersion = this.manifest.version;
-      await this.saveSettings();
+      // Record the version + sha this cached binary is validated for, so the
+      // next same-version connect takes the network-free fast path above.
+      // Non-fatal: the binary is verified on disk, so a marker-persist failure
+      // must NOT be reported as a download failure — we just re-verify on the
+      // next connect.
+      try {
+        this.settings.daemonBinaryVersion = this.manifest.version;
+        this.settings.daemonBinarySha = (await this.sha256File(local)) ?? undefined;
+        await this.saveSettings();
+      } catch (e) {
+        logger.warn(
+          `ensureDaemonBinary: daemon ready but failed to persist cache marker ` +
+          `(${errorMessage(e)}); will re-verify on the next connect`,
+        );
+      }
       new Notice(`Remote SSH: daemon ready for ${target.os}/${target.arch}.`);
       return local;
     } catch (e) {

--- a/plugin/src/transport/DaemonDownloader.ts
+++ b/plugin/src/transport/DaemonDownloader.ts
@@ -32,8 +32,12 @@ export interface DaemonDownloaderDeps {
   cacheDir: string;
   /** Persist downloaded bytes to disk and mark executable (chmod +x). */
   writeExecutable: (absPath: string, bytes: Uint8Array) => Promise<void>;
-  /** True if a cached file already exists. */
-  cacheHit: (absPath: string) => boolean;
+  /**
+   * Read a cached binary's bytes, or null if absent / unreadable. Used for
+   * sha-based cache validation: a cached file whose bytes still match the
+   * release manifest's expected sha is reused; anything else is re-downloaded.
+   */
+  readCached: (absPath: string) => Promise<Uint8Array | null>;
   /** `owner/repo` for the release URL. */
   repo: string;
   /**
@@ -113,8 +117,6 @@ export async function ensureDaemonBinary(
 ): Promise<string> {
   const filename = binaryFilename(target);
   const dest = path.join(deps.cacheDir, filename);
-  if (deps.cacheHit(dest)) return dest;
-
   const base = `https://github.com/${deps.repo}/releases/download/${deps.version}`;
 
   const manifestRaw = await deps.fetchText(`${base}/${MANIFEST_NAME}`);
@@ -140,6 +142,19 @@ export async function ensureDaemonBinary(
     throw new DaemonVerificationError(
       `${MANIFEST_NAME} has no entry for ${filename} (release ${deps.version})`,
     );
+  }
+
+  // Reuse the cached binary IFF its bytes already match the expected sha —
+  // i.e. the daemon didn't change across this bump. A cached binary from a
+  // prior plugin version (or the pre-static-build era) has the same filename
+  // but different bytes, so it fails this check and is re-downloaded. This is
+  // what makes a plugin upgrade refresh a *changed* daemon instead of
+  // re-deploying the stale one, while skipping the download for an unchanged
+  // one. (`writeExecutable` overwrites atomically, so the stale file is
+  // replaced in place — no separate delete.)
+  const cached = await deps.readCached(dest);
+  if (cached && sha256Hex(cached).toLowerCase() === expected.toLowerCase()) {
+    return dest;
   }
 
   const bytes = await deps.fetchBinary(`${base}/${filename}`);

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -135,6 +135,15 @@ export interface PluginSettings {
    */
   daemonDownloadConsented?: boolean;
   /**
+   * Plugin version the currently-cached daemon binary was validated for.
+   * The connect fast-path reuses the cached binary without hitting GitHub
+   * when this equals the running `manifest.version`; a mismatch (or absence)
+   * forces a sha re-check against the release manifest, so a plugin upgrade
+   * always refreshes a *changed* daemon and never re-downloads an unchanged
+   * one. Written after each successful (re)provision.
+   */
+  daemonBinaryVersion?: string;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -144,6 +144,14 @@ export interface PluginSettings {
    */
   daemonBinaryVersion?: string;
   /**
+   * sha256 (hex) of the currently-cached daemon binary. The connect fast-path
+   * re-hashes the cached file and reuses it only when this still matches — so
+   * a binary corrupted/truncated after its verified download is detected
+   * (network-free) and re-fetched instead of deployed. Paired with
+   * `daemonBinaryVersion`; both are written together after a provision.
+   */
+  daemonBinarySha?: string;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/tests/DaemonDownloader.test.ts
+++ b/plugin/tests/DaemonDownloader.test.ts
@@ -84,7 +84,7 @@ describe('ensureDaemonBinary', () => {
         return bytes;
       },
       cacheDir: '/vault/.obsidian/plugins/remote-ssh/server-bin',
-      cacheHit: () => false,
+      readCached: async () => null,
       writeExecutable: async (p, b) => {
         written.set(p, b);
       },
@@ -101,18 +101,28 @@ describe('ensureDaemonBinary', () => {
     expect(deps.written.get(p)).toEqual(bytes);
   });
 
-  it('uses the cache and does NOT download on a cache hit', async () => {
+  it('reuses the cached binary WITHOUT downloading when its bytes match the manifest sha', async () => {
     let fetched = false;
     const deps = makeDeps({
-      cacheHit: () => true,
-      fetchBinary: async () => {
-        fetched = true;
-        return bytes;
-      },
+      readCached: async () => bytes,   // cached bytes already hash to `sha`
+      fetchBinary: async () => { fetched = true; return bytes; },
     });
     const p = await ensureDaemonBinary(deps, target);
     expect(p).toContain(filename);
-    expect(fetched).toBe(false);
+    expect(fetched).toBe(false);       // no binary download
+    expect(deps.written.size).toBe(0); // nothing re-written
+  });
+
+  it('RE-DOWNLOADS when the cached binary sha does NOT match (stale from a prior plugin version)', async () => {
+    let fetched = false;
+    const stale = new Uint8Array([0x00, 0x11, 0x22]); // different bytes → different sha
+    const deps = makeDeps({
+      readCached: async () => stale,
+      fetchBinary: async () => { fetched = true; return bytes; },
+    });
+    const p = await ensureDaemonBinary(deps, target);
+    expect(fetched).toBe(true);                  // stale cache → fetched fresh
+    expect(deps.written.get(p)).toEqual(bytes);  // overwritten with the correct binary
   });
 
   it('throws DaemonVerificationError on sha256 mismatch (never caches)', async () => {
@@ -183,5 +193,7 @@ describe('resolveDaemonConsent', () => {
 describe('deferred hardening (#406 review)', () => {
   it.todo('verifies the cosign .bundle (sigstore) against the GitHub OIDC identity before deploy — closes the MITM gap that sha256-from-the-same-channel leaves open');
   it.todo('shares the daemon binary cache across vaults/profiles (e.g. ~/.obsidian-remote/server-bin) so a second profile reuses the first download + single consent');
-  it.todo('re-verifies a cache-hit binary against its sha256 before reuse — defends post-write on-disk corruption (the atomic tmp+rename write already closes the mid-download crash window)');
+  // Implemented: ensureDaemonBinary now re-checks a cached binary's sha256
+  // against the release manifest before reuse (see the reuse / re-download
+  // tests above), which also refreshes a stale binary after a plugin upgrade.
 });

--- a/plugin/tests/ensureDaemonBinary.test.ts
+++ b/plugin/tests/ensureDaemonBinary.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createHash } from 'crypto';
+
+// main.ts pulls in RemoteTerminalView (extends the obsidian ItemView the unit
+// mock doesn't model) — stub it so the import graph resolves. Same shim the
+// sibling connectProfile.daemon-downgrade.test.ts uses.
+vi.mock('../src/ui/RemoteTerminalView', () => ({
+  RemoteTerminalView: class {},
+  VIEW_TYPE_REMOTE_TERMINAL: 'remote-terminal',
+}));
+
+import { App } from 'obsidian';
+import RemoteSshPlugin from '../src/main';
+
+/** A fake SftpClient whose `exec` answers the daemon's `uname` probe. */
+const linuxAmd64Client = {
+  exec: async (cmd: string) => ({
+    stdout: cmd === 'uname -s' ? 'Linux' : 'x86_64',
+    stderr: '',
+    exitCode: 0,
+  }),
+};
+
+const tmpDirs: string[] = [];
+function scratchPluginDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `rs-daemon-${process.pid}-`));
+  tmpDirs.push(dir);
+  fs.mkdirSync(path.join(dir, 'server-bin'), { recursive: true });
+  return dir;
+}
+afterEach(() => {
+  while (tmpDirs.length) {
+    try { fs.rmSync(tmpDirs.pop()!, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+const BIN_NAME = 'obsidian-remote-server-linux-amd64';
+
+describe('RemoteSshPlugin.locateDaemonBinary — .dev-daemon marker gate', () => {
+  it('returns null for an UNMARKED staged binary (a download must not masquerade as a dev build)', () => {
+    const plugin = new RemoteSshPlugin(new App() as never);
+    const dir = scratchPluginDir();
+    fs.writeFileSync(path.join(dir, 'server-bin', BIN_NAME), 'ELF');
+    const p = plugin as unknown as { pluginDir: () => string; locateDaemonBinary: () => string | null };
+    p.pluginDir = () => dir;
+
+    expect(p.locateDaemonBinary()).toBeNull();
+  });
+
+  it('returns the binary path once dev-install has written the .dev-daemon marker', () => {
+    const plugin = new RemoteSshPlugin(new App() as never);
+    const dir = scratchPluginDir();
+    const bin = path.join(dir, 'server-bin', BIN_NAME);
+    fs.writeFileSync(bin, 'ELF');
+    fs.writeFileSync(path.join(dir, 'server-bin', '.dev-daemon'), '');
+    const p = plugin as unknown as { pluginDir: () => string; locateDaemonBinary: () => string | null };
+    p.pluginDir = () => dir;
+
+    expect(p.locateDaemonBinary()).toBe(bin);
+  });
+});
+
+describe('RemoteSshPlugin.ensureDaemonBinary — version + sha fast path', () => {
+  interface Internals {
+    pluginDir: () => string;
+    manifest: { version: string };
+    settings: Record<string, unknown>;
+    saveData: (d: unknown) => Promise<void>;
+    confirmDaemonDownload: (v: string) => Promise<boolean>;
+    ensureDaemonBinary: (client: unknown) => Promise<string | null>;
+  }
+
+  function makePlugin(dir: string, settings: Record<string, unknown>): Internals {
+    const plugin = new RemoteSshPlugin(new App() as never);
+    const p = plugin as unknown as Internals;
+    p.pluginDir = () => dir;
+    p.manifest = { version: '1.2.0' };
+    p.settings = settings;
+    p.saveData = async () => { /* no-op persist */ };
+    return p;
+  }
+
+  it('reuses the cached binary WITHOUT any download when version + sha both match', async () => {
+    const dir = scratchPluginDir();
+    const bin = path.join(dir, 'server-bin', BIN_NAME);
+    const bytes = Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01]);
+    fs.writeFileSync(bin, bytes);
+    const sha = createHash('sha256').update(bytes).digest('hex');
+    const p = makePlugin(dir, { daemonBinaryVersion: '1.2.0', daemonBinarySha: sha });
+
+    // No requestUrl is mocked here: a fall-through to the download path would
+    // throw, so returning the cached path proves the fast path fired.
+    const result = await p.ensureDaemonBinary(linuxAmd64Client);
+    expect(result).toBe(bin);
+  });
+
+  it('does NOT take the fast path when the cached bytes no longer match the sha (post-write corruption)', async () => {
+    const dir = scratchPluginDir();
+    // File whose real sha does NOT match the recorded marker → integrity fail.
+    fs.writeFileSync(path.join(dir, 'server-bin', BIN_NAME), Buffer.from([0x00, 0x11, 0x22]));
+    const p = makePlugin(dir, {
+      daemonBinaryVersion: '1.2.0',
+      daemonBinarySha: 'f'.repeat(64), // deliberately wrong
+      daemonDownloadConsented: false,
+    });
+    // Fall-through reaches the consent gate; decline it to end deterministically
+    // on the "staying on SFTP" path (no network) rather than the fast path.
+    p.confirmDaemonDownload = async () => false;
+
+    const result = await p.ensureDaemonBinary(linuxAmd64Client);
+    expect(result).toBeNull(); // fell through (not reused) → declined → SFTP
+  });
+
+  it('does NOT take the fast path when the recorded version differs from the plugin version', async () => {
+    const dir = scratchPluginDir();
+    const bin = path.join(dir, 'server-bin', BIN_NAME);
+    const bytes = Buffer.from([0x7f, 0x45, 0x4c, 0x46]);
+    fs.writeFileSync(bin, bytes);
+    const sha = createHash('sha256').update(bytes).digest('hex');
+    // sha matches the file, but the marker is for an OLDER plugin version.
+    const p = makePlugin(dir, {
+      daemonBinaryVersion: '1.1.0',
+      daemonBinarySha: sha,
+      daemonDownloadConsented: false,
+    });
+    p.confirmDaemonDownload = async () => false;
+
+    const result = await p.ensureDaemonBinary(linuxAmd64Client);
+    expect(result).toBeNull(); // version mismatch → re-check path → declined → SFTP
+  });
+});


### PR DESCRIPTION
Follow-up to #446 (static daemon, merged as beta.13). Dogfooding beta.13 showed the static fix shipped but the client **kept deploying the old dynamically-linked binary** — because the daemon cache never noticed the plugin upgraded.

## Root cause (two bugs)
1. `DaemonDownloader` cache was keyed by **arch only** (`cacheHit = existsSync(server-bin/obsidian-remote-server-<os>-<arch>)`). The download URL carried the version, but the cache filename didn't → a beta.12-era binary satisfied the cache-hit on beta.13 → **never re-downloaded**.
2. `locateDaemonBinary` returned **any** staged binary at the dev filename. A prior *download* lands at that same name, so it **masqueraded as a dev build** and skipped the download path (and thus any refresh) entirely.

## Design (agreed: single cached file, sha-diff, delete-and-replace — no per-version pileup)
- **`DaemonDownloader.ensureDaemonBinary`**: validate the cache by **sha256 against the release manifest**, not mere existence. Reuse **iff** the cached bytes still match the expected sha; otherwise re-download (atomic `writeExecutable` overwrites in place → old dropped). ⇒ an *unchanged* daemon across a bump is **not** re-downloaded; a *changed/stale* one is.
- **`main.ts ensureDaemonBinary`**: fast-path when `settings.daemonBinaryVersion === manifest.version` and the cached file exists → **no GitHub round-trip** (also works offline). On mismatch → sha re-check/download, then record the new version.
- **`locateDaemonBinary`**: require a **`.dev-daemon`** marker (written by `dev-install`) to treat a staged binary as a genuine dev build. An unmarked binary (a download) is re-validated, not trusted — this is what makes an existing store/BRAT user's stale binary **auto-replace seamlessly, no manual delete**.

Answers the concerns directly: **checks on every version-up**, **skips the download when the daemon is unchanged** (not "毎回全デプロイ"), and **deletes/replaces** the old binary (single file).

## Files
`DaemonDownloader.ts` (sha-diff + `readCached` dep) · `main.ts` (fast-path, marker, dev gate, wiring) · `types.ts` (`daemonBinaryVersion`) · `dev-install.mjs` (`.dev-daemon` marker) · `DaemonDownloader.test.ts` (reuse-on-sha-match / re-download-on-mismatch; implements the deferred #406 "re-verify sha before reuse").

## Verification
- `tsc` OK · `lint` OK · `vitest run` OK (1188 passed) · bumps **1.1.6-beta.14**.

## After merge → BRAT beta.14
The reporter's stale **dynamic** binary auto-replaces with the beta.13 **static** one on next connect (no manual `Remove-Item` needed): console shows the sha-driven re-download, then RPC comes up. Subsequent same-version connects take the network-free fast path.

Not auto-merging — review + smoke by @sotashimozono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)