### PR TITLE
test(shadow): pin #450 per-device config pre-spawn path redirect

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.17",
+  "version": "1.1.6-beta.18",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.6-beta.17",
+  "version": "1.1.6-beta.18",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.17",
+  "version": "1.1.6-beta.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.6-beta.17",
+      "version": "1.1.6-beta.18",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.6-beta.17",
+  "version": "1.1.6-beta.18",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -37,6 +37,7 @@ import * as os from 'os';
 import { ObservabilityInstaller } from './util/ObservabilityInstaller';
 import { normalizeRemotePath } from './util/pathUtils';
 import { PathMapper } from './path/PathMapper';
+import { preSpawnRemotePath } from './shadow/preSpawnPaths';
 import { withTimeout } from './util/withTimeout';
 import * as path from 'path';
 import { errorMessage } from "./util/errorMessage";
@@ -1168,10 +1169,7 @@ export default class RemoteSshPlugin extends Plugin {
     // `PathMapper.toRemote` is identity for non-private paths (community-plugins.json,
     // plugins/…), so those still round-trip shared, unchanged.
     const mapper = new PathMapper(ConnectionManager.resolveClientId(this.settings), remoteConfigDir);
-    const toRemote = (p: string): string => {
-      const mapped = mapper.toRemote(p);
-      return remoteBase === '.' ? mapped : `${remoteBase}/${mapped}`;
-    };
+    const toRemote = (p: string): string => preSpawnRemotePath(mapper, remoteBase, p);
 
     const client = new SftpClient(
       this.authResolver,

--- a/plugin/src/shadow/preSpawnPaths.ts
+++ b/plugin/src/shadow/preSpawnPaths.ts
@@ -1,0 +1,26 @@
+import type { PathMapper } from '../path/PathMapper';
+
+/**
+ * Resolve a vault-relative `.obsidian/…` path to the absolute remote path
+ * the pre-spawn config pull must read, applying the SAME per-client
+ * redirect the shadow window's adapter uses.
+ *
+ * Load-bearing: the four per-device config files (`app.json`,
+ * `appearance.json`, `core-plugins.json`, `hotkeys.json`) must resolve to
+ * `<configDir>/user/<clientId>/…`, NOT the dead shared identity path — the
+ * pre-spawn pull previously joined the bare remote base and read the shared
+ * path, clobbering the redirected per-device config on every spawn (#450
+ * CRITICAL). `PathMapper.toRemote` is identity for non-private paths, so
+ * `community-plugins.json` / `plugins/*` stay shared, unchanged.
+ *
+ * Extracted as a pure function so this redirect is unit-testable without
+ * standing up `preSpawnPull`'s standalone `SftpClient`.
+ */
+export function preSpawnRemotePath(
+  mapper: PathMapper,
+  remoteBase: string,
+  vaultRelPath: string,
+): string {
+  const mapped = mapper.toRemote(vaultRelPath);
+  return remoteBase === '.' ? mapped : `${remoteBase}/${mapped}`;
+}

--- a/plugin/tests/preSpawnRemotePath.test.ts
+++ b/plugin/tests/preSpawnRemotePath.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { PathMapper } from '../src/path/PathMapper';
+import { preSpawnRemotePath } from '../src/shadow/preSpawnPaths';
+
+/**
+ * Pins the #450 CRITICAL fix: the pre-spawn config pull must resolve the
+ * four per-device config files to THIS client's `user/<id>/` subtree, not
+ * the dead shared identity path (reading which clobbered per-device config
+ * on every shadow-window spawn). A regression that dropped the
+ * `PathMapper.toRemote` redirect (bare base-join) would flip the config
+ * assertions below to the shared path and fail here.
+ */
+describe('preSpawnRemotePath', () => {
+  const mapper = new PathMapper('host-a', '.obsidian');
+  const base = '/home/u/vault';
+
+  it('redirects the four per-device config files to the per-client subtree', () => {
+    for (const f of ['app.json', 'appearance.json', 'core-plugins.json', 'hotkeys.json']) {
+      expect(preSpawnRemotePath(mapper, base, `.obsidian/${f}`))
+        .toBe(`${base}/.obsidian/user/host-a/${f}`);
+    }
+  });
+
+  it('leaves shared files (community-plugins.json, plugin binaries) at the identity path', () => {
+    expect(preSpawnRemotePath(mapper, base, '.obsidian/community-plugins.json'))
+      .toBe(`${base}/.obsidian/community-plugins.json`);
+    expect(preSpawnRemotePath(mapper, base, '.obsidian/plugins/dataview/main.js'))
+      .toBe(`${base}/.obsidian/plugins/dataview/main.js`);
+  });
+
+  it('joins onto a "." remote base (vault root) without a leading slash', () => {
+    expect(preSpawnRemotePath(mapper, '.', '.obsidian/app.json'))
+      .toBe('.obsidian/user/host-a/app.json');
+  });
+
+  it('isolates clients — two client ids never resolve to the same config path', () => {
+    const a = new PathMapper('host-a', '.obsidian');
+    const b = new PathMapper('host-b', '.obsidian');
+    expect(preSpawnRemotePath(a, base, '.obsidian/app.json'))
+      .not.toBe(preSpawnRemotePath(b, base, '.obsidian/app.json'));
+  });
+});


### PR DESCRIPTION
## Why

The 6-agent review of the 1.1.6 release (#436) found every area GO with one
coverage gap: the **#450 CRITICAL fix** — `preSpawnPull` applying
`PathMapper.toRemote` so the pre-spawn config pull reads this client's
`user/<id>/` subtree instead of the dead shared identity path — had **no test**.
A regression that dropped the redirect (bare base-join) would silently clobber
per-device config on every shadow-window spawn again, with nothing to catch it.

## What

- Extract `preSpawnPull`'s inline remote-path closure into a pure
  `preSpawnRemotePath(mapper, remoteBase, vaultRelPath)` in
  `src/shadow/preSpawnPaths.ts` (`PathMapper.toRemote` → remote-base join),
  unit-testable without standing up `preSpawnPull`'s standalone `SftpClient`.
- `main.ts` now calls the extracted function — **behavior-preserving refactor**.
- 4 tests (`tests/preSpawnRemotePath.test.ts`) hit the real `PathMapper`:
  - per-client redirect for the four per-device files (`app` / `appearance` /
    `core-plugins` / `hotkeys`) → `<base>/.obsidian/user/<id>/…`
  - identity for shared files (`community-plugins.json`, plugin binaries)
  - `"."` remote base (vault root) joins without a leading slash
  - cross-client isolation — two client ids never resolve to the same config path

## Verification

`tsc` clean · `eslint` clean · `vitest` 1210 passed / 1 skipped / 2 todo
(incl. the 4 new tests).