### PR TITLE
fix(config): persist third-party plugin settings across restarts (#342, #429)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.7-beta.0",
+  "version": "1.1.7-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.7-beta.0",
+  "version": "1.1.7-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.7-beta.0",
+  "version": "1.1.7-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.7-beta.0",
+      "version": "1.1.7-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
@@ -271,6 +271,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -319,31 +320,9 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1192,8 +1171,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1346,9 +1324,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1366,9 +1341,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,9 +1358,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1406,9 +1375,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1426,9 +1392,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1446,9 +1409,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1633,6 +1593,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1863,6 +1824,7 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -2351,6 +2313,7 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -2510,6 +2473,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2975,8 +2939,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3409,6 +3372,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3463,6 +3427,7 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3963,6 +3928,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5385,6 +5351,7 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -5708,9 +5675,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5732,9 +5696,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5756,9 +5717,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5780,9 +5738,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6348,6 +6303,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7103,8 +7059,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7425,6 +7380,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7492,6 +7448,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -7588,6 +7545,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -7666,6 +7624,7 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -7755,8 +7714,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -271,7 +271,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -320,9 +319,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1171,7 +1192,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1324,6 +1346,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1341,6 +1366,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1358,6 +1386,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1375,6 +1406,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1392,6 +1426,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1409,6 +1446,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1593,7 +1633,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1824,7 +1863,6 @@
       "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.64.0",
         "@typescript-eslint/types": "8.64.0",
@@ -2313,7 +2351,6 @@
       "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.10",
@@ -2473,7 +2510,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2939,7 +2975,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3372,7 +3409,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3427,7 +3463,6 @@
       "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3928,7 +3963,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5351,7 +5385,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -5675,6 +5708,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5696,6 +5732,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5717,6 +5756,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5738,6 +5780,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6303,7 +6348,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7059,7 +7103,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7380,7 +7425,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7448,7 +7492,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -7545,7 +7588,6 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -7624,7 +7666,6 @@
       "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.10",
         "@vitest/mocker": "4.1.10",
@@ -7714,7 +7755,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.7-beta.0",
+  "version": "1.1.7-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -21,6 +21,8 @@ function isThumbnailEligible(vaultPath: string): boolean {
   if (dot < 0) return false;
   return THUMBNAIL_EXTENSIONS.has(vaultPath.slice(dot + 1).toLowerCase());
 }
+import * as fs from 'fs';
+import * as nodePath from 'path';
 import type { RemoteFsClient } from './RemoteFsClient';
 import type { WriterReflector } from './WriterReflector';
 import type { LocalOpRegistry } from './LocalOpRegistry';
@@ -869,6 +871,50 @@ export class SftpDataAdapter {
    * than whatever the cache holds now (which is the synthetic
    * mtime from the offline cache update).
    */
+  /**
+   * Mirror a successful `<configDir>/**` write onto the LOCAL shadow disk
+   * (#342 / #429 — "plugin settings are not kept after restarting the vault").
+   *
+   * Why this is load-bearing, and why a pull-on-connect cannot replace it:
+   * Obsidian loads community plugins during startup, and each plugin's
+   * `onload()` calls `Plugin.loadData()` — which reads
+   * `<configDir>/plugins/<id>/data.json` — BEFORE remote-ssh has connected
+   * over SSH and patched the adapter. That read therefore always hits the
+   * real `FileSystemAdapter`, i.e. the local shadow disk. We cannot get in
+   * front of it: the SSH connect is async and happens at layout-ready.
+   *
+   * So the local disk must ALREADY be correct at startup. Previously nothing
+   * ever wrote it: `saveData()` went through the patched adapter straight to
+   * the remote and the local copy stayed empty, so every restart booted the
+   * plugin on DEFAULTS — which the plugin then saved back, destroying the
+   * real settings on the remote too.
+   *
+   * Write-through fixes that at the source: local disk is a warm cache of the
+   * remote, so whichever way the shadow window is launched (Connect from the
+   * source window, or reopening the vault directly) the startup read sees the
+   * settings this device last saved. The remote per-device copy stays the
+   * source of truth and the cross-session backup.
+   *
+   * Scope is deliberately `<configDir>/**` only — the vault's NOTE tree stays
+   * virtual (served from the remote, never mirrored to disk); mirroring it
+   * would defeat the whole shadow-vault design. Best-effort: a failure here
+   * must never fail the write that already landed on the remote.
+   */
+  private writeThroughConfig(normalizedPath: string, data: Buffer): void {
+    if (!this.shadowBasePath || !this.pathMapper) return;
+    const rel = normalizedPath.startsWith('/') ? normalizedPath.slice(1) : normalizedPath;
+    if (!rel.startsWith(`${this.pathMapper.configDir}/`)) return;
+    try {
+      const abs = nodePath.join(this.shadowBasePath, ...rel.split('/'));
+      fs.mkdirSync(nodePath.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, data);
+    } catch (e) {
+      // The remote write already succeeded — the session is correct either
+      // way; only the next restart's warm start is degraded.
+      logger.warn(`writeThroughConfig: "${rel}" not mirrored locally (${errorMessage(e)})`);
+    }
+  }
+
   private async writeBuffer(
     normalizedPath: string,
     data: Buffer,
@@ -899,6 +945,10 @@ export class SftpDataAdapter {
     } finally {
       this.transferTracker?.end(txId);
     }
+
+    // The remote now holds `writtenData`. Mirror it onto the local shadow
+    // disk too, so the next Obsidian start reads the real settings (#342/#429).
+    this.writeThroughConfig(normalizedPath, writtenData);
 
     let mtime = 0;
     try {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -904,9 +904,46 @@ export class SftpDataAdapter {
     if (!this.shadowBasePath || !this.pathMapper) return;
     const rel = normalizedPath.startsWith('/') ? normalizedPath.slice(1) : normalizedPath;
     if (!rel.startsWith(`${this.pathMapper.configDir}/`)) return;
+
+    // Containment must be checked on the RESOLVED path, not the raw string:
+    // the prefix test above is a plain `startsWith`, so `.obsidian/x/../../../
+    // evil` would sail past it and `join` would then resolve the `..` right
+    // out of the shadow root. `resolve` also collapses win32 backslashes,
+    // which would otherwise be a second way to smuggle a separator through.
+    // The vault path reaches us from Obsidian / other plugins — not trusted.
+    const root = nodePath.resolve(this.shadowBasePath);
+    const abs = nodePath.resolve(root, rel);
+    if (abs !== root && !abs.startsWith(root + nodePath.sep)) {
+      logger.warn(`writeThroughConfig: refusing to mirror outside the shadow root: "${rel}"`);
+      return;
+    }
+
     try {
-      const abs = nodePath.join(this.shadowBasePath, ...rel.split('/'));
-      fs.mkdirSync(nodePath.dirname(abs), { recursive: true });
+      // NEVER write through a symlink. `ShadowVaultBootstrap.installPlugin`
+      // symlinks remote-ssh's OWN main.js / manifest.json / styles.css in the
+      // shadow vault back to the SOURCE vault's real files, and
+      // `fs.writeFileSync` follows symlinks — mirroring one would overwrite
+      // the source vault's plugin install and brick it. That is exactly the
+      // bug class #455 just fixed; do not reintroduce it here.
+      //
+      // Skipping costs nothing: the remote write already succeeded, and for
+      // plugin CODE the local copy is owned by the pull/push binary
+      // round-trip (`PLUGIN_BINARY_FILES`), not by this cache.
+      if (fs.lstatSync(abs, { throwIfNoEntry: false })?.isSymbolicLink()) {
+        logger.warn(`writeThroughConfig: "${rel}" is a symlink — not mirrored (would clobber its target)`);
+        return;
+      }
+      // Same hazard one level up: a symlinked ANCESTOR (e.g. a stale
+      // whole-dir plugin symlink from an older build) would redirect the
+      // write out of the shadow root even though `abs` looked contained.
+      const dir = nodePath.dirname(abs);
+      const realDir = fs.existsSync(dir) ? fs.realpathSync(dir) : null;
+      if (realDir && realDir !== root && !realDir.startsWith(root + nodePath.sep)) {
+        logger.warn(`writeThroughConfig: "${rel}" resolves outside the shadow root via a symlinked parent — not mirrored`);
+        return;
+      }
+
+      fs.mkdirSync(dir, { recursive: true });
       fs.writeFileSync(abs, data);
     } catch (e) {
       // The remote write already succeeded — the session is correct either

--- a/plugin/src/path/PathMapper.ts
+++ b/plugin/src/path/PathMapper.ts
@@ -24,7 +24,10 @@ function defaultObsidianConfigDir(): string {
  * (corrupted layout files, conflicting graph views) are loud failures.
  *
  * Patterns are matched as either an exact configDir-relative filename
- * or a directory prefix (so `cache` covers everything inside).
+ * or a directory prefix (so `cache` covers everything inside). A `*`
+ * segment matches exactly one path segment (see `matchesPrivatePattern`),
+ * which is what lets us privatise `plugins/<id>/data.json` without
+ * dragging the plugin's *code* along with it.
  */
 export const DEFAULT_PRIVATE_PATTERN_BASENAMES: readonly string[] = [
   'workspace.json',
@@ -41,6 +44,17 @@ export const DEFAULT_PRIVATE_PATTERN_BASENAMES: readonly string[] = [
   'appearance.json',
   'core-plugins.json',
   'hotkeys.json',
+  // Third-party plugin SETTINGS (#342 / #429) — per-device for exactly the
+  // same reason as the four above. `Plugin.saveData()` fires on every
+  // settings change, so a shared `<configDir>/plugins/<id>/data.json` would
+  // reintroduce the perpetual write-conflict the redirect above just killed.
+  //
+  // Deliberately `plugins/*/data.json` and NOT `plugins`: the plugin's CODE
+  // (manifest.json / main.js / styles.css) must stay SHARED at the identity
+  // path so a plugin installed on one machine still loads on every other —
+  // that round-trip is `ShadowVaultBootstrap.PLUGIN_BINARY_FILES`. Only the
+  // settings go per-device.
+  'plugins/*/data.json',
   'cache',
   'cache.zlib',
   'types.json',
@@ -48,6 +62,32 @@ export const DEFAULT_PRIVATE_PATTERN_BASENAMES: readonly string[] = [
   'graph.json',
   'canvas.json',
 ];
+
+/**
+ * Match a configDir-rooted private pattern against a normalized
+ * vault-relative path.
+ *
+ * Semantics: exact match, or directory-prefix match (`cache` covers
+ * `cache/anything`). A `*` pattern segment matches exactly one path
+ * segment — never across `/` — so `plugins/*` + `data.json` catches
+ * `plugins/claudian/data.json` but leaves `plugins/claudian/main.js`
+ * shared.
+ */
+function matchesPrivatePattern(pattern: string, normalized: string): boolean {
+  if (!pattern.includes('*')) {
+    return normalized === pattern || normalized.startsWith(pattern + '/');
+  }
+  const pat = pattern.split('/');
+  const seg = normalized.split('/');
+  // Shorter than the pattern → neither the file itself nor inside it.
+  if (seg.length < pat.length) return false;
+  for (let i = 0; i < pat.length; i++) {
+    if (pat[i] === '*') continue; // any single segment
+    if (pat[i] !== seg[i]) return false;
+  }
+  // Equal depth = the file itself; deeper = inside it (directory-prefix).
+  return true;
+}
 
 /**
  * Back-compat re-export: the basenames joined onto the default
@@ -170,7 +210,7 @@ export class PathMapper {
   /** True when the vault-relative path should live in this client's private subtree. */
   isPrivate(vaultPath: string): boolean {
     const normalized = stripLeadingSlash(vaultPath);
-    return this.privatePatterns.some(p => normalized === p || normalized.startsWith(p + '/'));
+    return this.privatePatterns.some(p => matchesPrivatePattern(p, normalized));
   }
 
   /**
@@ -184,7 +224,12 @@ export class PathMapper {
   isCrossingPoint(vaultPath: string): boolean {
     const normalized = stripLeadingSlash(vaultPath);
     if (this.isPrivate(normalized)) return false;
-    return this.privatePatterns.some(p => parentDirOf(p) === normalized);
+    // Exact-depth match (not dir-prefix): the crossing point is the pattern's
+    // immediate parent. For `plugins/*/data.json` that is `plugins/<id>` — so
+    // listing a plugin's own dir merges in this client's private `data.json`,
+    // while listing `plugins/` itself does not (every plugin dir already
+    // exists at the shared identity path, because the CODE is shared).
+    return this.privatePatterns.some(p => matchesPatternExact(parentDirOf(p), normalized));
   }
 
   // ─── translation ─────────────────────────────────────────────────────────
@@ -245,13 +290,21 @@ export class PathMapper {
       return { primary: this.toRemote(vaultPath), mergeFromUser: false };
     }
     if (this.isCrossingPoint(normalized)) {
+      // The private subtree mirrors the configDir-relative path, so the
+      // crossing point's counterpart is `privateRoot/<same relative path>`.
+      // For the configDir itself that relative path is empty → privateRoot.
+      // For `<configDir>/plugins/<id>` it is `privateRoot/plugins/<id>`.
+      const rest = normalized.startsWith(this.configDirSlash)
+        ? normalized.slice(this.configDirSlash.length)
+        : '';
       return {
         primary: vaultPath,
         mergeFromUser: true,
-        userSubtree: this.privateRoot,
-        // Hide the user-subdir entry from the primary listing so
-        // other clients' subtrees never surface.
-        hideUserDirName: PRIVATE_USER_SUBDIR,
+        userSubtree: rest ? `${this.privateRoot}/${rest}` : this.privateRoot,
+        // Only the configDir itself has the `user` sibling to hide, so other
+        // clients' subtrees never surface. Deeper crossing points (a plugin's
+        // own dir) have no such sibling.
+        hideUserDirName: normalized === this.configDir ? PRIVATE_USER_SUBDIR : undefined,
       };
     }
     return { primary: vaultPath, mergeFromUser: false };
@@ -259,6 +312,23 @@ export class PathMapper {
 }
 
 // ─── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Segment-wise EXACT match (same depth, `*` matching any one segment).
+ * Unlike `matchesPrivatePattern` this never matches a deeper path, so it
+ * is safe for crossing-point detection where a dir-prefix match would
+ * wrongly flag every ancestor.
+ */
+function matchesPatternExact(pattern: string, normalized: string): boolean {
+  const pat = pattern.split('/');
+  const seg = normalized.split('/');
+  if (pat.length !== seg.length) return false;
+  for (let i = 0; i < pat.length; i++) {
+    if (pat[i] === '*') continue;
+    if (pat[i] !== seg[i]) return false;
+  }
+  return true;
+}
 
 function stripLeadingSlash(p: string): string {
   return p.startsWith('/') ? p.slice(1) : p;

--- a/plugin/tests/PathMapper.test.ts
+++ b/plugin/tests/PathMapper.test.ts
@@ -74,11 +74,67 @@ describe('PathMapper.isPrivate', () => {
     // community-plugins.json stays shared (round-tripped with a forced
     // remote-ssh union), so it is NOT redirected per-client.
     expect(m.isPrivate('.obsidian/community-plugins.json')).toBe(false);
-    expect(m.isPrivate('.obsidian/plugins/myplugin/data.json')).toBe(false);
   });
 
   it('tolerates a leading slash on the input', () => {
     expect(m.isPrivate('/.obsidian/workspace.json')).toBe(true);
+  });
+});
+
+// #342 / #429 — a plugin's SETTINGS go per-device: `Plugin.saveData()` fires on
+// every settings change, so a shared `plugins/<id>/data.json` is the same
+// perpetual write-conflict the four core config files were redirected to
+// escape. Its CODE must stay SHARED, or a plugin installed on one machine
+// stops loading on the others (that round-trip is PLUGIN_BINARY_FILES).
+describe('PathMapper — plugin settings vs plugin code (#342 / #429)', () => {
+  const m = new PathMapper(ID);
+
+  it('privatises a plugin data.json', () => {
+    expect(m.isPrivate('.obsidian/plugins/claudian/data.json')).toBe(true);
+    expect(m.isPrivate('.obsidian/plugins/tasknotes/data.json')).toBe(true);
+  });
+
+  it('leaves the plugin code SHARED', () => {
+    expect(m.isPrivate('.obsidian/plugins/claudian/main.js')).toBe(false);
+    expect(m.isPrivate('.obsidian/plugins/claudian/manifest.json')).toBe(false);
+    expect(m.isPrivate('.obsidian/plugins/claudian/styles.css')).toBe(false);
+  });
+
+  it('does not over-match: `*` spans exactly one segment', () => {
+    expect(m.isPrivate('.obsidian/plugins')).toBe(false);
+    expect(m.isPrivate('.obsidian/plugins/claudian')).toBe(false);
+    expect(m.isPrivate('.obsidian/plugins/a/b/data.json')).toBe(false);
+    expect(m.isPrivate('.obsidian/data.json')).toBe(false);
+    expect(m.isPrivate('Notes/data.json')).toBe(false);
+  });
+
+  it('redirects data.json per-client, keeping code at the identity path', () => {
+    expect(m.toRemote('.obsidian/plugins/claudian/data.json'))
+      .toBe('.obsidian/user/host-a/plugins/claudian/data.json');
+    expect(m.toRemote('.obsidian/plugins/claudian/main.js'))
+      .toBe('.obsidian/plugins/claudian/main.js');
+  });
+
+  it('round-trips through toVault', () => {
+    const remote = m.toRemote('.obsidian/plugins/claudian/data.json');
+    expect(m.toVault(remote)).toBe('.obsidian/plugins/claudian/data.json');
+  });
+
+  it('listing a plugin dir merges in this client private subtree', () => {
+    const plan = m.resolveListing('.obsidian/plugins/claudian');
+    expect(plan.primary).toBe('.obsidian/plugins/claudian');
+    expect(plan.mergeFromUser).toBe(true);
+    expect(plan.userSubtree).toBe('.obsidian/user/host-a/plugins/claudian');
+    // The `user` sibling only exists at the configDir level, so nothing to
+    // hide at this depth.
+    expect(plan.hideUserDirName).toBeUndefined();
+  });
+
+  it('still hides the user subdir when listing the configDir itself', () => {
+    const plan = m.resolveListing('.obsidian');
+    expect(plan.mergeFromUser).toBe(true);
+    expect(plan.userSubtree).toBe('.obsidian/user/host-a');
+    expect(plan.hideUserDirName).toBe('user');
   });
 });
 

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -1496,3 +1496,103 @@ describe('SftpDataAdapter — writer reflect (#341)', () => {
     expect(fake.files['/v/a.md']).toBeUndefined();
   });
 });
+
+// ─── config write-through (#342 / #429) ─────────────────────────────────────
+//
+// Obsidian loads community plugins at startup and each `onload()` calls
+// `Plugin.loadData()` — reading `.obsidian/plugins/<id>/data.json` off the
+// LOCAL shadow disk — BEFORE remote-ssh has connected over SSH and patched the
+// adapter. Nothing used to write that local copy (saveData() went straight to
+// the remote), so every restart booted plugins on DEFAULTS, which they then
+// saved back, destroying the real settings on the remote too.
+//
+// The adapter must therefore mirror `<configDir>/**` writes to local disk.
+describe('SftpDataAdapter — config write-through to the local shadow disk (#342/#429)', () => {
+  let readCache: ReadCache;
+  let dirCache: DirCache;
+  let shadow: string;
+
+  beforeEach(async () => {
+    readCache = new ReadCache({ maxBytes: 4096 });
+    dirCache = new DirCache({ ttlMs: 10_000 });
+    shadow = await fs.mkdtemp(path.join(os.tmpdir(), 'shadow-wt-'));
+  });
+
+  it('mirrors a plugin data.json write onto local disk, and sends it to the per-device remote path', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      shadow,
+    );
+
+    await adapter.write('.obsidian/plugins/claudian/data.json', '{"model":"x"}');
+
+    // Local: the exact path Obsidian reads at the next startup.
+    const local = path.join(shadow, '.obsidian', 'plugins', 'claudian', 'data.json');
+    expect(await fs.readFile(local, 'utf-8')).toBe('{"model":"x"}');
+
+    // Remote: redirected into THIS device's private subtree, so a second
+    // device never collides on the same file.
+    expect(fake.files['/srv/vault/.obsidian/user/host-a/plugins/claudian/data.json']).toBeDefined();
+    expect(fake.files['/srv/vault/.obsidian/plugins/claudian/data.json']).toBeUndefined();
+  });
+
+  it('mirrors the core per-device config files too', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      shadow,
+    );
+
+    await adapter.write('.obsidian/app.json', '{"promptDelete":false}');
+
+    expect(await fs.readFile(path.join(shadow, '.obsidian', 'app.json'), 'utf-8'))
+      .toBe('{"promptDelete":false}');
+  });
+
+  it('does NOT mirror ordinary vault notes — the note tree stays virtual', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      shadow,
+    );
+
+    await adapter.write('Notes/foo.md', '# hi');
+
+    // The remote got it...
+    expect(fake.files['/srv/vault/Notes/foo.md']).toBeDefined();
+    // ...but nothing was mirrored to the local shadow disk.
+    await expect(fs.stat(path.join(shadow, 'Notes', 'foo.md'))).rejects.toThrow();
+  });
+
+  it('a local mirror failure never fails the write that already landed remotely', async () => {
+    const fake = makeFakeClient();
+    // Shadow root is a FILE, so creating any directory beneath it fails.
+    const bogus = path.join(shadow, 'not-a-dir');
+    await fs.writeFile(bogus, 'x');
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      bogus,
+    );
+
+    await expect(
+      adapter.write('.obsidian/plugins/claudian/data.json', '{"a":1}'),
+    ).resolves.toBeUndefined();
+
+    // The remote write still succeeded — only the warm-start cache is degraded.
+    expect(fake.files['/srv/vault/.obsidian/user/host-a/plugins/claudian/data.json']).toBeDefined();
+  });
+
+  it('is a no-op when no shadow base path is wired (unit-test default)', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'),
+    );
+    await expect(adapter.write('.obsidian/app.json', '{}')).resolves.toBeUndefined();
+  });
+});

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -1595,4 +1595,58 @@ describe('SftpDataAdapter — config write-through to the local shadow disk (#34
     );
     await expect(adapter.write('.obsidian/app.json', '{}')).resolves.toBeUndefined();
   });
+
+  // ShadowVaultBootstrap.installPlugin symlinks remote-ssh's OWN
+  // main.js/manifest.json/styles.css in the shadow vault back to the SOURCE
+  // vault's real files. fs.writeFileSync FOLLOWS symlinks, so mirroring one
+  // would overwrite the source vault's plugin install and brick it — the exact
+  // bug class #455 fixed. The mirror must refuse.
+  it('never writes THROUGH a symlink (would clobber the source vault — #455 regression guard)', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      shadow,
+    );
+
+    // The "source vault" real file, living OUTSIDE the shadow root.
+    const sourceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'source-vault-'));
+    const sourceMain = path.join(sourceDir, 'main.js');
+    await fs.writeFile(sourceMain, 'SOURCE-REAL-FILE');
+
+    // The shadow's plugin dir symlinks main.js at that source file.
+    const shadowPluginDir = path.join(shadow, '.obsidian', 'plugins', 'remote-ssh');
+    await fs.mkdir(shadowPluginDir, { recursive: true });
+    await fs.symlink(sourceMain, path.join(shadowPluginDir, 'main.js'));
+
+    await adapter.write('.obsidian/plugins/remote-ssh/main.js', 'NEW-BUNDLE-BYTES');
+
+    // The remote still got the write...
+    expect(fake.files['/srv/vault/.obsidian/plugins/remote-ssh/main.js']).toBeDefined();
+    // ...but the SOURCE vault's real file is untouched.
+    expect(await fs.readFile(sourceMain, 'utf-8')).toBe('SOURCE-REAL-FILE');
+    // ...and the symlink is still a symlink (not replaced by a real file).
+    expect((await fs.lstat(path.join(shadowPluginDir, 'main.js'))).isSymbolicLink()).toBe(true);
+  });
+
+  // The `startsWith(configDir + '/')` guard runs on the RAW string, before
+  // `..` is resolved — so it must not be the only containment check.
+  it('refuses to mirror a traversal path that escapes the shadow root', async () => {
+    const fake = makeFakeClient();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('host-a', '.obsidian'), null, null, null, null,
+      shadow,
+    );
+
+    const victim = path.join(shadow, '..', `escaped-${path.basename(shadow)}.txt`);
+    await expect(fs.stat(victim)).rejects.toThrow(); // not there yet
+
+    // Starts with `.obsidian/` so it passes the raw prefix test, but resolves
+    // out of the shadow root.
+    await adapter.write(`.obsidian/../escaped-${path.basename(shadow)}.txt`, 'pwned');
+
+    // Nothing was written outside the shadow root.
+    await expect(fs.stat(victim)).rejects.toThrow();
+  });
 });


### PR DESCRIPTION
Fixes the "plugin settings are not kept after restarting the vault" half of #429, and #342.

## The bug

Third-party plugin settings were lost on **every** restart of the shadow vault — and the good settings on the **remote were destroyed** in the process.

## Root cause — an ordering problem a connect-time pull cannot fix

Obsidian loads community plugins during startup. Each plugin's `onload()` calls `Plugin.loadData()`, which reads `<configDir>/plugins/<id>/data.json` — **before** remote-ssh has connected over SSH and patched the adapter. That read therefore always hits the real `FileSystemAdapter`, i.e. the **local shadow disk**. We cannot get in front of it: the SSH connect is async and lands at layout-ready.

And nothing ever wrote that local copy. `saveData()` went through the patched adapter straight to the remote, so the local file stayed empty:

1. Restart → `loadData()` reads the (empty) local `data.json` → plugin boots on **DEFAULTS**
2. Plugin saves those defaults → once the adapter is patched, they're pushed to the remote
3. → **the real remote settings are overwritten** 💥

The plugin *code* survived (`main.js` / `manifest.json` / `styles.css` are round-tripped by `PLUGIN_BINARY_FILES`), which is exactly the asymmetry reported in #429: *"Now I see that Claudian plugin is still installed after restarting the vault … Claudian settings are not kept after restarting the vault."*

Note this also means `preSpawnPull` cannot be the fix: it only runs when you Connect **from the source window**. Reopening the shadow vault directly never runs it.

## The fix

**1. `SftpDataAdapter` — write-through.** A successful `<configDir>/**` write is now mirrored onto the local shadow disk with the same bytes that landed on the remote. The local disk becomes a **warm cache**, so the startup read sees the settings this device last saved, no matter how the window was launched.

- Best-effort: a mirror failure never fails the remote write that already succeeded.
- Scope is `<configDir>/**` only — the **note tree stays virtual** (served from the remote, never mirrored). Mirroring it would defeat the shadow-vault design.

**2. `PathMapper` — `plugins/*/data.json` goes per-device**, redirected into `<configDir>/user/<clientId>/`.

`saveData()` fires on *every* settings change, so a shared remote path would reintroduce the perpetual write-conflict that the four core config files were redirected to escape (b0e2773). Per-device makes a cross-device collision **impossible by construction** — two machines can never fight over one settings file.

Deliberately `plugins/*/data.json` and **not** `plugins`: the plugin's **code must stay SHARED** at the identity path, or a plugin installed on one machine would stop loading on the others. This required:
- teaching the pattern matcher a `*` segment (matches exactly one path segment, never across `/`),
- making crossing-point detection wildcard-aware, so listing a plugin's own dir merges in this client's private `data.json` (keeping `list()` consistent with `exists()`/`read()`).

## Design after this PR

| | local shadow disk | remote |
|---|---|---|
| notes | virtual (not mirrored) | source of truth |
| `<configDir>/**` | **warm cache** (write-through) | source of truth |
| plugin settings `data.json` | warm cache | **per-device** `user/<clientId>/` |
| plugin code | — | **shared** (identity path) |

## Test plan

- [x] New `PathMapper` cases: settings-private / code-shared, `*` does not over-match (`plugins/a/b/data.json`, `.obsidian/data.json`, `Notes/data.json`), per-device `toRemote`, `toVault` round-trip, listing merge at both depths.
- [x] New `SftpDataAdapter` cases: the local mirror lands, the remote gets the **per-device** path (and *not* the shared one), ordinary notes are **not** mirrored, a mirror failure does not fail the write, no-op without a shadow base path.
- [x] Full suite green — 80 files, **1223 passed**, 0 failures.
- [x] `tsc --noEmit` clean, `eslint` clean.

## Not in this PR

The other half of #429 — plugins that bypass the Vault API entirely and use Node `fs` against `adapter.basePath` (Claudian creating `.md` files in the local folder). That is a separate architectural issue, already documented as a known trade-off in `docs/en/user-guide/plugin-compatibility.md`. Tracking separately so this fix ships on its own.