### PR TITLE
feat(vault): lazy per-folder loading — deepen the remote tree on File-Explorer expand

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.15",
+  "version": "1.1.6-beta.16",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.15",
+  "version": "1.1.6-beta.16",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.15",
+  "version": "1.1.6-beta.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.15",
+      "version": "1.1.6-beta.16",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.15",
+  "version": "1.1.6-beta.16",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -39,6 +39,10 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   reconnectMaxRetries: 5,
   clientId: '',
   userName: '',
+  // Deepen the remote tree one folder level at a time on File-Explorer expand,
+  // rather than eager-walking the whole (potentially huge, deep) tree at
+  // connect. Default on; safe to turn off for small vaults.
+  lazyFolderLoad: true,
   // Phase 4 marker for shadow vaults; null on a normal vault. Only
   // `ShadowVaultBootstrap` writes a non-null value.
   autoConnectProfileId: null,

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -24,6 +24,7 @@ import { classifyToNotice } from './transport/errorTaxonomy';
 import { VaultModelBuilder } from './vault/VaultModelBuilder';
 import { FsChangeListener } from './vault/FsChangeListener';
 import { BulkWalker } from './vault/BulkWalker';
+import { LazyFolderLoader } from './vault/LazyFolderLoader';
 import { RenameLeafFollower } from './vault/RenameLeafFollower';
 import { ObsidianRegistry } from './shadow/ObsidianRegistry';
 import { ShadowVaultBootstrap } from './shadow/ShadowVaultBootstrap';
@@ -843,6 +844,9 @@ export default class RemoteSshPlugin extends Plugin {
     this.sharedConfigWatcher?.stop();
     this.sharedConfigWatcher = null;
     this.adapterMgr.restore();
+    // Drop lazy-load state — the walker it captured is now disconnected. A
+    // stray File-Explorer click after this finds a null loader and no-ops.
+    this.lazyLoader = null;
     await this.conn.disconnectTransport();
     this.setState(SyncState.IDLE);
     if (this.settings.activeProfileId !== null) {
@@ -884,6 +888,43 @@ export default class RemoteSshPlugin extends Plugin {
     }
   }
 
+  /** Lazy per-folder loader (deepen-on-expand); null until a lazy connect. */
+  private lazyLoader: LazyFolderLoader | null = null;
+  private lazyExpandHookInstalled = false;
+
+  /** A fresh BulkWalker bound to the current session's transport + ignore list. */
+  private makeWalker(): BulkWalker {
+    return new BulkWalker({
+      adapter: this.app.vault.adapter,
+      rpcConnection: this.conn.rpcConnection ?? undefined,
+      // Older profiles have no walkIgnoreDirs → fall back to the sensible
+      // defaults so existing users immediately benefit. An explicit empty
+      // array (user cleared it) means "ignore nothing" and is respected.
+      ignoreDirs: this.conn.activeProfile?.walkIgnoreDirs ?? [...DEFAULT_WALK_IGNORE_DIRS],
+    });
+  }
+
+  /**
+   * One delegated, capture-phase click listener that deepens a folder the
+   * first time it's expanded in File Explorer. Obsidian renders folder
+   * children from the in-memory model, does NOT re-list on expand, and exposes
+   * no public folder-expand event — hence the DOM hook on `.nav-folder-title`
+   * (which carries the folder's `data-path`; verified in a real-Obsidian
+   * spike). Idempotent per folder via LazyFolderLoader, so a click on an
+   * already-loaded folder (or a collapse) is a cheap no-op. Installed once;
+   * `registerDomEvent` tears it down on unload.
+   */
+  private installLazyExpandHook(): void {
+    if (this.lazyExpandHookInstalled) return;
+    this.lazyExpandHookInstalled = true;
+    this.registerDomEvent(activeDocument, 'click', (evt) => {
+      const title = (evt.target as HTMLElement | null)?.closest?.('.nav-folder-title');
+      const path = title?.getAttribute('data-path');
+      if (path == null) return;
+      void this.lazyLoader?.loadFolder(path);
+    }, { capture: true });
+  }
+
   /**
    * POC for the shadow-vault architecture (see
    * docs/en/architecture/shadow-vault.md, Phase 1): walk the patched
@@ -921,29 +962,36 @@ export default class RemoteSshPlugin extends Plugin {
     // mtime+size per entry) when the active session is RPC AND the
     // daemon advertises the capability. Otherwise BulkWalker
     // transparently runs the legacy BFS via the patched adapter.
-    const walker = new BulkWalker({
-      adapter: this.app.vault.adapter,
-      rpcConnection: this.conn.rpcConnection ?? undefined,
-      // Older profiles have no walkIgnoreDirs → fall back to the
-      // sensible defaults so existing users immediately benefit. An
-      // explicit empty array (user cleared it) means "ignore nothing"
-      // and is respected (?? only fills null/undefined).
-      ignoreDirs: this.conn.activeProfile?.walkIgnoreDirs
-        ?? [...DEFAULT_WALK_IGNORE_DIRS],
-    });
-    const walk = await walker.walk('');
+    const walker = this.makeWalker();
+    // Lazy mode (default): walk only the ROOT level and deepen each folder on
+    // first expand, so a deep, dir-heavy vault doesn't pull + materialise tens
+    // of thousands of entries at connect. `walkIgnoreDirs` is applied per level
+    // either way. Set `lazyFolderLoad: false` to restore the full eager walk.
+    const lazy = this.settings.lazyFolderLoad !== false;
+    const walk = await walker.walk('', !lazy);
     logger.info(
       `populateVaultFromRemote(${label}): ${walk.source}, ${walk.entries.length} entries ` +
-      `in ${walk.walkMs}ms (pages=${walk.pages})` +
+      `in ${walk.walkMs}ms (pages=${walk.pages})${lazy ? ' [lazy: root level]' : ''}` +
       (walk.fastPathError ? ` (fast-path fallback: ${walk.fastPathError})` : ''),
     );
 
     const builder = new VaultModelBuilder(this.app.vault, { TFile, TFolder });
-    // Chunked so a large vault (tens of thousands of entries) fills the File
-    // Explorer progressively instead of freezing the window while every entry
-    // is materialised + `create`-triggered in a single JS tick.
+    // Chunked so even one level (or a full eager walk) fills the File Explorer
+    // progressively instead of freezing the window while every entry is
+    // materialised + `create`-triggered in a single JS tick.
     const result = await builder.buildChunked(walk.entries);
     const totalMs = Date.now() - start;
+
+    if (lazy) {
+      // Obsidian renders folders from the in-memory model and does NOT re-list
+      // on expand, so deepen-on-expand is driven by a File-Explorer click hook.
+      this.lazyLoader = new LazyFolderLoader(
+        () => this.makeWalker(),
+        () => new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
+      );
+      this.lazyLoader.markLoaded('');
+      this.installLazyExpandHook();
+    }
 
     const summary =
       `${result.filesAdded}f + ${result.foldersAdded}d built, ` +

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -152,6 +152,14 @@ export interface PluginSettings {
    */
   daemonBinarySha?: string;
   /**
+   * Load the remote tree ONE folder level at a time (deepen on File-Explorer
+   * expand) instead of walking + materialising the whole tree at connect.
+   * Default true — essential for large, deep, dir-heavy vaults where the eager
+   * build freezes the window. Set false to restore the full eager walk (fine
+   * for small vaults; makes search/graph see the whole tree immediately).
+   */
+  lazyFolderLoad?: boolean;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/src/vault/BulkWalker.ts
+++ b/plugin/src/vault/BulkWalker.ts
@@ -111,11 +111,17 @@ export class BulkWalker {
    */
   private static readonly MAX_PAGES = 1_000;
 
-  async walk(rootPath: string = ''): Promise<BulkWalkResult> {
+  /**
+   * Walk `rootPath`. With `recursive` true (default) the whole subtree is
+   * returned; with `recursive` false only `rootPath`'s IMMEDIATE children are
+   * returned — the primitive the lazy per-folder loader uses to deepen one
+   * level on demand instead of pulling a huge deep tree at connect.
+   */
+  async walk(rootPath: string = '', recursive: boolean = true): Promise<BulkWalkResult> {
     const start = Date.now();
     if (this.canUseFastPath()) {
       try {
-        const result = await this.fastPath(rootPath);
+        const result = await this.fastPath(rootPath, recursive);
         return {
           ...result,
           walkMs: Date.now() - start,
@@ -127,7 +133,7 @@ export class BulkWalker {
       } catch (e) {
         const message = errorMessage(e);
         logger.warn(`BulkWalker: fs.walk failed (${message}); falling back to per-folder list`);
-        const fallback = await this.fallbackPath(rootPath);
+        const fallback = await this.fallbackPath(rootPath, recursive);
         return {
           ...fallback,
           walkMs: Date.now() - start,
@@ -136,7 +142,7 @@ export class BulkWalker {
       }
     }
 
-    const fallback = await this.fallbackPath(rootPath);
+    const fallback = await this.fallbackPath(rootPath, recursive);
     return {
       ...fallback,
       walkMs: Date.now() - start,
@@ -152,7 +158,7 @@ export class BulkWalker {
     return conn.info.capabilities.includes(BulkWalker.FAST_PATH_CAPABILITY);
   }
 
-  private async fastPath(rootPath: string): Promise<{
+  private async fastPath(rootPath: string, recursive: boolean): Promise<{
     entries: RemoteEntry[];
     source: 'rpc-walk';
     truncated: boolean;
@@ -167,7 +173,7 @@ export class BulkWalker {
     let offset = 0;
     let pages = 0;
     for (;;) {
-      const params: WalkParams = { path: rootPath, recursive: true };
+      const params: WalkParams = { path: rootPath, recursive };
       if (this.deps.maxEntries != null) params.maxEntries = this.deps.maxEntries;
       if (offset > 0) params.offset = offset;
       if (this.deps.ignoreDirs?.length) params.ignore = this.deps.ignoreDirs;
@@ -206,7 +212,7 @@ export class BulkWalker {
     }
   }
 
-  private async fallbackPath(rootPath: string): Promise<{
+  private async fallbackPath(rootPath: string, recursive: boolean): Promise<{
     entries: RemoteEntry[];
     source: 'fallback-list';
     truncated: false;
@@ -226,7 +232,7 @@ export class BulkWalker {
       for (const sub of listing.folders) {
         if (!sub) continue;
         entries.push({ path: sub, isDirectory: true, ctime: 0, mtime: 0, size: 0 });
-        queue.push(sub);
+        if (recursive) queue.push(sub);   // one level only when non-recursive
       }
       for (const file of listing.files) {
         if (!file) continue;

--- a/plugin/src/vault/LazyFolderLoader.ts
+++ b/plugin/src/vault/LazyFolderLoader.ts
@@ -1,0 +1,81 @@
+import type { BulkWalker } from './BulkWalker';
+import type { VaultModelBuilder } from './VaultModelBuilder';
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/**
+ * Loads the remote vault tree ONE folder level at a time, on demand, instead
+ * of walking + materialising the whole (deep, dir-heavy) tree at connect.
+ *
+ * Connect does a shallow populate (root's immediate children). Every folder is
+ * materialised as an initially childless `TFolder` — Obsidian still renders an
+ * expand arrow for a childless folder (verified in a real-Obsidian spike:
+ * `nav-folder-title` gets `mod-collapsible` + a collapse-icon regardless of
+ * child count), so the user can open it. A File-Explorer folder-expand click
+ * (wired in `main.ts`, since Obsidian renders from the in-memory model and
+ * does NOT call `adapter.list` on expand) calls {@link loadFolder}, which
+ * walks just that folder and materialises its children; their own subfolders
+ * stay unloaded until expanded in turn.
+ *
+ * `walkIgnoreDirs` is honoured per level (the walker carries it), so ignore
+ * pruning and lazy depth-limiting compose. The live `fs.changed` watch keeps
+ * working against a partially-loaded tree because inserts `ensureParents`.
+ *
+ * Idempotent + deduped: re-expanding a loaded folder is a no-op, and two
+ * near-simultaneous expands of the same folder share one walk.
+ */
+export class LazyFolderLoader {
+  private readonly loaded = new Set<string>();
+  private readonly inFlight = new Map<string, Promise<void>>();
+
+  constructor(
+    /** Fresh walker per load — mirrors how the connect populate builds one. */
+    private readonly makeWalker: () => BulkWalker,
+    /** Fresh (stateless) builder per load. */
+    private readonly makeBuilder: () => VaultModelBuilder,
+  ) {}
+
+  /** Mark a path as already loaded (the root, after the connect shallow populate). */
+  markLoaded(path: string): void {
+    this.loaded.add(path);
+  }
+
+  /** Drop all lazy state (on disconnect / re-patch). */
+  reset(): void {
+    this.loaded.clear();
+    this.inFlight.clear();
+  }
+
+  isLoaded(path: string): boolean {
+    return this.loaded.has(path);
+  }
+
+  /**
+   * Materialise `folderPath`'s immediate children (one level). Resolves once
+   * they're in the vault model. No-op if the folder was already loaded; a
+   * concurrent load of the same folder shares one walk. A failed load leaves
+   * the folder unloaded so a later expand retries.
+   */
+  loadFolder(folderPath: string): Promise<void> {
+    if (this.loaded.has(folderPath)) return Promise.resolve();
+    const existing = this.inFlight.get(folderPath);
+    if (existing) return existing;
+    const p = this.doLoad(folderPath);
+    this.inFlight.set(folderPath, p);
+    return p.finally(() => this.inFlight.delete(folderPath));
+  }
+
+  private async doLoad(folderPath: string): Promise<void> {
+    try {
+      const walk = await this.makeWalker().walk(folderPath, false); // one level only
+      const result = await this.makeBuilder().buildChunked(walk.entries);
+      this.loaded.add(folderPath);
+      logger.info(
+        `LazyFolderLoader: loaded "${folderPath}" — ${result.filesAdded}f + ${result.foldersAdded}d ` +
+        `(${result.skipped} already present)`,
+      );
+    } catch (e) {
+      logger.warn(`LazyFolderLoader: load "${folderPath}" failed (${errorMessage(e)}); will retry on next expand`);
+    }
+  }
+}

--- a/plugin/tests/LazyFolderLoader.test.ts
+++ b/plugin/tests/LazyFolderLoader.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LazyFolderLoader } from '../src/vault/LazyFolderLoader';
+import type { BulkWalker } from '../src/vault/BulkWalker';
+import type { VaultModelBuilder } from '../src/vault/VaultModelBuilder';
+
+function fakeWalk(path: string) {
+  return {
+    entries: [{ path: `${path}/child.md`, isDirectory: false, ctime: 0, mtime: 0, size: 0 }],
+    source: 'rpc-walk' as const,
+    truncated: false,
+    walkMs: 1,
+    pages: 1,
+    fastPathError: null,
+  };
+}
+
+function makeBuilder(): VaultModelBuilder & { buildChunked: ReturnType<typeof vi.fn> } {
+  return {
+    buildChunked: vi.fn(async (entries: readonly unknown[]) => ({
+      filesAdded: entries.length, foldersAdded: 0, skipped: 0, errors: [],
+    })),
+  } as unknown as VaultModelBuilder & { buildChunked: ReturnType<typeof vi.fn> };
+}
+
+describe('LazyFolderLoader', () => {
+  it('loadFolder walks ONE level (recursive=false) and builds the children', async () => {
+    const walk = vi.fn(async (path: string, _recursive: boolean) => fakeWalk(path));
+    const builder = makeBuilder();
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => builder);
+
+    await loader.loadFolder('work/sub');
+
+    expect(walk).toHaveBeenCalledExactlyOnceWith('work/sub', false);
+    expect(builder.buildChunked).toHaveBeenCalledOnce();
+    expect(loader.isLoaded('work/sub')).toBe(true);
+  });
+
+  it('is idempotent — a second load of the same folder does not re-walk', async () => {
+    const walk = vi.fn(async (path: string) => fakeWalk(path));
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => makeBuilder());
+    await loader.loadFolder('a');
+    await loader.loadFolder('a');
+    expect(walk).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedupes concurrent loads of the same folder into one walk', async () => {
+    const walk = vi.fn(async (path: string) => fakeWalk(path));
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => makeBuilder());
+    await Promise.all([loader.loadFolder('b'), loader.loadFolder('b'), loader.loadFolder('b')]);
+    expect(walk).toHaveBeenCalledTimes(1);
+  });
+
+  it('markLoaded skips the walk entirely', async () => {
+    const walk = vi.fn(async (path: string) => fakeWalk(path));
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => makeBuilder());
+    loader.markLoaded('c');
+    await loader.loadFolder('c');
+    expect(walk).not.toHaveBeenCalled();
+  });
+
+  it('a failed walk leaves the folder unloaded so a later expand retries', async () => {
+    const walk = vi.fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(fakeWalk('x'));
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => makeBuilder());
+
+    await loader.loadFolder('x');
+    expect(loader.isLoaded('x')).toBe(false);   // failed → not marked loaded
+
+    await loader.loadFolder('x');               // retry succeeds
+    expect(walk).toHaveBeenCalledTimes(2);
+    expect(loader.isLoaded('x')).toBe(true);
+  });
+
+  it('reset clears loaded state', async () => {
+    const walk = vi.fn(async (path: string) => fakeWalk(path));
+    const loader = new LazyFolderLoader(() => ({ walk } as unknown as BulkWalker), () => makeBuilder());
+    await loader.loadFolder('a');
+    expect(loader.isLoaded('a')).toBe(true);
+    loader.reset();
+    expect(loader.isLoaded('a')).toBe(false);
+  });
+});


### PR DESCRIPTION
Dogfooding: even chunked (#448 / beta.15), a **deep, dir-heavy** vault (`work/Vault` — tens of thousands of directories nested deep) is too heavy to walk + materialise in full at connect. This loads the tree **one folder level at a time**.

## Spike-confirmed design
A diagnostic spike drove REAL Obsidian to settle the two runtime unknowns that code-reading couldn't:
- **U2 ✅**: a childless `TFolder` still renders an expand arrow (`nav-folder-title` gets `mod-collapsible` + a collapse-icon regardless of child count) → an **unloaded folder is openable** (no placeholder/lookahead needed).
- **U1**: expanding a folder does **not** call `adapter.list` (`listCallsAfterExpand=[]`) → File Explorer renders from the in-memory model, so deepen-on-expand is driven by a DOM **`.nav-folder-title` click hook** (the element carries the folder's `data-path`).

## What changed
- **`BulkWalker.walk(root, recursive=true)`** — `recursive:false` returns just a folder's immediate children (daemon `fs.walk` / one-level `adapter.list`), honouring `walkIgnoreDirs` per level. Default preserves the full-tree walk.
- **`LazyFolderLoader`** — idempotent, deduped per-folder deepen (walk one level → `buildChunked`). Unit-tested: recursive-false walk, idempotency, concurrent-dedup, `markLoaded`, retry-on-failure, `reset`.
- **`populateVaultFromRemote`** — with `lazyFolderLoad` (default **true**) it walks only the **root level**, wires the loader, marks root loaded, and installs a capture-phase `.nav-folder-title` click hook that deepens a folder on first expand (idempotent per folder → collapse / re-expand are no-ops). `lazyFolderLoad: false` restores the full eager walk. Loader dropped on disconnect.

## Composition & tradeoffs
- **ignore (reduce N) × lazy (limit depth)** compose — each per-level walk applies `walkIgnoreDirs`.
- The live `fs.changed` watch keeps working against a partial tree (inserts `ensureParents`).
- **Graph / search see only loaded branches** for now — accepted tradeoff (revisit later), per the agreed plan.

## Verification
- `tsc` OK · `lint` OK · `vitest run` OK (**1202** passed; +6 `LazyFolderLoader` tests). Ships **1.1.6-beta.16**.
- The spike proved the primitives (empty-folder arrow, no list-on-expand); the **integration** (shallow populate + hook actually loading children on expand) is confirmed by real-machine smoke — please smoke on the large `work` vault after merge.

## Follow-ups (noted, not in this PR)
- Settings-tab toggle for `lazyFolderLoad` (field + default exist; opt-out via data.json for now).
- Dedicated E2E asserting shallow-populate + expand-loads-children.
- Lightweight structure cache (persist the walked levels → fast reconnect) — the other agreed lever.

## After merge → BRAT beta.16
Reconnect the deep `work` vault: only the root level loads at connect (fast, no freeze); expanding a folder loads just its children. Deep subtrees stay unloaded until opened.

Not auto-merging — review + smoke by @sotashimozono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)