### PR TITLE
perf(vault): chunk connect-time populate — large vaults no longer freeze the UI

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.14",
+  "version": "1.1.6-beta.15",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.14",
+  "version": "1.1.6-beta.15",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.14",
+  "version": "1.1.6-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.14",
+      "version": "1.1.6-beta.15",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.14",
+  "version": "1.1.6-beta.15",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -939,7 +939,10 @@ export default class RemoteSshPlugin extends Plugin {
     );
 
     const builder = new VaultModelBuilder(this.app.vault, { TFile, TFolder });
-    const result = await builder.build(walk.entries);
+    // Chunked so a large vault (tens of thousands of entries) fills the File
+    // Explorer progressively instead of freezing the window while every entry
+    // is materialised + `create`-triggered in a single JS tick.
+    const result = await builder.buildChunked(walk.entries);
     const totalMs = Date.now() - start;
 
     const summary =

--- a/plugin/src/vault/VaultModelBuilder.ts
+++ b/plugin/src/vault/VaultModelBuilder.ts
@@ -103,42 +103,84 @@ export class VaultModelBuilder {
     // Folders before files at the same depth, then by depth ascending,
     // so parents always exist by the time their children are processed.
     const ordered = [...entries].sort(byFoldersFirstThenDepth);
-
-    for (const entry of ordered) {
-      if (!entry.path) {
-        result.errors.push({ path: entry.path, message: 'empty path is not allowed' });
-        continue;
-      }
-      if (this.vault.getAbstractFileByPath(entry.path)) {
-        result.skipped++;
-        continue;
-      }
-      const parent = this.resolveParent(entry.path);
-      if (!parent) {
-        result.errors.push({
-          path: entry.path,
-          message: `parent folder for "${entry.path}" not found in vault`,
-        });
-        continue;
-      }
-      try {
-        if (entry.isDirectory) {
-          this.insertFolder(entry.path, parent);
-          result.foldersAdded++;
-        } else {
-          this.insertFile(entry, parent);
-          result.filesAdded++;
-        }
-      } catch (e) {
-        result.errors.push({ path: entry.path, message: errorMessage(e) });
-      }
-    }
+    for (const entry of ordered) this.insertBuildEntry(entry, result);
 
     logger.info(
       `VaultModelBuilder: built ${result.filesAdded}f + ${result.foldersAdded}d, ` +
       `${result.skipped} skipped, ${result.errors.length} errors`,
     );
     return result;
+  }
+
+  /**
+   * Chunked, non-blocking variant of `build` for the bulk connect-time
+   * populate. Inserts the (folders-first) entry list in fixed-size chunks,
+   * yielding to the event loop between them so Obsidian can paint the File
+   * Explorer increments and stay responsive.
+   *
+   * A synchronous one-tick build of a large vault (tens of thousands of
+   * entries, each firing a `vault.trigger('create')`) blocks the main thread
+   * for tens of seconds — the tree looks empty and the window freezes.
+   * Chunking trades that for the tree filling in progressively.
+   *
+   * Ordering is preserved (the sorted list is walked start-to-end), so a
+   * file's parent folder is always inserted in the same or an earlier chunk.
+   * Inserts are idempotent (an already-present path is skipped), so a live
+   * `fs.changed` insert landing between chunks can't double-add.
+   */
+  async buildChunked(
+    entries: ReadonlyArray<RemoteEntry>,
+    chunkSize = 500,
+  ): Promise<BuildResult> {
+    const result: BuildResult = {
+      filesAdded: 0, foldersAdded: 0, skipped: 0, errors: [],
+    };
+    const ordered = [...entries].sort(byFoldersFirstThenDepth);
+    for (let i = 0; i < ordered.length; i += chunkSize) {
+      const end = Math.min(i + chunkSize, ordered.length);
+      for (let j = i; j < end; j++) this.insertBuildEntry(ordered[j], result);
+      if (end < ordered.length) await yieldToEventLoop();
+    }
+    logger.info(
+      `VaultModelBuilder: built ${result.filesAdded}f + ${result.foldersAdded}d (chunked), ` +
+      `${result.skipped} skipped, ${result.errors.length} errors`,
+    );
+    return result;
+  }
+
+  /**
+   * Insert one walked entry into the vault model, accumulating counters and
+   * errors. Shared by `buildSync` and `buildChunked` so the two stay in
+   * lock-step. Never throws — a bad entry is recorded in `result.errors`.
+   */
+  private insertBuildEntry(entry: RemoteEntry, result: BuildResult): void {
+    if (!entry.path) {
+      result.errors.push({ path: entry.path, message: 'empty path is not allowed' });
+      return;
+    }
+    if (this.vault.getAbstractFileByPath(entry.path)) {
+      result.skipped++;
+      return;
+    }
+    const parent = this.resolveParent(entry.path);
+    if (!parent) {
+      result.errors.push({
+        path: entry.path,
+        message: `parent folder for "${entry.path}" not found in vault`,
+      });
+      return;
+    }
+    try {
+      if (entry.isDirectory) {
+        this.insertFolder(entry.path, parent);
+        result.foldersAdded++;
+      } else {
+        this.insertFile(entry, parent);
+        result.filesAdded++;
+      }
+    } catch (e) {
+      result.errors.push({ path: entry.path, message: errorMessage(e) });
+    }
   }
 
   // ─── internals ───────────────────────────────────────────────────────────
@@ -544,6 +586,17 @@ export class VaultModelBuilder {
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Yield to the macrotask queue so the renderer can paint pending File
+ * Explorer updates between build chunks. A microtask (`Promise.resolve()`)
+ * would run before the browser paints; a 0 ms timer lets it paint first.
+ * Uses `window.setTimeout` per the repo's timer convention (the vitest setup
+ * polyfills `window`).
+ */
+function yieldToEventLoop(): Promise<void> {
+  return new Promise(resolve => { window.setTimeout(resolve, 0); });
+}
 
 /**
  * Sort key: folders first at any given depth, then by depth ascending.

--- a/plugin/tests/VaultModelBuilder.test.ts
+++ b/plugin/tests/VaultModelBuilder.test.ts
@@ -73,6 +73,55 @@ function makeFakeVault() {
   return { vault, root, fileMap, triggers };
 }
 
+describe('VaultModelBuilder.buildChunked', () => {
+  it('builds every entry across multiple chunks (folders-before-files), no errors', async () => {
+    const { vault, fileMap } = makeFakeVault();
+    // One folder + 1200 files under it → spans several chunks at chunkSize 100.
+    const entries: RemoteEntry[] = [{ path: 'work', isDirectory: true, ctime: 0, mtime: 0, size: 0 }];
+    for (let i = 0; i < 1200; i++) {
+      entries.push({ path: `work/n${i}.md`, isDirectory: false, ctime: 0, mtime: 0, size: 0 });
+    }
+    // Reverse the input to prove ordering is fixed internally, not by the caller.
+    const shuffled = [...entries].reverse();
+
+    const result = await new VaultModelBuilder(vault as never, deps).buildChunked(shuffled, 100);
+
+    expect(result.foldersAdded).toBe(1);
+    expect(result.filesAdded).toBe(1200);
+    expect(result.errors).toEqual([]);
+    expect(Object.keys(fileMap)).toHaveLength(1201);
+    expect(fileMap['work']).toBeInstanceOf(FakeTFolder);
+    expect(fileMap['work/n0.md']).toBeInstanceOf(FakeTFile);
+    expect(fileMap['work/n1199.md']).toBeInstanceOf(FakeTFile);
+  });
+
+  it('is idempotent: entries already in the vault are skipped, not re-added', async () => {
+    const { vault } = makeFakeVault();
+    const builder = new VaultModelBuilder(vault as never, deps);
+    const entries: RemoteEntry[] = [
+      { path: 'a',     isDirectory: true,  ctime: 0, mtime: 0, size: 0 },
+      { path: 'a/x.md', isDirectory: false, ctime: 0, mtime: 0, size: 0 },
+    ];
+    await builder.buildChunked(entries, 1);
+    const second = await builder.buildChunked(entries, 1);
+    expect(second).toEqual({ filesAdded: 0, foldersAdded: 0, skipped: 2, errors: [] });
+  });
+
+  it('produces the same model + result as the synchronous build()', async () => {
+    const entries: RemoteEntry[] = [
+      { path: 'd',      isDirectory: true,  ctime: 0, mtime: 0, size: 0 },
+      { path: 'd/a.md', isDirectory: false, ctime: 1, mtime: 2, size: 3 },
+      { path: 'top.md', isDirectory: false, ctime: 0, mtime: 0, size: 0 },
+    ];
+    const a = makeFakeVault();
+    const sync = await new VaultModelBuilder(a.vault as never, deps).build(entries);
+    const b = makeFakeVault();
+    const chunked = await new VaultModelBuilder(b.vault as never, deps).buildChunked(entries, 1);
+    expect(chunked).toEqual(sync);
+    expect(Object.keys(b.fileMap).sort()).toEqual(Object.keys(a.fileMap).sort());
+  });
+});
+
 describe('VaultModelBuilder.build', () => {
   it('returns zero counts for empty entry list', async () => {
     const { vault } = makeFakeVault();


### PR DESCRIPTION
Dogfooding beta.14 (RPC daemon finally working) surfaced a scale problem the earlier SFTP/broken-daemon path had masked: a profile pointed at a **large** remote vault (`~/work` with tens of thousands of files, many directly under `work/`) **freezes Obsidian for tens of seconds** on connect, and File Explorer stays empty / most of the tree never appears.

## Root cause (investigated, file:line)
`populateVaultFromRemote` → `VaultModelBuilder.build(walk.entries)` → `buildSync` materialises **every** walked entry and fires a `vault.trigger('create', …)` for each in **one synchronous JS tick**. For ~30k entries that's ~30k `fileMap` inserts + ~30k trigger events with no yield → the main thread is blocked for tens of seconds, so the window freezes and the tree can't paint. The RPC `fs.walk` itself already paginates fine (handles 50k+); the freeze is the **build**, not the walk. There is no lazy loading and no persisted structure cache today.

## Fix (this PR): chunked, non-blocking build
- `VaultModelBuilder`: extracted the per-entry insert into `insertBuildEntry` (shared by `buildSync`); added **`buildChunked(entries, chunkSize=500)`** — processes the folders-first list in chunks and **yields to the event loop between chunks**, so File Explorer paints the increments and the window stays responsive.
  - Ordering preserved (the sorted list is walked start-to-end → a file's parent folder is always in the same or an earlier chunk).
  - Inserts are idempotent (existing paths skipped) → a live `fs.changed` insert landing between chunks can't double-add.
- `populateVaultFromRemote` now calls `buildChunked`.

Net: the tree **fills in progressively** instead of freezing; behaviour is otherwise identical to `build()` (a test asserts the two produce the same model + result).

## Follow-ups (agreed design, separate PRs)
- **Lightweight structure cache** (per @sotashimozono): persist the walked tree — *names + structure + mtime/size only, no contents* — inside the shadow vault (`walk-index.json`, so it rides the shadow-dir rename; remotePath-stamped for invalidation). Reconnect builds from cache instantly, then reconciles deltas from a fresh walk → skips the cold re-walk+build.
- **Lazy per-folder loading** (materialise a folder's children on expand) — larger change, later.
- File **contents** stay on-demand (only viewed files, existing ReadCache) — unchanged, per the agreed design.

## Verification
- `tsc` OK · `lint` OK · `vitest run` OK (1196 passed; +3 `buildChunked` tests: multi-chunk full build / idempotency / parity with `build()`). Ships **1.1.6-beta.15**.

## After merge → BRAT beta.15
Reconnect the large `work` vault: the window should stay responsive and the File Explorer tree fill in progressively (no multi-second freeze).

> Note: the earlier daemon arc (#443–#447) is orthogonal — it didn't touch walk/build/cache; this freeze is a pre-existing scale limit exposed now that RPC does a fast complete walk. The "cache that used to handle this" was in-memory only (gone on restart), so it wasn't broken by the shadow-dir rename.

Not auto-merging — review + smoke by @sotashimozono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)