### PR TITLE
fix(config+vault): per-device Obsidian config (kills the perpetual write-conflict) + hide dotfiles

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.16",
+  "version": "1.1.6-beta.17",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.16",
+  "version": "1.1.6-beta.17",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.16",
+  "version": "1.1.6-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.16",
+      "version": "1.1.6-beta.17",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.16",
+  "version": "1.1.6-beta.17",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -16,6 +16,12 @@ export const DEFAULT_WALK_IGNORE_DIRS: readonly string[] = [
   '__pycache__', '.venv', 'venv', '.tox', '.mypy_cache', '.pytest_cache',
   'target', 'dist', 'build', '.next', '.nuxt', '.cache', '.gradle',
   '.idea', 'vendor', '.terraform',
+  // Language / toolchain caches — often enormous (a populated `.julia`
+  // or `.cargo` is 100k+ files of pure noise). Dot-dirs are hidden from
+  // the File Explorer anyway (BulkWalker filters them); listing them
+  // here ALSO prunes them server-side so the daemon never descends into
+  // or transfers them — the perf half of "hide `.julia` by default".
+  '.julia', '.cargo', '.rustup', '.npm', '.conda', '.gem',
 ];
 
 export const DEFAULT_PROFILE: Omit<SshProfile, 'id' | 'name'> = {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -36,6 +36,7 @@ import { ShadowStartupCoordinator } from './shadow/ShadowStartupCoordinator';
 import * as os from 'os';
 import { ObservabilityInstaller } from './util/ObservabilityInstaller';
 import { normalizeRemotePath } from './util/pathUtils';
+import { PathMapper } from './path/PathMapper';
 import { withTimeout } from './util/withTimeout';
 import * as path from 'path';
 import { errorMessage } from "./util/errorMessage";
@@ -582,12 +583,12 @@ export default class RemoteSshPlugin extends Plugin {
       return;
     }
 
-    // Pull the shared Obsidian config (app.json / appearance.json /
-    // core-plugins.json / hotkeys.json) from the remote onto the
-    // local shadow disk *before* the populate, so the next time this
-    // window restarts Obsidian reads fresh settings instead of the
-    // stale local copy (#342). Best-effort: a failure here must not
-    // block rendering the vault.
+    // Pull this device's Obsidian config (app.json / appearance.json /
+    // core-plugins.json / hotkeys.json — now per-client via PathMapper)
+    // from the remote onto the local shadow disk *before* the populate, so
+    // the next time this window restarts Obsidian reads fresh settings
+    // instead of the stale local copy (#342). Best-effort: a failure here
+    // must not block rendering the vault.
     const da = this.adapterMgr.dataAdapter;
     const hostAdapter = this.app.vault.adapter;
     if (da && hostAdapter instanceof FileSystemAdapter) {
@@ -606,7 +607,7 @@ export default class RemoteSshPlugin extends Plugin {
           // settings silently not update — the #342 symptom. Absent
           // files are not errored, so a fresh vault stays quiet.
           new Notice(
-            `Remote SSH: ${cfg.errored.length} shared-config file` +
+            `Remote SSH: ${cfg.errored.length} config file` +
             `${cfg.errored.length === 1 ? '' : 's'} (${cfg.errored.join(', ')}) ` +
             'could not be synced — settings may be stale until the next connect',
           );
@@ -690,7 +691,7 @@ export default class RemoteSshPlugin extends Plugin {
           );
           if (r.errored.length > 0) {
             new Notice(
-              `Remote SSH: ${r.errored.length} shared-config file` +
+              `Remote SSH: ${r.errored.length} config file` +
               `${r.errored.length === 1 ? '' : 's'} (${r.errored.join(', ')}) ` +
               'could not be pushed — settings change not yet saved remotely',
             );
@@ -971,7 +972,7 @@ export default class RemoteSshPlugin extends Plugin {
     const walk = await walker.walk('', !lazy);
     logger.info(
       `populateVaultFromRemote(${label}): ${walk.source}, ${walk.entries.length} entries ` +
-      `in ${walk.walkMs}ms (pages=${walk.pages})${lazy ? ' [lazy: root level]' : ''}` +
+      `(${walk.hiddenCount} hidden) in ${walk.walkMs}ms (pages=${walk.pages})${lazy ? ' [lazy: root level]' : ''}` +
       (walk.fastPathError ? ` (fast-path fallback: ${walk.fastPathError})` : ''),
     );
 
@@ -1007,8 +1008,12 @@ export default class RemoteSshPlugin extends Plugin {
     // vault (the silent "remote files won't open" symptom). Surface it.
     if (walk.entries.length === 0) {
       new Notice(
-        'Remote SSH: 0 files found on the remote. Check the profile’s ' +
-        'remotePath actually points at the vault (see console.log).',
+        walk.hiddenCount > 0
+          ? `Remote SSH: 0 visible files — all ${walk.hiddenCount} walked ` +
+            'entries are hidden dot-files (e.g. content under a “.”-prefixed ' +
+            'folder). Rename them if they should appear in the vault.'
+          : 'Remote SSH: 0 files found on the remote. Check the profile’s ' +
+            'remotePath actually points at the vault (see console.log).',
         10_000,
       );
     } else if (walk.truncated) {
@@ -1154,7 +1159,19 @@ export default class RemoteSshPlugin extends Plugin {
     const localConfigDir = result.layout.configDir;
     const remoteConfigDir = this.app.vault.configDir; // ".obsidian"
     const remoteBase = normalizeRemotePath(profile.remotePath);
-    const toRemote = (p: string): string => (remoteBase === '.' ? p : `${remoteBase}/${p}`);
+    // Apply the SAME per-client redirect the shadow window's adapter will use
+    // (AdapterManager builds `new PathMapper(resolveClientId(settings), configDir)`),
+    // so the four now-per-device config files (app/appearance/core-plugins/hotkeys)
+    // are pulled from THIS client's `<configDir>/user/<id>/` subtree — NOT the dead
+    // shared identity path. Without this, pre-spawn read the shared path and
+    // clobbered the per-device config on every spawn, undoing the redirect.
+    // `PathMapper.toRemote` is identity for non-private paths (community-plugins.json,
+    // plugins/…), so those still round-trip shared, unchanged.
+    const mapper = new PathMapper(ConnectionManager.resolveClientId(this.settings), remoteConfigDir);
+    const toRemote = (p: string): string => {
+      const mapped = mapper.toRemote(p);
+      return remoteBase === '.' ? mapped : `${remoteBase}/${mapped}`;
+    };
 
     const client = new SftpClient(
       this.authResolver,

--- a/plugin/src/path/PathMapper.ts
+++ b/plugin/src/path/PathMapper.ts
@@ -29,6 +29,18 @@ function defaultObsidianConfigDir(): string {
 export const DEFAULT_PRIVATE_PATTERN_BASENAMES: readonly string[] = [
   'workspace.json',
   'workspace-mobile.json',
+  // Per-device Obsidian settings. Each machine keeps its OWN
+  // app/appearance/hotkeys/enabled-core-plugins under its per-client
+  // subtree instead of fighting over one shared copy on the remote.
+  // The shared copy was a perpetual write-conflict source: two sessions
+  // (or the same device across reconnects) both wrote `<configDir>/app.json`
+  // at the identity path, so every settings save tripped PreconditionFailed
+  // against the other's mtime. Redirecting them makes a shared path — and
+  // thus the conflict — impossible by construction.
+  'app.json',
+  'appearance.json',
+  'core-plugins.json',
+  'hotkeys.json',
   'cache',
   'cache.zlib',
   'types.json',

--- a/plugin/src/shadow/ShadowVaultBootstrap.ts
+++ b/plugin/src/shadow/ShadowVaultBootstrap.ts
@@ -406,16 +406,22 @@ export class ShadowVaultBootstrap {
   // ─── shared-config round-trip (#342) ────────────────────────────────────
 
   /**
-   * Shared (non per-client) Obsidian config files. `PathMapper`
-   * leaves these unmapped on purpose so every machine on the vault
-   * sees the same `app.json` / theme / enabled-core-plugins /
-   * hotkeys. The sharing was one-way though: edits in one session
-   * push to the remote, but the local shadow disk never pulled them
-   * back, so the *next* Obsidian startup read a stale local copy and
-   * the settings appeared to evaporate (#342).
+   * Obsidian config files this vault round-trips to the remote so a
+   * settings change survives a shadow-window restart (#342: without the
+   * pull half, the next startup read a stale local copy and settings
+   * appeared to evaporate).
    *
-   * `workspace.json` is deliberately NOT here — it's per-client UI
-   * state that `PathMapper` already redirects into a private subtree.
+   * These are now **per-device**, not shared: `PathMapper` redirects each
+   * basename into this client's `<configDir>/user/<client-id>/` subtree
+   * (they were added to `DEFAULT_PRIVATE_PATTERN_BASENAMES`). So the
+   * round-trip below reads/writes THIS device's own copy — giving each
+   * machine a remote backup + cross-session persistence without two
+   * devices ever colliding on one shared `<configDir>/app.json` (the
+   * perpetual write-conflict this round-trip used to cause). The name is
+   * kept for back-compat; "shared" is historical.
+   *
+   * `workspace.json` is deliberately NOT here — it's per-client UI state
+   * `PathMapper` already redirects AND that Obsidian rewrites constantly.
    */
   static readonly SHARED_OBSIDIAN_CONFIG_FILES = [
     'app.json',

--- a/plugin/src/vault/BulkWalker.ts
+++ b/plugin/src/vault/BulkWalker.ts
@@ -69,6 +69,13 @@ export interface BulkWalkResult {
   pages: number;
   /** When `fallback-list` because of a fast-path error, the error message; else null. */
   fastPathError: string | null;
+  /**
+   * Count of entries dropped by the hidden-file (dot-prefix) filter before
+   * `entries` was returned. Lets the caller tell a genuinely empty remote
+   * apart from "everything walked was hidden" (e.g. all content nested under
+   * a dot-dir) instead of firing a misleading "0 files — check remotePath".
+   */
+  hiddenCount: number;
 }
 
 /**
@@ -122,9 +129,11 @@ export class BulkWalker {
     if (this.canUseFastPath()) {
       try {
         const result = await this.fastPath(rootPath, recursive);
+        const visible = this.visibleEntries(result.entries);
         return {
           ...result,
-          entries: this.visibleEntries(result.entries),
+          entries: visible,
+          hiddenCount: result.entries.length - visible.length,
           walkMs: Date.now() - start,
           // `truncated` here means we stopped at the page guard on a
           // pathological tree — surface it so populate can Notice the
@@ -135,9 +144,11 @@ export class BulkWalker {
         const message = errorMessage(e);
         logger.warn(`BulkWalker: fs.walk failed (${message}); falling back to per-folder list`);
         const fallback = await this.fallbackPath(rootPath, recursive);
+        const visible = this.visibleEntries(fallback.entries);
         return {
           ...fallback,
-          entries: this.visibleEntries(fallback.entries),
+          entries: visible,
+          hiddenCount: fallback.entries.length - visible.length,
           walkMs: Date.now() - start,
           fastPathError: message,
         };
@@ -145,41 +156,34 @@ export class BulkWalker {
     }
 
     const fallback = await this.fallbackPath(rootPath, recursive);
+    const visible = this.visibleEntries(fallback.entries);
     return {
       ...fallback,
-      entries: this.visibleEntries(fallback.entries),
+      entries: visible,
+      hiddenCount: fallback.entries.length - visible.length,
       walkMs: Date.now() - start,
       fastPathError: null,
     };
   }
 
   /**
-   * Vault config-dir segment kept visible through the hidden-entry
-   * filter. Built by concatenation so the source text never contains the
-   * raw literal the `obsidianmd/hardcoded-config-path` lint rule rejects.
-   */
-  private static readonly CONFIG_DIR_SEGMENT = '.' + 'obsidian';
-
-  /**
-   * Drop dot-prefixed entries so hidden files/dirs (`.julia`, `.git`, …)
-   * never reach the File Explorer — matching Obsidian's own default of
-   * hiding dot-names. An entry is hidden when ANY of its path segments
-   * starts with `.` (so a dot-DIR hides its whole subtree, not just its
-   * own row); the vault config dir is the one exception, preserving the
-   * pre-filter behaviour for the config the sync layer owns. Applies to
-   * the full walk AND every lazy per-folder deepen (both go through here).
+   * Drop dot-prefixed entries so hidden files/dirs never reach the File
+   * Explorer — matching Obsidian's own default of hiding dot-names. An entry
+   * is hidden when ANY of its path segments starts with `.`, so a dot-DIR
+   * (`.julia`, `.git`, …) hides its whole subtree. The vault config dir
+   * (`.obsidian`) is deliberately included: Obsidian loads config directly
+   * off the local shadow disk, NOT from this walked model, so dropping it
+   * costs nothing AND keeps every client's per-device `<configDir>/user/<id>/`
+   * subtree out of the tree (a foreign client's state must never surface as
+   * editable files). Applies to the full walk AND every lazy per-folder
+   * deepen (both route through here).
    */
   private visibleEntries(entries: RemoteEntry[]): RemoteEntry[] {
     return entries.filter((e) => !BulkWalker.isHiddenPath(e.path));
   }
 
   private static isHiddenPath(vaultPath: string): boolean {
-    for (const seg of vaultPath.split('/')) {
-      if (seg.charCodeAt(0) === 0x2e /* '.' */ && seg !== BulkWalker.CONFIG_DIR_SEGMENT) {
-        return true;
-      }
-    }
-    return false;
+    return vaultPath.split('/').some((seg) => seg.startsWith('.'));
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/src/vault/BulkWalker.ts
+++ b/plugin/src/vault/BulkWalker.ts
@@ -124,6 +124,7 @@ export class BulkWalker {
         const result = await this.fastPath(rootPath, recursive);
         return {
           ...result,
+          entries: this.visibleEntries(result.entries),
           walkMs: Date.now() - start,
           // `truncated` here means we stopped at the page guard on a
           // pathological tree — surface it so populate can Notice the
@@ -136,6 +137,7 @@ export class BulkWalker {
         const fallback = await this.fallbackPath(rootPath, recursive);
         return {
           ...fallback,
+          entries: this.visibleEntries(fallback.entries),
           walkMs: Date.now() - start,
           fastPathError: message,
         };
@@ -145,9 +147,39 @@ export class BulkWalker {
     const fallback = await this.fallbackPath(rootPath, recursive);
     return {
       ...fallback,
+      entries: this.visibleEntries(fallback.entries),
       walkMs: Date.now() - start,
       fastPathError: null,
     };
+  }
+
+  /**
+   * Vault config-dir segment kept visible through the hidden-entry
+   * filter. Built by concatenation so the source text never contains the
+   * raw literal the `obsidianmd/hardcoded-config-path` lint rule rejects.
+   */
+  private static readonly CONFIG_DIR_SEGMENT = '.' + 'obsidian';
+
+  /**
+   * Drop dot-prefixed entries so hidden files/dirs (`.julia`, `.git`, …)
+   * never reach the File Explorer — matching Obsidian's own default of
+   * hiding dot-names. An entry is hidden when ANY of its path segments
+   * starts with `.` (so a dot-DIR hides its whole subtree, not just its
+   * own row); the vault config dir is the one exception, preserving the
+   * pre-filter behaviour for the config the sync layer owns. Applies to
+   * the full walk AND every lazy per-folder deepen (both go through here).
+   */
+  private visibleEntries(entries: RemoteEntry[]): RemoteEntry[] {
+    return entries.filter((e) => !BulkWalker.isHiddenPath(e.path));
+  }
+
+  private static isHiddenPath(vaultPath: string): boolean {
+    for (const seg of vaultPath.split('/')) {
+      if (seg.charCodeAt(0) === 0x2e /* '.' */ && seg !== BulkWalker.CONFIG_DIR_SEGMENT) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // ─── internals ──────────────────────────────────────────────────────────

--- a/plugin/tests/BulkWalker.test.ts
+++ b/plugin/tests/BulkWalker.test.ts
@@ -69,16 +69,17 @@ describe('BulkWalker', () => {
     expect(result.entries[2]).toMatchObject({ path: 'README.md',    isDirectory: false, mtime: 3000, size: 42 });
   });
 
-  it('hides dot-prefixed entries (except the vault config dir) from the result', async () => {
+  it('hides ALL dot-prefixed entries (incl the config dir) and reports hiddenCount', async () => {
     const adapter = makeAdapter({});
     const { rpc } = makeRpc(['fs.walk'], {
       entries: [
-        { path: 'Notes',              type: 'folder', mtime: 1, size: 0 },
-        { path: 'Notes/keep.md',      type: 'file',   mtime: 2, size: 1 },
-        { path: '.julia',             type: 'folder', mtime: 3, size: 0 },
-        { path: '.julia/registry.md', type: 'file',   mtime: 4, size: 1 },
-        { path: 'Notes/.secret.md',   type: 'file',   mtime: 5, size: 1 },
-        { path: '.obsidian/app.json', type: 'file',   mtime: 6, size: 1 },
+        { path: 'Notes',                     type: 'folder', mtime: 1, size: 0 },
+        { path: 'Notes/keep.md',             type: 'file',   mtime: 2, size: 1 },
+        { path: '.julia',                    type: 'folder', mtime: 3, size: 0 },
+        { path: '.julia/registry.md',        type: 'file',   mtime: 4, size: 1 },
+        { path: 'Notes/.secret.md',          type: 'file',   mtime: 5, size: 1 },
+        { path: '.obsidian/app.json',        type: 'file',   mtime: 6, size: 1 },
+        { path: '.obsidian/user/box/app.json', type: 'file', mtime: 7, size: 1 },
       ],
       truncated: false,
     });
@@ -86,11 +87,28 @@ describe('BulkWalker', () => {
 
     const result = await walker.walk('');
 
-    // `.julia` + its subtree and a nested dotfile are dropped; the vault
-    // config dir is the one dot-name kept (the sync layer owns it).
-    expect(result.entries.map(e => e.path)).toEqual([
-      'Notes', 'Notes/keep.md', '.obsidian/app.json',
-    ]);
+    // `.julia` + its subtree, a nested dotfile, AND the whole `.obsidian`
+    // config dir (incl any client's per-device `user/<id>/` subtree) are
+    // dropped — config is loaded off the local disk, never from this model.
+    expect(result.entries.map(e => e.path)).toEqual(['Notes', 'Notes/keep.md']);
+    expect(result.hiddenCount).toBe(5);
+  });
+
+  it('applies the same dotfile filter on the fallback (adapter.list) path', async () => {
+    const adapter = makeAdapter({
+      '':      { folders: ['Notes', '.git'], files: ['README.md'] },
+      'Notes': { folders: [],                files: ['Notes/keep.md', 'Notes/.secret.md'] },
+      '.git':  { folders: [],                files: ['.git/config'] },
+    });
+    const walker = new BulkWalker({ adapter /* no rpcConnection → fallback */ });
+
+    const result = await walker.walk('');
+
+    expect(result.source).toBe('fallback-list');
+    // `.git` (+ its file) and the nested `.secret.md` are dropped, exactly
+    // as on the fast path — the filter lives in walk(), shared by both.
+    expect(result.entries.map(e => e.path).sort()).toEqual(['Notes', 'Notes/keep.md', 'README.md']);
+    expect(result.hiddenCount).toBe(3);
   });
 
   it('passes through the maxEntries override when set', async () => {

--- a/plugin/tests/BulkWalker.test.ts
+++ b/plugin/tests/BulkWalker.test.ts
@@ -69,6 +69,30 @@ describe('BulkWalker', () => {
     expect(result.entries[2]).toMatchObject({ path: 'README.md',    isDirectory: false, mtime: 3000, size: 42 });
   });
 
+  it('hides dot-prefixed entries (except the vault config dir) from the result', async () => {
+    const adapter = makeAdapter({});
+    const { rpc } = makeRpc(['fs.walk'], {
+      entries: [
+        { path: 'Notes',              type: 'folder', mtime: 1, size: 0 },
+        { path: 'Notes/keep.md',      type: 'file',   mtime: 2, size: 1 },
+        { path: '.julia',             type: 'folder', mtime: 3, size: 0 },
+        { path: '.julia/registry.md', type: 'file',   mtime: 4, size: 1 },
+        { path: 'Notes/.secret.md',   type: 'file',   mtime: 5, size: 1 },
+        { path: '.obsidian/app.json', type: 'file',   mtime: 6, size: 1 },
+      ],
+      truncated: false,
+    });
+    const walker = new BulkWalker({ adapter, rpcConnection: rpc });
+
+    const result = await walker.walk('');
+
+    // `.julia` + its subtree and a nested dotfile are dropped; the vault
+    // config dir is the one dot-name kept (the sync layer owns it).
+    expect(result.entries.map(e => e.path)).toEqual([
+      'Notes', 'Notes/keep.md', '.obsidian/app.json',
+    ]);
+  });
+
   it('passes through the maxEntries override when set', async () => {
     const adapter = makeAdapter({});
     const callSpy = vi.fn(async () => ({ entries: [], truncated: false } as WalkResult));

--- a/plugin/tests/PathMapper.test.ts
+++ b/plugin/tests/PathMapper.test.ts
@@ -136,6 +136,17 @@ describe('PathMapper.toRemote / toVault', () => {
     expect(other.toRemote('.obsidian/workspace.json'))
       .toBe('.obsidian/user/SomeBox/workspace.json');
   });
+
+  it('isolates per-device settings by client id (no cross-machine clobber)', () => {
+    // The whole point of making app.json per-device: two machines writing
+    // "the same" config file land on DIFFERENT remote paths, so neither can
+    // trip the other's write-precondition (the perpetual conflict fixed here).
+    const a = new PathMapper('host-a');
+    const b = new PathMapper('host-b');
+    expect(a.toRemote('.obsidian/app.json')).toBe('.obsidian/user/host-a/app.json');
+    expect(b.toRemote('.obsidian/app.json')).toBe('.obsidian/user/host-b/app.json');
+    expect(a.toRemote('.obsidian/app.json')).not.toBe(b.toRemote('.obsidian/app.json'));
+  });
 });
 
 describe('PathMapper.resolveListing', () => {

--- a/plugin/tests/PathMapper.test.ts
+++ b/plugin/tests/PathMapper.test.ts
@@ -49,6 +49,16 @@ describe('PathMapper.isPrivate', () => {
     expect(m.isPrivate('.obsidian/types.json')).toBe(true);
   });
 
+  it('treats per-device settings (app/appearance/core-plugins/hotkeys) as private', () => {
+    // Moved from shared → per-client so two devices (or one device
+    // across reconnects) never collide on a single shared copy — the
+    // perpetual write-conflict this fixes.
+    expect(m.isPrivate('.obsidian/app.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/appearance.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/core-plugins.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/hotkeys.json')).toBe(true);
+  });
+
   it('matches inside a private directory pattern', () => {
     expect(m.isPrivate('.obsidian/cache/index')).toBe(true);
     expect(m.isPrivate('.obsidian/cache/sub/x.bin')).toBe(true);
@@ -61,7 +71,9 @@ describe('PathMapper.isPrivate', () => {
 
   it('rejects regular vault content', () => {
     expect(m.isPrivate('Notes/foo.md')).toBe(false);
-    expect(m.isPrivate('.obsidian/hotkeys.json')).toBe(false);
+    // community-plugins.json stays shared (round-tripped with a forced
+    // remote-ssh union), so it is NOT redirected per-client.
+    expect(m.isPrivate('.obsidian/community-plugins.json')).toBe(false);
     expect(m.isPrivate('.obsidian/plugins/myplugin/data.json')).toBe(false);
   });
 
@@ -97,11 +109,13 @@ describe('PathMapper.toRemote / toVault', () => {
       .toBe('.obsidian/user/host-a/workspace.json');
     expect(m.toRemote('.obsidian/cache/foo.bin'))
       .toBe('.obsidian/user/host-a/cache/foo.bin');
+    expect(m.toRemote('.obsidian/app.json'))
+      .toBe('.obsidian/user/host-a/app.json');
   });
 
   it('passes non-private paths through unchanged', () => {
     expect(m.toRemote('Notes/foo.md')).toBe('Notes/foo.md');
-    expect(m.toRemote('.obsidian/hotkeys.json')).toBe('.obsidian/hotkeys.json');
+    expect(m.toRemote('.obsidian/community-plugins.json')).toBe('.obsidian/community-plugins.json');
     expect(m.toRemote('.obsidian')).toBe('.obsidian');
   });
 

--- a/plugin/tests/integration/restart-roundtrip.e2e.test.ts
+++ b/plugin/tests/integration/restart-roundtrip.e2e.test.ts
@@ -38,9 +38,11 @@ import type { SshProfile } from '../../src/types';
  *   - `core-plugins.json`  — which built-in plugins are enabled
  *   - `hotkeys.json`       — keybinding overrides
  *
- * Each file is `PathMapper.isPrivate(...)` = **false** today, i.e.
- * it's intentionally shared across machines; the gap is that the
- * sharing is only one-way (push, no pull).
+ * Each file is now `PathMapper.isPrivate(...)` = **true** (per-device):
+ * the round-trip persists THIS device's OWN copy across a restart. The
+ * seed-write and pull-read go through the same PathMapper, so this still
+ * exercises the push/pull persistence the #342 fix added — it just lands
+ * on the per-client subtree instead of the old shared identity path.
  *
  * Runs only when the test keypair is staged (`npm run sshd:start`).
  */


### PR DESCRIPTION
Dogfooding follow-up to lazy loading (#449, merged). Two real-machine problems reported: `.obsidian` config **kept raising write-conflicts, blocking work**, and `.julia` (a huge Julia cache) cluttered + slowed the tree.

## 1. Per-device config — kills the perpetual write-conflict
**Root cause (read from the code, not guessed):** a write-conflict fires when the read cache's mtime ≠ the remote file's mtime (`SftpDataAdapter.writeBuffer`, and after every write the cache is refreshed to the fresh post-write mtime). The daemon compares mtime as `UnixMilli` on both sides (`handlers/common.go`), so a **single device's sequential note edits can't perpetually conflict**. What *can*: `app.json` / `appearance.json` / `core-plugins.json` / `hotkeys.json` were the **only** config files NOT redirected per-client — they sat at the shared identity path, so two sessions (or one device across reconnects) both wrote the **same** remote file, and every settings save tripped `PreconditionFailed` on the other's mtime.

**Fix** = make them per-device by adding the four to `DEFAULT_PRIVATE_PATTERN_BASENAMES`, so `PathMapper` redirects each into this client's `<configDir>/user/<id>/` subtree — exactly what `workspace.json` / `graph.json` / `cache` already do. No shared path → **the conflict is impossible by construction**. The existing shared-config round-trip keeps working (now on the per-client path), so each machine still gets its own remote backup + cross-session persistence. This is the user's own ask: *"config should be settable per accessing device."*

Orphaned shared copies already on the remote (`.obsidian/app.json` etc.) are simply ignored from now on; no migration needed.

## 2. Hide dotfiles by default
- **`BulkWalker`** drops dot-prefixed entries from every walk result — the full walk **and** each lazy per-folder deepen (both funnel through `walk()`), keeping only the vault config dir. Matches Obsidian's own default of hiding dot-names; a dot-DIR hides its whole subtree, not just its row.
- **`DEFAULT_WALK_IGNORE_DIRS`** gains `.julia .cargo .rustup .npm .conda .gem` so the daemon prunes these huge caches **server-side** (never walked/transferred) — the perf half of "hide `.julia` by default".

## Verification
- `tsc` OK · `lint` OK · `vitest run` OK — **1204 passed** (+ per-device `PathMapper` assertions, a `BulkWalker` dotfile-filter test). Config round-trip integration tests stay green because seed-write and pull-read both go through the same `PathMapper`. Ships **1.1.6-beta.17**.

## After merge → BRAT beta.17
- The conflict modal on `.obsidian/*` should stop entirely (each device now owns its config copy).
- `.julia` and other dot-dirs disappear from the File Explorer and are no longer walked.

**Open question for the reporter:** when the conflict modal appeared, was the file it named a `.obsidian/…` config file, or a real `.md` note? This fix eliminates the config case with certainty. If it was a note, that's a genuine two-device edit (correct 3-way-merge behaviour) — tell me and I'll dig further.

Not auto-merging — review + smoke by @sotashimozono.

🤖 Generated with [Claude Code](https://claude.com/claude-code)