### PR TITLE
test(e2e): make the suite trustworthy + actually test the restart (#342/#429)

### DIFF
--- a/.github/workflows/demo-capture.yml
+++ b/.github/workflows/demo-capture.yml
@@ -109,6 +109,11 @@ jobs:
         env:
           OBSIDIAN_PATH: ~/obsidian/squashfs-root/obsidian
           DISPLAY: ':99'
+          # demo.spec.ts is `testIgnore`d by default so the recorder never
+          # runs inside the behavioural E2E suite. This is the one place that
+          # opts it back in. Without this the walkthrough would silently match
+          # ZERO tests and the GIF would never regenerate.
+          E2E_DEMO: '1'
         run: npx playwright test --config e2e/playwright.config.ts demo.spec.ts
 
       - name: Stitch screencast frames into a GIF (two-pass palettegen)

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/playwright.config.ts
+++ b/plugin/e2e/playwright.config.ts
@@ -13,10 +13,19 @@ import { defineConfig } from '@playwright/test';
  *   OBSIDIAN_PATH  — path to the Obsidian binary / AppImage
  *   TEST_VAULT     — path to the pre-scaffolded test vault
  *   CDP_PORT       — debugging port (default: 9222)
+ *   E2E_DEMO       — set to include `demo.spec.ts` (media capture only)
  */
 export default defineConfig({
   testDir: '.',
   testMatch: '**/*.spec.ts',
+  // `demo.spec.ts` is the SCREENCAST RECORDER, not a test: it asserts
+  // nothing, it drives the UI purely to emit PNG frames for the README GIF.
+  // `testMatch` was picking it up, so it ran inside the behavioural
+  // "Obsidian E2E smoke" job — where it burns CI minutes and can only ever
+  // go red for reasons unrelated to product behaviour, which is corrosive to
+  // trusting the suite. Excluded by default; the `Record demo + push GIF`
+  // workflow sets E2E_DEMO=1 to opt it back in.
+  testIgnore: process.env.E2E_DEMO ? [] : ['**/demo.spec.ts'],
   timeout: 120_000,
   retries: 1,
   workers: 1, // Obsidian is a single-instance app

--- a/plugin/e2e/reflect.spec.ts
+++ b/plugin/e2e/reflect.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
 
 /**
  * M11 (#125) — remote-write reflection scenarios.
@@ -22,9 +23,12 @@ import { RemoteVerifier } from './helpers/remote-verifier';
  * plugin), then asserts that the connected Obsidian window's File
  * Explorer reflects the change within `REFLECT_TIMEOUT_MS`.
  *
- * Skipped en bloc when:
- *   - the Docker test sshd is unreachable (no key file or no port 2222)
- *   - the plugin failed to connect to the remote vault
+ * This suite HARD-FAILS — it never skips. It used to `test.skip` both
+ * when sshd was down and when `connectAndOpenShadow` THREW, so a
+ * genuinely broken connect reported CI green: exactly the failure mode
+ * `helpers/sshd.ts` exists to stop ("that is how 1.0.49 shipped
+ * broken"). The connect-* specs were migrated to `assertSshdReachable`;
+ * this spec and `sync.spec.ts` were left behind. Not any more.
  *
  * Run: `npm run test:e2e:reflect`
  */
@@ -41,14 +45,20 @@ const REFLECT_TIMEOUT_MS = 15_000;
 let obsidian: ObsidianHandle;
 let scaffold: ScaffoldResult;
 let remote: RemoteVerifier;
-let connected = false;
 
 test.beforeAll(async () => {
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken
+  // connect is a broken plugin. Both must be red, not green-by-skipping.
+  await assertSshdReachable();
+
   remote = new RemoteVerifier();
   const remoteOk = await remote.connect();
   if (!remoteOk) {
-    test.skip(true, 'Docker test sshd is not running — skipping reflect tests');
-    return;
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though ' +
+      'the port is open — check the test key / container state. This spec ' +
+      'hard-fails rather than skipping.',
+    );
   }
 
   scaffold = scaffoldTestVault();
@@ -62,12 +72,11 @@ test.beforeAll(async () => {
   // The previous heuristic (`items > 0`) was a false positive:
   // local_demo*.md from the scaffold seed was always non-zero, so
   // `connected` was true even when the connect command was a no-op.
-  try {
-    obsidian = await connectAndOpenShadow(obsidian, scaffold.vaultPath);
-    connected = true;
-  } catch (e) {
-    test.skip(true, `connectAndOpenShadow failed: ${String(e)}`);
-  }
+  //
+  // Deliberately NOT wrapped in try/catch: if the connect flow throws,
+  // the plugin is broken and this suite must go RED. Swallowing it into
+  // a `test.skip` is what let a broken connect ship green.
+  obsidian = await connectAndOpenShadow(obsidian, scaffold.vaultPath);
 });
 
 test.afterAll(async () => {
@@ -91,9 +100,9 @@ test.afterAll(async () => {
 });
 
 test.describe('Remote → Obsidian reflection (M11)', () => {
-  test.beforeEach(() => {
-    if (!connected) test.skip(true, 'Not connected to remote');
-  });
+  // No `beforeEach` skip gate: reaching here means `beforeAll` completed,
+  // which means the connect succeeded. If it didn't, beforeAll threw and
+  // the whole suite is already red — which is the point.
 
   test('1 — create: remote-written file appears in File Explorer', async () => {
     const file = `${STAMP}-create.md`;

--- a/plugin/e2e/restart-settings.spec.ts
+++ b/plugin/e2e/restart-settings.spec.ts
@@ -1,0 +1,219 @@
+import { test, expect } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * #342 / #429 — a third-party plugin's settings must survive an Obsidian
+ * RESTART. This is the only spec that actually quits Obsidian and relaunches
+ * it on the SAME vault, which is the entire failure surface of those issues.
+ *
+ * Why nothing else catches this
+ * -----------------------------
+ * The bug is an ORDERING bug. Obsidian loads community plugins during startup
+ * and each `onload()` calls `Plugin.loadData()` — reading
+ * `.obsidian/plugins/<id>/data.json` off the LOCAL shadow disk — BEFORE
+ * remote-ssh has connected over SSH and patched the vault adapter. Nothing
+ * used to write that local copy (`saveData()` went through the patched adapter
+ * straight to the remote), so every restart booted plugins on DEFAULTS, which
+ * they then saved back, overwriting the good settings on the remote too.
+ *
+ * No unit test can see this: it needs a real Obsidian process to die and come
+ * back. `tests/integration/restart-roundtrip.e2e.test.ts` is NOT that test —
+ * despite the name it is a vitest that never starts Obsidian; it calls
+ * `ShadowVaultBootstrap` against a tmpdir and asserts the bootstrap's own
+ * output. It proves the pull works; it does not prove Obsidian READS it.
+ *
+ * What this spec does
+ * -------------------
+ *   1. connect → land in the shadow vault window
+ *   2. write a plugin's `data.json` through the PATCHED adapter — byte-for-byte
+ *      what `Plugin.saveData()` does
+ *   3. assert the remote stored it PER-DEVICE (under `.obsidian/user/<id>/`)
+ *      and NOT at the shared identity path — two machines must not collide
+ *   4. assert the LOCAL shadow disk got it too (the write-through)
+ *   5. QUIT Obsidian, RELAUNCH on the SAME shadow vault
+ *   6. assert the settings are still on local disk — i.e. what `loadData()`
+ *      reads at the next startup is the real settings, not defaults
+ *
+ * Against the pre-1.1.7 build, step 4 fails outright: the local file is never
+ * created, because the write only ever went to the remote.
+ *
+ * HARD-FAILS, never skips.
+ */
+
+const STAMP = Date.now().toString(36);
+
+/** A stand-in for any community plugin (Claudian, TaskNotes, …). */
+const PROBE_PLUGIN_ID = 'e2e-settings-probe';
+const PROBE_DATA_REL = `.obsidian/plugins/${PROBE_PLUGIN_ID}/data.json`;
+
+/**
+ * What the "plugin" persists. Non-default on purpose: booting on defaults IS
+ * the symptom, so the payload has to be something defaults could never be.
+ */
+const PROBE_SETTINGS = {
+  probe: STAMP,
+  enabled: true,
+  nested: { n: 42 },
+};
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+
+test.beforeAll(async () => {
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though ' +
+      'the port is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+
+  // Use the building blocks rather than `connectAndOpenShadow` so we keep hold
+  // of the shadow vault PATH — needed both to relaunch on the same vault and
+  // to read the on-disk copy directly.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  if (remote) {
+    // The per-device copy lives under a client-id dir discovered at runtime.
+    for (const dir of await remote.listDir('.obsidian/user')) {
+      await remote
+        .removeFile(`.obsidian/user/${dir}/plugins/${PROBE_PLUGIN_ID}/data.json`)
+        .catch(() => {});
+    }
+    await remote.removeFile(PROBE_DATA_REL).catch(() => {});
+    await remote.disconnect();
+  }
+  scaffold?.cleanup();
+});
+
+/**
+ * Locate the probe's per-device `data.json` on the remote by scanning the
+ * `.obsidian/user/<clientId>/` subtrees. Deliberately DISCOVERED rather than
+ * computed from `os.hostname()`, so the test pins BEHAVIOUR ("it landed in
+ * some per-device subtree") instead of re-implementing `sanitizeClientId`.
+ */
+async function readPerDeviceProbe(): Promise<{ clientId: string; body: string } | null> {
+  for (const clientId of await remote.listDir('.obsidian/user')) {
+    const body = await remote.readFile(
+      `.obsidian/user/${clientId}/plugins/${PROBE_PLUGIN_ID}/data.json`,
+    );
+    if (body !== null) return { clientId, body };
+  }
+  return null;
+}
+
+/** The local shadow-disk path Obsidian's `loadData()` reads at startup. */
+function localProbePath(): string {
+  return path.join(shadowVaultPath, ...PROBE_DATA_REL.split('/'));
+}
+
+test.describe('plugin settings survive an Obsidian restart (#342 / #429)', () => {
+  test('saveData → quit → relaunch: settings survive, and the remote copy is per-device', async () => {
+    // ── 1. Persist settings exactly the way Plugin.saveData() does ─────────
+    // saveData() is literally `adapter.write('.obsidian/plugins/<id>/data.json', json)`.
+    // Going through the PATCHED adapter is the whole point: that is the path
+    // that used to reach only the remote, leaving the local disk cold.
+    const writeErr = await obsidian.page.evaluate(
+      async ({ rel, settings }) => {
+        const app = (window as unknown as {
+          app?: { vault?: { adapter?: { write?: (p: string, d: string) => Promise<void> } } };
+        }).app;
+        const adapter = app?.vault?.adapter;
+        if (!adapter?.write) return 'no adapter on app.vault.adapter';
+        try {
+          await adapter.write(rel, JSON.stringify(settings));
+          return null;
+        } catch (e) {
+          return String(e);
+        }
+      },
+      { rel: PROBE_DATA_REL, settings: PROBE_SETTINGS },
+    );
+    expect(writeErr, 'the saveData()-equivalent write failed').toBeNull();
+
+    // ── 2. The remote stored it PER-DEVICE, not at the shared path ─────────
+    // `saveData()` fires on EVERY settings change, so a shared remote path is
+    // a perpetual write-conflict between two machines.
+    await expect
+      .poll(async () => (await readPerDeviceProbe()) !== null, {
+        message: 'probe data.json never appeared under .obsidian/user/<clientId>/ on the remote',
+        timeout: 15_000,
+      })
+      .toBe(true);
+
+    const perDevice = await readPerDeviceProbe();
+    expect(perDevice).not.toBeNull();
+    expect(JSON.parse(perDevice!.body)).toEqual(PROBE_SETTINGS);
+
+    expect(
+      await remote.exists(PROBE_DATA_REL),
+      'plugin settings must NOT be written to the shared identity path — that ' +
+      'is the cross-device write-conflict this design exists to make impossible',
+    ).toBe(false);
+
+    // ── 3. The write-through put it on LOCAL disk ─────────────────────────
+    // This is the assertion that fails on every build before 1.1.7: the local
+    // copy simply never existed, which is why the next startup read defaults.
+    await expect
+      .poll(() => fs.existsSync(localProbePath()), {
+        message:
+          'local shadow-disk copy of data.json was never written. Obsidian reads ' +
+          'THIS file at startup, before the plugin connects — without it the ' +
+          'plugin boots on defaults and overwrites the remote (#342 / #429).',
+        timeout: 10_000,
+      })
+      .toBe(true);
+    expect(JSON.parse(fs.readFileSync(localProbePath(), 'utf8'))).toEqual(PROBE_SETTINGS);
+
+    // ── 4. QUIT and RELAUNCH on the SAME vault ────────────────────────────
+    await obsidian.cleanup();
+    obsidian = await launchObsidian(shadowVaultPath);
+
+    // ── 5. What a startup loadData() would see is the REAL settings ────────
+    // Read the file straight off disk: that is precisely what Obsidian hands a
+    // plugin's loadData() during onload(), before remote-ssh has connected.
+    expect(
+      fs.existsSync(localProbePath()),
+      'after restart the local data.json is gone — loadData() would return ' +
+      'defaults, and the plugin would then save those defaults over the real ' +
+      'settings on the remote (#342 / #429)',
+    ).toBe(true);
+
+    expect(
+      JSON.parse(fs.readFileSync(localProbePath(), 'utf8')),
+      'settings did not survive the restart',
+    ).toEqual(PROBE_SETTINGS);
+
+    // ── 6. And the remote copy was NOT clobbered by a defaults re-save ─────
+    const after = await readPerDeviceProbe();
+    expect(after, 'per-device settings vanished from the remote after restart').not.toBeNull();
+    expect(
+      JSON.parse(after!.body),
+      'the remote copy was overwritten during restart — this is the data-loss ' +
+      'half of #429 (plugin boots on defaults, saves them back over the remote)',
+    ).toEqual(PROBE_SETTINGS);
+  });
+});

--- a/plugin/e2e/restart-settings.spec.ts
+++ b/plugin/e2e/restart-settings.spec.ts
@@ -3,11 +3,13 @@ import {
   launchObsidian,
   driveConnectFlow,
   findShadowVaultPath,
+  waitForShadowVaultLoaded,
   type ObsidianHandle,
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
 import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -92,6 +94,14 @@ test.beforeAll(async () => {
   shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
   await obsidian.cleanup();
   obsidian = await launchObsidian(shadowVaultPath);
+
+  // MUST wait for the shadow window to finish connecting before touching the
+  // adapter. `launchObsidian` only waits for the plugin to LOAD; the SSH
+  // connect + adapter patch land later, at layout-ready. Writing before that
+  // hits the stock FileSystemAdapter and dies with a local-disk ENOENT (it
+  // does not mkdir -p) — which is itself a neat demonstration of the very
+  // window #342/#429 lives in: at startup the adapter is NOT ours yet.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
 });
 
 test.afterAll(async () => {
@@ -193,13 +203,17 @@ test.describe('plugin settings survive an Obsidian restart (#342 / #429)', () =>
     obsidian = await launchObsidian(shadowVaultPath);
 
     // ── 5. What a startup loadData() would see is the REAL settings ────────
-    // Read the file straight off disk: that is precisely what Obsidian hands a
-    // plugin's loadData() during onload(), before remote-ssh has connected.
+    // Asserted BEFORE waiting for the connect, deliberately. `launchObsidian`
+    // returns once the plugin has LOADED but before the SSH connect + adapter
+    // patch — i.e. we are standing exactly in the pre-connect window where
+    // Obsidian calls each plugin's `loadData()`. Whatever is on local disk
+    // right now IS what a third-party plugin gets handed. It must be the real
+    // settings, not nothing.
     expect(
       fs.existsSync(localProbePath()),
-      'after restart the local data.json is gone — loadData() would return ' +
-      'defaults, and the plugin would then save those defaults over the real ' +
-      'settings on the remote (#342 / #429)',
+      'after restart the local data.json is gone — in this exact window ' +
+      'loadData() would return defaults, and the plugin would then save those ' +
+      'defaults over the real settings on the remote (#342 / #429)',
     ).toBe(true);
 
     expect(
@@ -207,13 +221,19 @@ test.describe('plugin settings survive an Obsidian restart (#342 / #429)', () =>
       'settings did not survive the restart',
     ).toEqual(PROBE_SETTINGS);
 
-    // ── 6. And the remote copy was NOT clobbered by a defaults re-save ─────
+    // ── 6. Let the session fully reconnect, then check for the data loss ───
+    // This is where the old bug did its damage: the plugin (booted on
+    // defaults) saves them, the adapter gets patched, and the defaults land on
+    // the remote on top of the real settings. Give it the chance to happen.
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
     const after = await readPerDeviceProbe();
     expect(after, 'per-device settings vanished from the remote after restart').not.toBeNull();
     expect(
       JSON.parse(after!.body),
-      'the remote copy was overwritten during restart — this is the data-loss ' +
-      'half of #429 (plugin boots on defaults, saves them back over the remote)',
+      'the remote copy was overwritten during the restart — this is the ' +
+      'data-loss half of #429 (plugin boots on defaults, then saves them back ' +
+      'over the real settings on the remote)',
     ).toEqual(PROBE_SETTINGS);
   });
 });

--- a/plugin/e2e/sync.spec.ts
+++ b/plugin/e2e/sync.spec.ts
@@ -7,6 +7,7 @@ import {
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
 
 /**
  * E2E sync tests — verify that local Obsidian operations (create,
@@ -22,13 +23,17 @@ import { RemoteVerifier } from './helpers/remote-verifier';
  * via a separate SFTP connection (RemoteVerifier) to confirm the
  * changes landed.
  *
- * The entire suite is skipped if Docker sshd is unreachable.
+ * This suite HARD-FAILS — it never skips. It used to `test.skip` both
+ * when sshd was down and when `connectAndOpenShadow` THREW, so a
+ * genuinely broken connect reported CI green: exactly the failure mode
+ * `helpers/sshd.ts` exists to stop ("that is how 1.0.49 shipped
+ * broken"). The connect-* specs were migrated to `assertSshdReachable`;
+ * this spec and `reflect.spec.ts` were left behind. Not any more.
  */
 
 let obsidian: ObsidianHandle;
 let scaffold: ScaffoldResult;
 let remote: RemoteVerifier;
-let connected = false;
 
 const STAMP = Date.now().toString(36);
 const TEST_NOTE = `e2e-test-${STAMP}.md`;
@@ -36,12 +41,18 @@ const TEST_CONTENT_INITIAL = `# E2E Test Note\n\nCreated by sync.spec.ts at ${ST
 const TEST_CONTENT_EDITED = `# E2E Test Note (edited)\n\nEdited by sync.spec.ts at ${STAMP}\n`;
 
 test.beforeAll(async () => {
-  // Check remote connectivity first — skip everything if sshd is down
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken
+  // connect is a broken plugin. Both must be red, not green-by-skipping.
+  await assertSshdReachable();
+
   remote = new RemoteVerifier();
   const remoteOk = await remote.connect();
   if (!remoteOk) {
-    test.skip(true, 'Docker test sshd is not running — skipping sync tests');
-    return;
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though ' +
+      'the port is open — check the test key / container state. This spec ' +
+      'hard-fails rather than skipping.',
+    );
   }
 
   scaffold = scaffoldTestVault();
@@ -55,12 +66,11 @@ test.beforeAll(async () => {
   // visible). The previous heuristic — `connected = items > 0` —
   // returned true on the scaffold's seeded local_demo*.md even
   // when the connect command was a silent no-op.
-  try {
-    obsidian = await connectAndOpenShadow(obsidian, scaffold.vaultPath);
-    connected = true;
-  } catch (e) {
-    test.skip(true, `connectAndOpenShadow failed: ${String(e)}`);
-  }
+  //
+  // Deliberately NOT wrapped in try/catch: if the connect flow throws,
+  // the plugin is broken and this suite must go RED. Swallowing it into
+  // a `test.skip` is what let a broken connect ship green.
+  obsidian = await connectAndOpenShadow(obsidian, scaffold.vaultPath);
 });
 
 test.afterAll(async () => {
@@ -74,9 +84,9 @@ test.afterAll(async () => {
 });
 
 test.describe('Remote sync verification', () => {
-  test.beforeEach(() => {
-    if (!connected) test.skip(true, 'Not connected to remote');
-  });
+  // No `beforeEach` skip gate: reaching here means `beforeAll` completed,
+  // which means the connect succeeded. If it didn't, beforeAll threw and
+  // the whole suite is already red — which is the point.
 
   test('create — new note appears on remote', async () => {
     const { page } = obsidian;

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.7",
+      "version": "1.1.8-beta.0",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.7",
+  "version": "1.1.8-beta.0",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
A green E2E run did not mean the product worked. This PR fixes three ways the suite could pass while broken, and adds the one scenario it never covered.

## 1. 🔴 Green-by-skipping — a broken connect passed CI

`sync.spec.ts` and `reflect.spec.ts` still carried the old skip gate:

```ts
try { obsidian = await connectAndOpenShadow(...); connected = true; }
catch (e) { test.skip(true, `connectAndOpenShadow failed: ${e}`); }
```

A **thrown** connect — i.e. a genuinely broken plugin — was swallowed into a **skip**, and CI went **green**. Same for `if (!connected) test.skip(...)`, and for sshd being down.

`helpers/sshd.ts` already exists to prevent exactly this, and even documents why:

> *These specs HARD-FAIL (never skip) when sshd is down: a broken connect must not pass CI green — **that is precisely how 1.0.49 shipped broken**.*

The `connect-*` specs were migrated to `assertSshdReachable()`. These two were left behind and kept the old behaviour. **Migrated now** — both hard-fail, and the connect is no longer wrapped in try/catch. A broken connect is RED.

## 2. 🟡 The screencast recorder ran as a test

`demo.spec.ts` asserts nothing — it drives the UI to emit PNG frames for the README GIF — but `testMatch: '**/*.spec.ts'` pulled it into the behavioural **Obsidian E2E smoke** job, where it burns minutes and can only go red for reasons unrelated to the product. Corrosive to trusting the suite.

Now `testIgnore`d by default. `demo-capture.yml` sets `E2E_DEMO=1` to opt back in, so the GIF still regenerates. Verified both ways:

```
default:      7 spec files, demo absent, restart-settings present
E2E_DEMO=1:   demo.spec.ts › capture demo screencast   (1 test)
```

## 3. 🔴 Nothing ever restarted Obsidian — so #342/#429 was never really tested

**#342/#429 is an ordering bug.** Obsidian loads community plugins and each `onload()` calls `Plugin.loadData()` — reading `data.json` off the **local** shadow disk — **before** remote-ssh connects and patches the adapter. It is only observable across a real **quit + relaunch**.

**No spec did that.** And `tests/integration/restart-roundtrip.e2e.test.ts` is *not* it: despite the name it's a **vitest that never starts Obsidian** — it calls `ShadowVaultBootstrap` against a tmpdir and asserts the bootstrap's own output. It proves the pull works; it never proves Obsidian **reads** it.

So the fix shipped in 1.1.7 had **no end-to-end verification at all**.

### New: `e2e/restart-settings.spec.ts`

1. connect → land in the shadow vault window
2. write a plugin's `data.json` through the **patched adapter** — byte-for-byte what `saveData()` does
3. assert the remote stored it **per-device** (`.obsidian/user/<clientId>/…`) and **not** at the shared identity path — two machines must not collide
4. assert the **write-through** landed it on **local disk**
5. **QUIT Obsidian. RELAUNCH on the SAME vault.**
6. assert the settings are still on disk (what `loadData()` reads at the next startup) **and** that the remote copy was not clobbered by a defaults re-save

Against a **pre-1.1.7 build this fails at step 4**: the local file is never created, because the write only ever reached the remote. That is precisely the regression 1.1.7 fixed — and, until now, nothing verified it.

The harness already supported this: `connectAndOpenShadow` has always done quit+relaunch (onto the *shadow* vault). The same-vault case is three lines. It was simply never written.

## Still open (not in this PR)

- `reflect.spec.ts` has two `test.fixme` cases (remote-modify reflects in editor; 1 MB PNG via ResourceBridge) — visibly disabled, so not a trust hole, but they are unverified features.
- No E2E covers #455 (shadow self-install guard) or #449 (lazy folder loading — no spec ever expands a collapsed folder to trigger a deferred remote load).