### PR TITLE
test(e2e): hard-test matrix — images, plugins, fs visibility, links, cache pressure (17 → 60)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/cache-pressure.spec.ts
+++ b/plugin/e2e/cache-pressure.spec.ts
@@ -1,0 +1,891 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+import * as crypto from 'node:crypto';
+
+/**
+ * Cache pressure — the ReadCache/DirCache correctness surface when the working
+ * set does NOT fit in the cache.
+ *
+ * Why this spec exists
+ * -------------------
+ * `AdapterManager.patch()` builds both caches with NO options
+ * (`src/adapter/AdapterManager.ts:119-120`):
+ *
+ *     this.readCache = new ReadCache();   // maxBytes → 64 MiB  (src/cache/ReadCache.ts:43)
+ *     this.dirCache  = new DirCache();    // ttlMs    → 3000 ms (src/cache/DirCache.ts:27)
+ *
+ * so any vault with more than 64 MiB of *touched* content runs permanently in
+ * eviction. The cache classes are unit-tested in isolation, where `put`/`peek`
+ * are trivially correct; nothing exercises the ADAPTER's revalidation policy
+ * against a real remote whose cache is being churned. Everything below runs
+ * through the PATCHED `app.vault.adapter` in a live Obsidian window against the
+ * docker sshd — the only place that policy is observable.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE DEFECT (SFTP suite, both tests) — mtime-only revalidation
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `SftpDataAdapter.readBuffer()` — `src/adapter/SftpDataAdapter.ts:817-833` —
+ * revalidates a cached read on **mtime EQUALITY ALONE**:
+ *
+ *     if (cached) {
+ *       const s = await this.client.stat(remote);
+ *       if (s.mtime === cached.mtime) {
+ *         this.readCache.get(remote);   // ← serves the CACHED bytes
+ *         return cached.data;
+ *       }
+ *
+ * `s.size` is right there in the same stat — it is used two lines later
+ * (`src/adapter/SftpDataAdapter.ts:825`) to size the transfer-tracker entry —
+ * and is NEVER compared against `cached.data.byteLength`. Meanwhile SFTP mtime
+ * has **1-second resolution**: `src/ssh/SftpClient.ts:664` does
+ * `mtime: stats.mtime * 1000`; the sub-second part does not exist on the wire.
+ *
+ * Consequence: any remote edit landing in the SAME wall-clock second as the
+ * cached copy's mtime is INVISIBLE to the adapter, which keeps serving the old
+ * bytes indefinitely — even though the file's SIZE changed and stat said so.
+ * In an editor that is silent data staleness: the user reads a version that no
+ * longer exists on the server, and the next save writes it back over the real
+ * one.
+ *
+ * Corroboration that the 1-second granularity is real and already known:
+ * `e2e/reflect.spec.ts:143-145` must `waitForTimeout(1_100)` before its second
+ * write, commented "sftp's mtime resolution is per-second". That sleep is a
+ * test working around the product's blind spot.
+ *
+ * CORRECT BEHAVIOUR: a stat whose `size` differs from the cached buffer's
+ * length MUST force a refetch, regardless of mtime. The fix belongs in
+ * `SftpDataAdapter.readBuffer` (reuse the cached bytes only when mtime AND size
+ * both match). It must NOT be "fixed" by weakening the assertions below.
+ *
+ * Why the deterministic defect test lives in the SFTP suite
+ * --------------------------------------------------------
+ * The defective code path is transport-independent — `SftpDataAdapter` is the
+ * adapter for BOTH transports, only the injected `RemoteFsClient` differs. But
+ * on RPC the daemon pushes `fs.changed` and
+ * `FsChangeListener.handleNotification` calls `dataAdapter.invalidateRemotePath()`
+ * (`src/vault/FsChangeListener.ts:204`), dropping the entry and MASKING the bug
+ * — asynchronously, i.e. non-deterministically. On SFTP there is no
+ * notification channel at all: `AdapterManager.patch` subscribes only
+ * `if (this.conn.rpcConnection)` (`src/adapter/AdapterManager.ts:259-266`), and
+ * no `WatchPoller` exists anywhere in `src/` (the name appears only in a
+ * ReadCache comment). So on SFTP the stale entry is served forever. The SFTP
+ * suite is therefore the DETERMINISTIC form of the defect. The RPC suite still
+ * asserts the same user-visible correctness — today only the watch-invalidation
+ * rescues it — so a regression in that mitigation also goes red.
+ *
+ * Predictions at time of writing:
+ *   RPC suite  — all PASS.
+ *   SFTP suite — BOTH tests FAIL. That is the defect, not a broken test.
+ *
+ * Proving eviction (never inferring it)
+ * -------------------------------------
+ * esbuild only minifies identifiers — `esbuild.config.mjs` sets `minify: prod`
+ * and no `mangleProps` — so the live cache is reachable from the renderer:
+ *
+ *   app.plugins.plugins['remote-ssh'].adapterMgr.readCache.stats()
+ *     → { entries, bytes, hits, misses, evictions }   (src/cache/ReadCache.ts:112-120)
+ *   …readCache.has(remoteAbsPath)                     (src/cache/ReadCache.ts:65)
+ *   …adapterMgr.dataAdapter.toRemote(vaultPath)       (src/adapter/SftpDataAdapter.ts:1023)
+ *
+ * Every eviction claim below is read off that probe. If the probe is missing
+ * the spec HARD-FAILS with "cannot prove the cache was exceeded" rather than
+ * quietly continuing with a weaker claim.
+ *
+ * A note on `stats().entries`: the cache also holds Obsidian's own small reads
+ * (workspace.json, app.json, …), so a bare `entries < 9` would not mean what it
+ * appears to. The blob-level residency check below is the honest form of that
+ * claim: fewer than 9 of the 9 blobs remain resident, and blob0 — the LRU
+ * victim — is provably gone.
+ *
+ * HARD-FAILS, never skips.
+ */
+
+// 9 × 8 MiB = 72 MiB of touched content against a 64 MiB budget: the working
+// set cannot fit, so eviction is forced by construction, not by luck.
+const BLOB_COUNT = 9;
+const BLOB_BYTES = 8 * 1024 * 1024;
+
+/** ReadCache default budget — `src/cache/ReadCache.ts:43`. */
+const READ_CACHE_MAX_BYTES = 64 * 1024 * 1024; // 67_108_864
+
+/** DirCache default TTL — `src/cache/DirCache.ts:27`. */
+const DIR_CACHE_TTL_MS = 3_000;
+
+/**
+ * Budget for "a remote directory change became visible through the adapter".
+ * Deliberately tight: a regression to a long DirCache TTL, or a broken watch,
+ * must go RED rather than merely be slow.
+ */
+const DIR_VISIBLE_MS = 5_000;
+
+/** Same budget `reflect.spec.ts` uses for the remote→adapter propagation chain. */
+const REFLECT_TIMEOUT_MS = 15_000;
+
+const STAMP = Date.now().toString(36);
+const blobRel = (i: number): string => `${STAMP}-blob${i}.bin`;
+const BLOB_RELS = Array.from({ length: BLOB_COUNT }, (_, i) => blobRel(i));
+const TARGET_REL = `${STAMP}-target.md`;
+const PAYLOAD_REL = `${STAMP}-payload.bin`;
+const LATE_REL = `${STAMP}-late.md`;
+const SFTP_TARGET_REL = `${STAMP}-sftp-target.md`;
+
+// 72 MiB of incompressible random bytes, generated once and reused by both the
+// seeding and the expected-hash side of every assertion.
+const BLOBS: Buffer[] = BLOB_RELS.map(() => crypto.randomBytes(BLOB_BYTES));
+const BLOB_SHA: string[] = BLOBS.map((b) => sha256(b));
+
+/** Every remote file this spec creates, for the afterAll sweep. */
+const created = new Set<string>([
+  ...BLOB_RELS, TARGET_REL, PAYLOAD_REL, LATE_REL, SFTP_TARGET_REL,
+]);
+
+let remote: RemoteVerifier;
+
+// This spec pushes >72 MiB over loopback SSH inside single tests; the config
+// default (120 s) is not enough. Applied at describe level AND per test/hook —
+// `describe.configure({ timeout })` does not cover hook bodies on every
+// Playwright version, and a hook that times out at 120 s while seeding 72 MiB
+// would look like a product failure.
+const LONG_TIMEOUT_MS = 300_000;
+test.describe.configure({ timeout: LONG_TIMEOUT_MS });
+
+test.beforeAll(async () => {
+  test.setTimeout(LONG_TIMEOUT_MS);
+
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken connect
+  // is a broken plugin. Both must be red, not green-by-skipping.
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though the ' +
+      'port is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  for (let i = 0; i < BLOB_COUNT; i++) {
+    await remote.writeBinaryFile(BLOB_RELS[i], BLOBS[i]);
+  }
+  await remote.writeFile(TARGET_REL, `# target ${STAMP}\n\ninitial\n`);
+});
+
+test.afterAll(async () => {
+  if (!remote) return;
+  await Promise.allSettled([...created].map((f) => remote.removeFile(f)));
+  await remote.disconnect();
+});
+
+// ─── in-page probe shapes ─────────────────────────────────────────────────────
+//
+// Type-only declarations: erased at compile time, so referencing them inside a
+// `page.evaluate` callback is safe (only *values* may not be captured).
+
+interface ReadCacheStatsShape {
+  entries: number;
+  bytes: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+}
+
+interface ReadCacheProbe {
+  stats?: () => ReadCacheStatsShape;
+  has?: (remoteAbsPath: string) => boolean;
+}
+
+interface DataAdapterProbe {
+  toRemote?: (vaultPath: string) => string;
+}
+
+interface PluginProbe {
+  adapterMgr?: {
+    readCache?: ReadCacheProbe | null;
+    dataAdapter?: DataAdapterProbe | null;
+  };
+}
+
+interface VaultAdapterProbe {
+  read?: (p: string) => Promise<string>;
+  readBinary?: (p: string) => Promise<ArrayBuffer>;
+  writeBinary?: (p: string, data: ArrayBuffer) => Promise<void>;
+  list?: (p: string) => Promise<{ files: string[]; folders: string[] }>;
+}
+
+interface WindowProbe {
+  app?: {
+    plugins?: { plugins?: Record<string, PluginProbe | undefined> };
+    vault?: { adapter?: VaultAdapterProbe };
+  };
+}
+
+type ProbeResult<T> = { ok: true; value: T } | { ok: false; why: string };
+
+// ─── node-side helpers ────────────────────────────────────────────────────────
+
+function sha256(buf: Buffer): string {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+/**
+ * Read `readCache.stats()` off the live plugin instance. Returns a discriminated
+ * result rather than throwing, so the precondition test can report exactly WHICH
+ * hop of the probe path is missing.
+ */
+async function probeReadCacheStats(page: Page): Promise<ProbeResult<ReadCacheStatsShape>> {
+  return page.evaluate((): ProbeResult<ReadCacheStatsShape> => {
+    const app = (window as unknown as WindowProbe).app;
+    const plugin = app?.plugins?.plugins?.['remote-ssh'];
+    if (!plugin) return { ok: false, why: "app.plugins.plugins['remote-ssh'] is undefined" };
+    const mgr = plugin.adapterMgr;
+    if (!mgr) {
+      return {
+        ok: false,
+        why: `plugin.adapterMgr is undefined (plugin keys: ${Object.keys(plugin).join(',')})`,
+      };
+    }
+    const rc = mgr.readCache;
+    if (!rc) {
+      return {
+        ok: false,
+        why:
+          `adapterMgr.readCache is ${String(rc)} — the adapter is not patched ` +
+          `(adapterMgr keys: ${Object.keys(mgr).join(',')})`,
+      };
+    }
+    if (typeof rc.stats !== 'function') {
+      return { ok: false, why: 'readCache.stats is not a function' };
+    }
+    return { ok: true, value: rc.stats() };
+  });
+}
+
+/**
+ * Same probe, but a missing probe is FATAL: without it no statement about
+ * eviction can be made, and a spec that silently continued would be asserting
+ * nothing.
+ */
+async function requireReadCacheStats(page: Page): Promise<ReadCacheStatsShape> {
+  const r = await probeReadCacheStats(page);
+  if (!r.ok) {
+    throw new Error(
+      'cannot prove the cache was exceeded: the ReadCache stats probe is ' +
+      `unreachable — ${r.why}. Expected ` +
+      "app.plugins.plugins['remote-ssh'].adapterMgr.readCache.stats().",
+    );
+  }
+  return r.value;
+}
+
+/** Which of `rels` are STILL resident in the ReadCache, keyed by the real remote path. */
+async function cachedFlags(page: Page, rels: string[]): Promise<boolean[]> {
+  const r = await page.evaluate((paths): ProbeResult<boolean[]> => {
+    const mgr = (window as unknown as WindowProbe).app?.plugins?.plugins?.['remote-ssh']?.adapterMgr;
+    const rc = mgr?.readCache;
+    const da = mgr?.dataAdapter;
+    const has = rc?.has;
+    const toRemote = da?.toRemote;
+    if (!rc || !da || typeof has !== 'function' || typeof toRemote !== 'function') {
+      return { ok: false, why: 'readCache.has / dataAdapter.toRemote unreachable' };
+    }
+    return { ok: true, value: paths.map((p) => has.call(rc, toRemote.call(da, p))) };
+  }, rels);
+  if (!r.ok) {
+    throw new Error(`cannot prove the cache was exceeded: ${r.why}`);
+  }
+  return r.value;
+}
+
+/**
+ * Read each path through the PATCHED adapter and hash the bytes IN-PAGE, so the
+ * comparison is against exactly the buffer Obsidian hands a plugin — not a
+ * re-fetch we performed ourselves.
+ */
+async function readBinaryInPage(
+  page: Page,
+  rels: string[],
+): Promise<Array<{ path: string; sha256: string; byteLength: number }>> {
+  return page.evaluate(async (paths) => {
+    const adapter = (window as unknown as WindowProbe).app?.vault?.adapter;
+    if (!adapter?.readBinary) {
+      throw new Error('app.vault.adapter.readBinary is missing — the adapter is not patched');
+    }
+    const out: Array<{ path: string; sha256: string; byteLength: number }> = [];
+    for (const p of paths) {
+      const ab = await adapter.readBinary(p);
+      const digest = await crypto.subtle.digest('SHA-256', ab);
+      const hex = Array.from(new Uint8Array(digest))
+        .map((b) => b.toString(16).padStart(2, '0'))
+        .join('');
+      out.push({ path: p, sha256: hex, byteLength: ab.byteLength });
+    }
+    return out;
+  }, rels);
+}
+
+/**
+ * `adapter.read(path)` through the patched adapter. A thrown error comes back as
+ * a `read-threw: …` string rather than propagating, so an `expect.poll` reports
+ * its own message (and the offending value) instead of dying on a transient.
+ */
+async function adapterRead(page: Page, rel: string): Promise<string> {
+  return page.evaluate(async (p) => {
+    const adapter = (window as unknown as WindowProbe).app?.vault?.adapter;
+    if (!adapter?.read) return 'read-threw: app.vault.adapter.read is missing';
+    try {
+      return await adapter.read(p);
+    } catch (e) {
+      return `read-threw: ${String(e)}`;
+    }
+  }, rel);
+}
+
+/** `adapter.list(dir).files` through the patched adapter. */
+async function adapterListFiles(page: Page, dir: string): Promise<string[]> {
+  return page.evaluate(async (d) => {
+    const adapter = (window as unknown as WindowProbe).app?.vault?.adapter;
+    if (!adapter?.list) {
+      throw new Error('app.vault.adapter.list is missing — the adapter is not patched');
+    }
+    const listed = await adapter.list(d);
+    return listed.files;
+  }, dir);
+}
+
+/**
+ * Connect a scaffolded vault and hand back a handle on the SHADOW window — the
+ * only window whose `app.vault.adapter` is the patched one.
+ */
+async function connectShadow(scaffold: ScaffoldResult): Promise<ObsidianHandle> {
+  let handle = await launchObsidian(scaffold.vaultPath);
+  await driveConnectFlow(handle.page);
+  const shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await handle.cleanup();
+  handle = await launchObsidian(shadowVaultPath);
+  // launchObsidian only waits for the plugin to LOAD; the SSH connect + adapter
+  // patch land later, at layout-ready. Every probe below assumes the PATCHED
+  // adapter, so we must not proceed until the remote tree is in the model.
+  await waitForShadowVaultLoaded(handle.page, logPathFor(shadowVaultPath), 30_000);
+  return handle;
+}
+
+// ═════════════════════════════════════════════════════════════════════════════
+// RPC transport — the default, and the transport under real cache pressure.
+// ═════════════════════════════════════════════════════════════════════════════
+
+test.describe('ReadCache / DirCache under pressure (rpc transport)', () => {
+  let obsidian: ObsidianHandle;
+  let scaffold: ScaffoldResult;
+
+  test.beforeAll(async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+    scaffold = scaffoldTestVault(); // transport defaults to 'rpc'
+    obsidian = await connectShadow(scaffold);
+  });
+
+  test.afterAll(async () => {
+    await obsidian?.cleanup();
+    scaffold?.cleanup();
+  });
+
+  test('precondition: the ReadCache stats probe is reachable', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    const probe = await probeReadCacheStats(obsidian.page);
+    expect(
+      probe.ok ? '' : probe.why,
+      "cannot prove the cache was exceeded — app.plugins.plugins['remote-ssh']" +
+      '.adapterMgr.readCache.stats() is unreachable from the renderer. Every ' +
+      'eviction claim in this spec is read off that probe; without it the spec ' +
+      'would be asserting nothing, so it hard-fails here rather than continuing.',
+    ).toBe('');
+
+    const stats = await requireReadCacheStats(obsidian.page);
+    // The exact shape matters — the assertions below index these five fields.
+    expect(Object.keys(stats).sort()).toEqual(['bytes', 'entries', 'evictions', 'hits', 'misses']);
+    for (const [k, v] of Object.entries(stats)) {
+      expect(typeof v, `readCache.stats().${k} must be a number`).toBe('number');
+    }
+
+    // `readCache.has()` + `dataAdapter.toRemote()` are how eviction of a SPECIFIC
+    // file is proven below; fail here, not mid-assertion, if they are gone.
+    const flags = await cachedFlags(obsidian.page, [TARGET_REL]);
+    expect(flags).toHaveLength(1);
+
+    const hasSubtle = await obsidian.page.evaluate(
+      () => typeof crypto?.subtle?.digest === 'function',
+    );
+    expect(
+      hasSubtle,
+      'crypto.subtle.digest is unavailable in the Obsidian renderer — this spec ' +
+      'hashes every payload in-page to compare against a Node-side SHA-256; ' +
+      'without it the byte-identity claims could not be made at all.',
+    ).toBe(true);
+  });
+
+  test('reading 72 MiB across 9 files provably exceeds the 64 MiB budget', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    const results = await readBinaryInPage(obsidian.page, BLOB_RELS);
+    expect(results).toHaveLength(BLOB_COUNT);
+    for (let i = 0; i < BLOB_COUNT; i++) {
+      expect(results[i].byteLength, `${BLOB_RELS[i]} came back the wrong size`).toBe(BLOB_BYTES);
+      expect(results[i].sha256, `${BLOB_RELS[i]} did not read back byte-identical`)
+        .toBe(BLOB_SHA[i]);
+    }
+
+    const stats = await requireReadCacheStats(obsidian.page);
+
+    expect(
+      stats.evictions,
+      `72 MiB of reads against a ${READ_CACHE_MAX_BYTES}-byte budget must have ` +
+      'evicted something, but readCache.stats() reports 0 evictions ' +
+      `(${JSON.stringify(stats)}). Either the budget is no longer the 64 MiB ` +
+      'default (AdapterManager.ts:119 constructs `new ReadCache()` with no ' +
+      'options) or the eviction path never ran — in either case the rest of this ' +
+      'spec would not be testing cache pressure at all.',
+    ).toBeGreaterThan(0);
+
+    expect(
+      stats.bytes,
+      'the ReadCache is holding more bytes than its own budget — evictIfOverBudget ' +
+      '(src/cache/ReadCache.ts:122) must bring `bytes` back to <= maxBytes after ' +
+      'every put',
+    ).toBeLessThanOrEqual(READ_CACHE_MAX_BYTES);
+
+    // The honest form of "entries < 9": `stats().entries` also counts Obsidian's
+    // own small reads, so blob-level residency is what actually proves the 72 MiB
+    // working set did not fit.
+    const resident = await cachedFlags(obsidian.page, BLOB_RELS);
+    expect(
+      resident.filter(Boolean).length,
+      `all ${BLOB_COUNT} blobs (72 MiB) are still resident in a 64 MiB cache — the ` +
+      'budget is not being enforced',
+    ).toBeLessThan(BLOB_COUNT);
+    expect(
+      resident[0],
+      'blob0 was read first and is therefore the least-recently-used blob; with ' +
+      '72 MiB pushed through a 64 MiB budget it MUST have been an eviction victim',
+    ).toBe(false);
+  });
+
+  test('a file evicted by LRU still reads back byte-identical', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    // Proven, not assumed: blob0 really is out of the cache, so this read has to
+    // go back to the remote.
+    const [before] = await cachedFlags(obsidian.page, [blobRel(0)]);
+    expect(
+      before,
+      'blob0 is unexpectedly still cached — the previous test proved the 64 MiB ' +
+      'budget was exceeded, so this read would not exercise the refetch path',
+    ).toBe(false);
+
+    const [got] = await readBinaryInPage(obsidian.page, [blobRel(0)]);
+    const remoteStat = await remote.stat(blobRel(0));
+    expect(remoteStat, `${blobRel(0)} vanished from the remote`).not.toBeNull();
+
+    expect(
+      got.byteLength,
+      'the refetch after eviction returned an EMPTY buffer — an evicted entry must ' +
+      'be re-fetched in full, not served as a zero-length miss',
+    ).toBeGreaterThan(0);
+    expect(
+      got.byteLength,
+      'the refetch after eviction returned a TRUNCATED buffer: the adapter produced ' +
+      `${got.byteLength} bytes but the remote holds ${remoteStat!.size}`,
+    ).toBe(remoteStat!.size);
+    expect(
+      got.sha256,
+      'a file evicted by LRU did not read back byte-identical — eviction must be ' +
+      'completely transparent to the reader',
+    ).toBe(BLOB_SHA[0]);
+  });
+
+  test('a file evicted then MODIFIED remotely does not serve a stale copy', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    const first = `# target ${STAMP}\n\nversion-one\n`;
+    await remote.writeFile(TARGET_REL, first);
+    await expect
+      .poll(() => adapterRead(obsidian.page, TARGET_REL), {
+        message: 'the adapter never saw the seeded content of the target note',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(first);
+
+    // Push the 72 MiB working set through the cache again; the target note is now
+    // the least-recently-used entry and must be evicted.
+    await readBinaryInPage(obsidian.page, BLOB_RELS);
+    const [stillCached] = await cachedFlags(obsidian.page, [TARGET_REL]);
+    expect(
+      stillCached,
+      'could not evict the target note even after reading 72 MiB through a 64 MiB ' +
+      'cache — the rest of this test would prove nothing',
+    ).toBe(false);
+
+    const second = `# target ${STAMP}\n\nversion-TWO-after-eviction\n`;
+    await remote.writeFile(TARGET_REL, second);
+
+    await expect
+      .poll(() => adapterRead(obsidian.page, TARGET_REL), {
+        message:
+          'after eviction + a remote modification the adapter served a STALE copy. ' +
+          'An evicted entry has no cached bytes to serve, so the read must have gone ' +
+          'back to the remote and returned the new content.',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(second);
+  });
+
+  test('a CACHED file modified remotely with an UNCHANGED mtime does not serve a stale copy', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    const before = `# target ${STAMP}\n\ncached-copy\n`;
+    await remote.writeFile(TARGET_REL, before);
+    await expect
+      .poll(() => adapterRead(obsidian.page, TARGET_REL), {
+        message: 'the adapter never saw the seeded content of the target note',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(before);
+
+    const [cached] = await cachedFlags(obsidian.page, [TARGET_REL]);
+    expect(cached, 'the target note must be RESIDENT in the ReadCache for this test to mean anything')
+      .toBe(true);
+
+    const stat = await remote.stat(TARGET_REL);
+    expect(stat, 'the target note vanished from the remote').not.toBeNull();
+    const M = stat!.mtimeMs;
+
+    // New bytes AND a new length: a `size` comparison — which `stat` hands the
+    // adapter for free — would catch this even with the mtime frozen.
+    const after = `# target ${STAMP}\n\nMODIFIED-SAME-MTIME-${'z'.repeat(400)}\n`;
+    await remote.writeFile(TARGET_REL, after);
+    // Force the mtime back to what the cache recorded — the deterministic
+    // stand-in for "two edits inside one 1-second SFTP mtime tick".
+    await remote.setMtime(TARGET_REL, Math.floor(M / 1000));
+
+    const forced = await remote.stat(TARGET_REL);
+    expect(forced, 'the target note vanished from the remote').not.toBeNull();
+    expect(forced!.mtimeMs, 'harness: setMtime did not pin the mtime back to M').toBe(M);
+    expect(forced!.size, 'harness: the remote size does not match the new content').toBe(
+      Buffer.byteLength(after),
+    );
+    expect(
+      forced!.size,
+      'harness: the new content is the same LENGTH as the old one, so a size check ' +
+      'could not detect it either — the fixture is wrong',
+    ).not.toBe(Buffer.byteLength(before));
+
+    await expect
+      .poll(() => adapterRead(obsidian.page, TARGET_REL), {
+        message:
+          'STALE READ: the remote file has different bytes and a different SIZE but ' +
+          'the same mtime, and the adapter served the cached copy. ' +
+          'SftpDataAdapter.readBuffer (src/adapter/SftpDataAdapter.ts:817-833) ' +
+          'compares ONLY `s.mtime === cached.mtime` and ignores `s.size`, even though ' +
+          'the same stat carries it. On the RPC transport the daemon watch ' +
+          '(src/vault/FsChangeListener.ts:204 → invalidateRemotePath) is the ONLY ' +
+          'thing that drops the entry — if this assertion failed, that mitigation is ' +
+          'gone and the mtime-only revalidation is now user-visible here too. The SFTP ' +
+          'suite in this file shows the same defect with no mitigation at all. Fix the ' +
+          'adapter (refetch when size differs); do NOT relax this assertion.',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(after);
+  });
+
+  test('writes under cache pressure are not corrupted', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    // 3 MB of random bytes written through the PATCHED adapter's writeBinary —
+    // the exact call an attachment / plugin write makes. `.bin` rather than `.md`
+    // so Obsidian's metadata cache does not try to parse random bytes as markdown.
+    const payload = crypto.randomBytes(3 * 1024 * 1024);
+    const expectedSha = sha256(payload);
+    const b64 = payload.toString('base64');
+
+    const writeErr = await obsidian.page.evaluate(
+      async ({ rel, data }) => {
+        const adapter = (window as unknown as WindowProbe).app?.vault?.adapter;
+        if (!adapter?.writeBinary) return 'app.vault.adapter.writeBinary is missing';
+        const bin = atob(data);
+        const bytes = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+        try {
+          await adapter.writeBinary(rel, bytes.buffer);
+          return null;
+        } catch (e) {
+          return String(e);
+        }
+      },
+      { rel: PAYLOAD_REL, data: b64 },
+    );
+    expect(writeErr, 'writeBinary of the 3 MB payload failed').toBeNull();
+
+    // Push the 72 MiB working set through the cache so the just-written entry —
+    // now the least-recently-used one — is evicted. Without this the read-back
+    // below would be served from the very buffer we wrote and would prove nothing
+    // about what actually landed on the remote.
+    await readBinaryInPage(obsidian.page, BLOB_RELS);
+    const [stillCached] = await cachedFlags(obsidian.page, [PAYLOAD_REL]);
+    expect(
+      stillCached,
+      'the just-written payload survived 72 MiB of reads through a 64 MiB cache — ' +
+      'the verification read below would then hit the cache, not the remote',
+    ).toBe(false);
+
+    // Ground truth: what is ON THE REMOTE, read by a connection that has never
+    // heard of the plugin's caches.
+    const onRemote = await remote.readBinaryFile(PAYLOAD_REL);
+    expect(onRemote, 'the 3 MB payload never reached the remote').not.toBeNull();
+    expect(
+      onRemote!.byteLength,
+      'the payload on the remote is the wrong length — a write under cache pressure ' +
+      'was truncated',
+    ).toBe(payload.byteLength);
+    expect(
+      sha256(onRemote!),
+      'the payload on the remote is NOT byte-identical to what was written — a write ' +
+      'was corrupted while the cache was churning',
+    ).toBe(expectedSha);
+
+    // And the adapter's own read-back — now a genuine refetch — agrees.
+    const [readBack] = await readBinaryInPage(obsidian.page, [PAYLOAD_REL]);
+    expect(readBack.byteLength, 'adapter.readBinary of the payload returned the wrong length')
+      .toBe(payload.byteLength);
+    expect(
+      readBack.sha256,
+      'adapter.readBinary of the payload did not hash to the bytes that were written',
+    ).toBe(expectedSha);
+  });
+
+  test('DirCache: a remote create is visible to adapter.list() within 5 s', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    // Populate the DirCache for the vault root.
+    const initial = await adapterListFiles(obsidian.page, '');
+    expect(
+      initial.includes(TARGET_REL),
+      'the target note seeded in beforeAll is not in adapter.list("") — the listing ' +
+      'itself is broken, so nothing below would mean anything',
+    ).toBe(true);
+    expect(initial).not.toContain(LATE_REL);
+
+    await remote.writeFile(LATE_REL, `# late ${STAMP}\n`);
+
+    await expect
+      .poll(async () => (await adapterListFiles(obsidian.page, '')).includes(LATE_REL), {
+        message:
+          'a file created on the remote was still not in adapter.list("") after ' +
+          `${DIR_VISIBLE_MS} ms. The DirCache TTL is ${DIR_CACHE_TTL_MS} ms by default ` +
+          '(src/cache/DirCache.ts:27, constructed with no options at ' +
+          'src/adapter/AdapterManager.ts:120) and the RPC watch invalidates the entry ' +
+          'outright (src/vault/FsChangeListener.ts:204) — so either the TTL regressed ' +
+          'to something long or the watch-invalidation broke. Both are user-visible as ' +
+          '"new files never show up".',
+        timeout: DIR_VISIBLE_MS,
+      })
+      .toBe(true);
+  });
+
+  test('DirCache: a remote DELETE disappears from adapter.list()', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    // The create test left it there; make the starting state explicit anyway.
+    await expect
+      .poll(async () => (await adapterListFiles(obsidian.page, '')).includes(LATE_REL), {
+        message: 'the late file is not listed, so its deletion cannot be observed',
+        timeout: DIR_VISIBLE_MS,
+      })
+      .toBe(true);
+
+    await remote.removeFile(LATE_REL);
+
+    await expect
+      .poll(async () => (await adapterListFiles(obsidian.page, '')).includes(LATE_REL), {
+        message:
+          'a file deleted on the remote was STILL listed by adapter.list("") after ' +
+          `${DIR_VISIBLE_MS} ms — the DirCache is serving a directory listing that no ` +
+          'longer exists. A user clicking that entry gets an ENOENT.',
+        timeout: DIR_VISIBLE_MS,
+      })
+      .toBe(false);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// SFTP transport — no daemon watch channel, and therefore the only place the
+// mtime-only revalidation defect is DETERMINISTICALLY observable.
+//
+// `AdapterManager.patch()` subscribes FsChangeListener only when an RPC tunnel
+// exists (src/adapter/AdapterManager.ts:259-266), and no WatchPoller exists in
+// src/, so on SFTP nothing ever invalidates a ReadCache entry from the outside.
+// A cached entry whose mtime matches is served forever — whatever the remote
+// says its SIZE is.
+//
+// BOTH tests below are PREDICTED TO FAIL against the current product. They are
+// written at full strength on purpose: the defect lives in
+// SftpDataAdapter.readBuffer (src/adapter/SftpDataAdapter.ts:817-833) and must
+// be fixed THERE, not by weakening these assertions.
+// ═════════════════════════════════════════════════════════════════════════════
+
+test.describe('stale reads on the SFTP transport (mtime-only revalidation)', () => {
+  let obsidian: ObsidianHandle;
+  let scaffold: ScaffoldResult;
+
+  test.beforeAll(async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+    scaffold = scaffoldTestVault({ transport: 'sftp' });
+    obsidian = await connectShadow(scaffold);
+  });
+
+  test.afterAll(async () => {
+    await obsidian?.cleanup();
+    scaffold?.cleanup();
+  });
+
+  test('a CACHED file modified remotely with an UNCHANGED mtime does not serve a stale copy', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    const before = `# sftp target ${STAMP}\n\ncached-copy\n`;
+    await remote.writeFile(SFTP_TARGET_REL, before);
+    await expect
+      .poll(() => adapterRead(obsidian.page, SFTP_TARGET_REL), {
+        message: 'the adapter never saw the seeded content of the SFTP target note',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(before);
+
+    const [cached] = await cachedFlags(obsidian.page, [SFTP_TARGET_REL]);
+    expect(cached, 'the note must be RESIDENT in the ReadCache for this test to mean anything')
+      .toBe(true);
+
+    const stat = await remote.stat(SFTP_TARGET_REL);
+    expect(stat, 'the SFTP target note vanished from the remote').not.toBeNull();
+    const M = stat!.mtimeMs;
+
+    // New bytes AND a new length — the `size` the adapter already gets from stat
+    // would catch this even with the mtime frozen.
+    const after = `# sftp target ${STAMP}\n\nMODIFIED-SAME-MTIME-${'z'.repeat(600)}\n`;
+    await remote.writeFile(SFTP_TARGET_REL, after);
+    await remote.setMtime(SFTP_TARGET_REL, Math.floor(M / 1000));
+
+    const forced = await remote.stat(SFTP_TARGET_REL);
+    expect(forced, 'the SFTP target note vanished from the remote').not.toBeNull();
+    expect(forced!.mtimeMs, 'harness: setMtime did not pin the mtime back to M').toBe(M);
+    expect(forced!.size, 'harness: the remote size does not match the new content').toBe(
+      Buffer.byteLength(after),
+    );
+    expect(
+      forced!.size,
+      'harness: the new content is the same LENGTH as the old one — the fixture is wrong',
+    ).not.toBe(Buffer.byteLength(before));
+
+    await expect
+      .poll(() => adapterRead(obsidian.page, SFTP_TARGET_REL), {
+        message:
+          'STALE READ — THE DEFECT. The remote file has different bytes and a ' +
+          'different SIZE, but the same mtime, and the adapter served the CACHED copy. ' +
+          'SftpDataAdapter.readBuffer (src/adapter/SftpDataAdapter.ts:817-833) ' +
+          'revalidates on `s.mtime === cached.mtime` ALONE: it never compares `s.size` ' +
+          'against the cached buffer length, even though the very same stat returns ' +
+          '`size` (it uses it two lines later, at :825, to size the transfer tracker). ' +
+          'Because SFTP mtime is 1-second resolution (src/ssh/SftpClient.ts:664 — ' +
+          '`mtime: stats.mtime * 1000`), any two edits inside one wall-clock second ' +
+          'collapse onto the same mtime and the user silently keeps reading a version ' +
+          'that no longer exists on the server — then saves it back over the real one. ' +
+          'CORRECT BEHAVIOUR: a size mismatch MUST force a refetch. Fix it in ' +
+          'SftpDataAdapter.readBuffer; do NOT weaken this assertion.',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(after);
+  });
+
+  test('same-second remote edit on the SFTP transport (field-realistic repro)', async () => {
+    test.setTimeout(LONG_TIMEOUT_MS);
+
+    // The FIELD-REALISTIC form of the test above: no setMtime, no clock trickery —
+    // just a read followed immediately by a remote edit, the way a second machine
+    // (or a `git pull` on the server) actually behaves. The 1-second SFTP mtime
+    // granularity does the rest.
+    //
+    // The test above is the DETERMINISTIC form. This one depends on the second edit
+    // landing in the same wall-clock second as the cached copy's mtime, so that
+    // condition is CONSTRUCTED rather than assumed: each attempt uses a fresh file,
+    // and an attempt whose second edit crossed a second boundary is discarded and
+    // retried (there the mtime moves and the adapter refetches for the RIGHT
+    // reason — not the scenario under test). If no attempt ever lands inside one
+    // second, the HARNESS is at fault and this test THROWS; it never degrades into
+    // a vacuous pass.
+    const ATTEMPTS = 8;
+    let file: string | null = null;
+    let expectedAfter = '';
+    const crossings: number[] = [];
+
+    for (let attempt = 0; attempt < ATTEMPTS && !file; attempt++) {
+      const candidate = `${STAMP}-samesecond-${attempt}.md`;
+      created.add(candidate);
+
+      const first = `# same-second ${attempt}\n\nfirst\n`;
+      await remote.writeFile(candidate, first);
+
+      // Cache it. The cached entry's mtime is the second in which `first` landed.
+      const got = await adapterRead(obsidian.page, candidate);
+      expect(got, `attempt ${attempt}: the adapter did not read back the freshly written file`)
+        .toBe(first);
+      const cachedStat = await remote.stat(candidate);
+      expect(cachedStat, `attempt ${attempt}: the candidate file vanished`).not.toBeNull();
+
+      // Second edit, immediately, NO sleep — different content, different length.
+      const second = `# same-second ${attempt}\n\nSECOND-EDIT-${'q'.repeat(300)}\n`;
+      await remote.writeFile(candidate, second);
+      const afterStat = await remote.stat(candidate);
+      expect(afterStat, `attempt ${attempt}: the candidate file vanished`).not.toBeNull();
+
+      if (afterStat!.mtimeMs === cachedStat!.mtimeMs) {
+        file = candidate;
+        expectedAfter = second;
+      } else {
+        crossings.push(attempt);
+      }
+    }
+
+    if (!file) {
+      throw new Error(
+        'harness: could not land two edits inside one wall-clock second after ' +
+        `${ATTEMPTS} attempts (every attempt crossed a second boundary: ` +
+        `${crossings.join(',')}). This test HARD-FAILS rather than passing vacuously — ` +
+        'the scenario it names was never actually created.',
+      );
+    }
+
+    await expect
+      .poll(() => adapterRead(obsidian.page, file!), {
+        message:
+          'STALE READ — THE DEFECT, in its field-realistic form. Two remote edits landed ' +
+          'inside the same wall-clock second, so SFTP reported the SAME mtime for both ' +
+          '(1-second resolution: src/ssh/SftpClient.ts:664). ' +
+          'SftpDataAdapter.readBuffer (src/adapter/SftpDataAdapter.ts:817-833) ' +
+          'revalidated on mtime EQUALITY ALONE and served the first version — even though ' +
+          'the file SIZE changed and the stat it had just performed already said so. Same ' +
+          'defect as the deterministic test above, reproduced with no clock manipulation ' +
+          'at all: this is what a user editing from a second machine hits. CORRECT ' +
+          'BEHAVIOUR: a size mismatch MUST force a refetch. Fix the adapter; do NOT weaken ' +
+          'this assertion.',
+        timeout: REFLECT_TIMEOUT_MS,
+      })
+      .toBe(expectedAfter);
+  });
+});

--- a/plugin/e2e/fs-visibility.spec.ts
+++ b/plugin/e2e/fs-visibility.spec.ts
@@ -10,6 +10,15 @@ import {
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
 import { makeFakePlugin, seedPluginOnRemote } from './helpers/remote-fixtures';
+import {
+  COMMUNITY_PLUGINS_REL,
+  captureCommunityPlugins,
+  parseIdList,
+  preCleanRemoteFixtures,
+  resetRemoteFixtures,
+  type CommunityPluginsSnapshot,
+  type FixtureFootprint,
+} from './helpers/remote-reset';
 import { assertSshdReachable } from './helpers/sshd';
 import { logPathFor } from './helpers/log-oracle';
 import * as fs from 'node:fs';
@@ -90,11 +99,19 @@ import { fileURLToPath } from 'node:url';
 
 const STAMP = Date.now().toString(36);
 
+/**
+ * The family prefix every note this spec seeds shares. Cleanup matches on THIS,
+ * not on the four stamped names below: a run that crashed took its stamp with
+ * it, and the only way to sweep its leftovers off the shared docker vault is to
+ * recognise them by family.
+ */
+const NOTE_PREFIX = 'e2e-fs-';
+
 /** Vault-relative note paths, unique to this run. */
-const CONTROL_NOTE = `e2e-fs-${STAMP}-control.md`;
-const PLUGIN_NOTE = `e2e-fs-${STAMP}-plugin.md`;
-const REMOTE_ONLY_NOTE = `e2e-fs-${STAMP}-remote-only.md`;
-const REAL_PLUGIN_NOTE = `e2e-fs-${STAMP}-claudian.md`;
+const CONTROL_NOTE = `${NOTE_PREFIX}${STAMP}-control.md`;
+const PLUGIN_NOTE = `${NOTE_PREFIX}${STAMP}-plugin.md`;
+const REMOTE_ONLY_NOTE = `${NOTE_PREFIX}${STAMP}-remote-only.md`;
+const REAL_PLUGIN_NOTE = `${NOTE_PREFIX}${STAMP}-claudian.md`;
 
 const CONTROL_BODY = `# control ${STAMP}\n\nwritten through app.vault.adapter.write()\n`;
 const PLUGIN_BODY = `# plugin ${STAMP}\n\nwritten with raw fs under adapter.basePath\n`;
@@ -106,7 +123,19 @@ const FIXTURE_NOTE = 'remote_demo1.md';
 
 /** The #429 reproduction plugin (vehicle b). */
 const FS_PLUGIN_ID = 'e2e-fs-probe';
-const REMOTE_COMMUNITY_PLUGINS = '.obsidian/community-plugins.json';
+
+/**
+ * Everything this spec puts on the SHARED, PERSISTENT docker vault — and
+ * therefore owes back. A fixture plugin left enabled in the remote's
+ * `community-plugins.json` is pulled into the shadow vault of every LATER spec
+ * at connect (`src/main.ts:632-670`), so leaving one behind reddens tests this
+ * file has nothing to do with. The product cannot undo it either: the enabled
+ * list is a monotonic union (`ShadowVaultBootstrap.ts:698-702`).
+ */
+const FOOTPRINT: FixtureFootprint = {
+  pluginIds: [FS_PLUGIN_ID],
+  notePrefixes: [NOTE_PREFIX],
+};
 
 /**
  * `onload()` body of the reproduction plugin: literally the code from the
@@ -149,8 +178,13 @@ let obsidian: ObsidianHandle;
 let scaffold: ScaffoldResult;
 let remote: RemoteVerifier;
 let shadowVaultPath: string;
-/** The remote's community-plugins.json before this spec touched it (null = absent). */
-let remoteCommunityPluginsBefore: string | null = null;
+/**
+ * The remote's community-plugins.json before this spec touched it (raw === null
+ * means it did not exist, and restoring must DELETE it rather than write `[]`).
+ * Captured after the pre-clean, so a leftover fixture id from a crashed run can
+ * never be baked into what we call "original".
+ */
+let communityPluginsSnapshot: CommunityPluginsSnapshot = { raw: null };
 
 test.beforeAll(async () => {
   await assertSshdReachable();
@@ -162,6 +196,15 @@ test.beforeAll(async () => {
       'the port is open. This spec hard-fails rather than skipping.',
     );
   }
+
+  // ── Defensive PRE-CLEAN, before anything is seeded ───────────────────────
+  // The docker vault is shared and persists across specs. A previous run that
+  // crashed leaves `e2e-fs-*` notes at the root, `e2e-fs-probe` under
+  // `.obsidian/plugins/` (and under the per-device `.obsidian/user/<clientId>/`),
+  // and its id still named in the remote enabled list — which the product's
+  // monotonic union can never have removed. Purge all of it, so this spec never
+  // inherits another run's garbage.
+  await preCleanRemoteFixtures(remote, FOOTPRINT);
 
   // ── Seed the REMOTE before anything connects ─────────────────────────────
   // Both fixtures must exist on the remote before the shadow window's connect,
@@ -180,10 +223,10 @@ test.beforeAll(async () => {
   // connect-time pull merges into the shadow vault and what decides which
   // binaries get staged. Merged rather than overwritten (so a concurrent
   // fixture's id survives) and remembered, so `afterAll` can restore it.
-  remoteCommunityPluginsBefore = await remote.readFile(REMOTE_COMMUNITY_PLUGINS);
-  const enabledIds = new Set<string>(parseIdList(remoteCommunityPluginsBefore));
+  communityPluginsSnapshot = await captureCommunityPlugins(remote);
+  const enabledIds = new Set<string>(parseIdList(communityPluginsSnapshot.raw));
   enabledIds.add(FS_PLUGIN_ID);
-  await remote.writeFile(REMOTE_COMMUNITY_PLUGINS, JSON.stringify([...enabledIds]));
+  await remote.writeFile(COMMUNITY_PLUGINS_REL, JSON.stringify([...enabledIds]));
 
   scaffold = scaffoldTestVault();
   obsidian = await launchObsidian(scaffold.vaultPath);
@@ -204,36 +247,20 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await obsidian?.cleanup();
+  // MOST OF THIS SPEC IS EXPECTED TO FAIL, so cleanup lives here — `afterAll`
+  // runs whatever the tests did — and every step inside `resetRemoteFixtures` is
+  // independently guarded, so one failure cannot skip the rest. Reverting the
+  // remote is unavoidably the harness's job: the product's enabled list is a
+  // monotonic union and will never drop `e2e-fs-probe` on its own, and a fixture
+  // plugin still named there is pulled in, staged and LOADED by the shadow vault
+  // of every spec that runs after this one.
+  await obsidian?.cleanup().catch(() => {});
   if (remote) {
-    for (const note of [CONTROL_NOTE, PLUGIN_NOTE, REMOTE_ONLY_NOTE, REAL_PLUGIN_NOTE]) {
-      await remote.removeFile(note).catch(() => {});
-    }
-    await remote.rmrf(`.obsidian/plugins/${FS_PLUGIN_ID}`).catch(() => {});
-    // Restore the remote's plugin list so this spec leaves no fixture plugin
-    // enabled for whatever runs next.
-    if (remoteCommunityPluginsBefore === null) {
-      await remote.removeFile(REMOTE_COMMUNITY_PLUGINS).catch(() => {});
-    } else {
-      await remote
-        .writeFile(REMOTE_COMMUNITY_PLUGINS, remoteCommunityPluginsBefore)
-        .catch(() => {});
-    }
+    await resetRemoteFixtures(remote, FOOTPRINT, communityPluginsSnapshot);
     await remote.disconnect();
   }
   scaffold?.cleanup();
 });
-
-/** Tolerant read of a `community-plugins.json` body: absent / junk → no ids. */
-function parseIdList(raw: string | null): string[] {
-  if (raw === null) return [];
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
-  } catch {
-    return [];
-  }
-}
 
 /** `app.vault.adapter.basePath`, as the renderer sees it. */
 function readBasePath(page: Page): Promise<unknown> {

--- a/plugin/e2e/fs-visibility.spec.ts
+++ b/plugin/e2e/fs-visibility.spec.ts
@@ -1,0 +1,697 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { makeFakePlugin, seedPluginOnRemote } from './helpers/remote-fixtures';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * #429 (the OPEN half) — "Claudian creates .md files in the local folder
+ * instead of the remote vault".
+ *
+ * READ THIS BEFORE TOUCHING AN ASSERTION
+ * ======================================
+ * MOST OF THIS SPEC IS EXPECTED TO FAIL against the current product. That is
+ * the point: it is the executable statement of the defect, and it must stay RED
+ * until the product is fixed. These reds CANNOT be fixed by weakening the
+ * assertions — "a file a plugin writes into the vault ends up in the vault" IS
+ * the user-facing contract, and relaxing it would merely delete the bug report.
+ * The only correct fixes are in the product:
+ *
+ *   (i)  mirror the note tree onto the shadow disk and run a local→remote
+ *        watcher over it, so raw `fs` under `basePath` is a real two-way view
+ *        of the vault; or
+ *   (ii) patch `getFullPath` / `getFilePath` (alongside the already-patched
+ *        `basePath` surface) and back them with a genuinely FS-backed view of
+ *        the remote vault.
+ *
+ * The defect, in the code
+ * -----------------------
+ *  - `src/adapter/SftpDataAdapter.ts:155-166` — `get basePath()` and
+ *    `getBasePath()` deliberately return the LOCAL shadow-vault root
+ *    (`~/.obsidian-remote/vaults/<profile-id>/`). Its own docblock concedes the
+ *    consequence: "the vault tree is virtual — served from the remote, not
+ *    mirrored to disk — so raw Node `fs` here only touches the local shadow
+ *    copy: reads miss remote notes, writes don't reach the remote."
+ *  - `src/adapter/AdapterManager.ts:33-52` — `PATCHED_METHODS` lists the
+ *    read/write/fs-op surface plus `basePath` / `getBasePath`, but NOT
+ *    `getFullPath` and NOT `getFilePath`. Those two survive as the stock
+ *    `FileSystemAdapter` implementations, which join onto the local base and so
+ *    hand plugins a local path for a file that exists only on the remote.
+ *  - `SftpDataAdapter.writeThroughConfig` mirrors only `<configDir>/**` to the
+ *    local disk (that is the #342 fix). The NOTE tree is never mirrored, and
+ *    nothing watches the local disk for a plugin's raw `fs` writes.
+ *
+ * Net effect — precisely the field report: a plugin doing
+ *
+ *     fs.writeFileSync(path.join(this.app.vault.adapter.basePath, 'note.md'), body)
+ *
+ * writes into `~/.obsidian-remote/vaults/<id>/note.md`, where the bytes sit
+ * forever: invisible to the vault model, never pushed to the remote. And,
+ * symmetrically, a note that DOES exist on the remote is not readable through
+ * raw `fs` under `basePath`.
+ *
+ * Two execution vehicles, both real
+ * ---------------------------------
+ *  (a) IN-PAGE RAW FS — `page.evaluate` + `window.require('fs')`. Obsidian's
+ *      renderer has nodeIntegration, so this is byte-for-byte what a community
+ *      plugin's own `require('fs')` gets. A precondition test asserts
+ *      `window.require` really is there and FAILS LOUDLY if it is not: a silent
+ *      fallback would leave the whole vehicle green while testing nothing.
+ *  (b) A REAL PLUGIN — a loadable community plugin (`makeFakePlugin`) whose
+ *      `onload()` runs the literal code from the issue. It is seeded ON THE
+ *      REMOTE, so the connect-time community-plugins + plugin-binary pull
+ *      (`src/main.ts:632-670`) stages it into the shadow vault; the shadow vault
+ *      is then relaunched, because Obsidian only scans the plugins dir at
+ *      startup. It is deliberately NOT seeded into the source scaffold vault:
+ *      `ShadowVaultBootstrap` would snapshot it into
+ *      `settings.pendingPluginSuggestions` and the shadow window would open a
+ *      `PendingPluginsModal` that swallows Ctrl+P and hangs every later palette
+ *      step.
+ *
+ * The first test is a CONTROL — a write through the vault API — and must PASS.
+ * It isolates the real defect from harness faults: if the control is red, the
+ * connect / adapter-patch / SFTP-verifier plumbing is broken and nothing else
+ * in this file means anything.
+ *
+ * HARD-FAILS, never skips.
+ */
+
+const STAMP = Date.now().toString(36);
+
+/** Vault-relative note paths, unique to this run. */
+const CONTROL_NOTE = `e2e-fs-${STAMP}-control.md`;
+const PLUGIN_NOTE = `e2e-fs-${STAMP}-plugin.md`;
+const REMOTE_ONLY_NOTE = `e2e-fs-${STAMP}-remote-only.md`;
+const REAL_PLUGIN_NOTE = `e2e-fs-${STAMP}-claudian.md`;
+
+const CONTROL_BODY = `# control ${STAMP}\n\nwritten through app.vault.adapter.write()\n`;
+const PLUGIN_BODY = `# plugin ${STAMP}\n\nwritten with raw fs under adapter.basePath\n`;
+const REMOTE_ONLY_BODY = `# remote only ${STAMP}\n\nseeded straight onto the remote over SFTP\n`;
+const REAL_PLUGIN_BODY = `# claudian repro ${STAMP}\n\nfs.writeFileSync from a plugin onload()\n`;
+
+/** A note the docker fixture vault always has — the read-side subject. */
+const FIXTURE_NOTE = 'remote_demo1.md';
+
+/** The #429 reproduction plugin (vehicle b). */
+const FS_PLUGIN_ID = 'e2e-fs-probe';
+const REMOTE_COMMUNITY_PLUGINS = '.obsidian/community-plugins.json';
+
+/**
+ * `onload()` body of the reproduction plugin: literally the code from the
+ * issue. The outcome is parked on `window.__E2E_FS_PROBE__` so the test can
+ * tell three very different failures apart — "the plugin never ran", "the
+ * plugin ran and the write threw", and "the plugin ran, the write succeeded,
+ * and the bytes went nowhere near the remote" (the actual bug).
+ */
+const FS_PLUGIN_ONLOAD = [
+  "const fs = require('fs'); const path = require('path');",
+  'try {',
+  `  const p = path.join(this.app.vault.adapter.basePath, ${JSON.stringify(REAL_PLUGIN_NOTE)});`,
+  `  fs.writeFileSync(p, ${JSON.stringify(REAL_PLUGIN_BODY)});`,
+  '  window.__E2E_FS_PROBE__ = { wrote: p, error: null };',
+  '} catch (e) { window.__E2E_FS_PROBE__ = { wrote: null, error: String(e) }; }',
+].join('\n    ');
+
+/** What the reproduction plugin reports back from its `onload()`. */
+interface FsProbeResult {
+  wrote: string | null;
+  error: string | null;
+}
+
+/**
+ * The slice of Node's `fs` / `path` these tests use. Structural types only —
+ * they exist so the in-renderer code is type-checked without importing Node
+ * types into a browser context (the real modules come from `window.require`).
+ */
+interface FsLike {
+  existsSync(p: string): boolean;
+  readFileSync(p: string, encoding: 'utf8'): string;
+  writeFileSync(p: string, data: string): void;
+  readdirSync(p: string): string[];
+}
+interface PathLike {
+  join(...parts: string[]): string;
+}
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+/** The remote's community-plugins.json before this spec touched it (null = absent). */
+let remoteCommunityPluginsBefore: string | null = null;
+
+test.beforeAll(async () => {
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though ' +
+      'the port is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  // ── Seed the REMOTE before anything connects ─────────────────────────────
+  // Both fixtures must exist on the remote before the shadow window's connect,
+  // because that connect is when the product reads the remote:
+  //   - the note is picked up by the initial vault-model populate;
+  //   - the plugin binary is staged onto the shadow disk by the connect-time
+  //     community-plugins + plugin-binary round-trip (`src/main.ts:632-670`).
+  await remote.writeFile(REMOTE_ONLY_NOTE, REMOTE_ONLY_BODY);
+
+  const pluginFiles: Record<string, string> = {
+    ...makeFakePlugin({ id: FS_PLUGIN_ID, version: '1.0.0', onloadBody: FS_PLUGIN_ONLOAD }),
+  };
+  await seedPluginOnRemote(remote, FS_PLUGIN_ID, pluginFiles);
+
+  // Enable it in the REMOTE's community-plugins.json — that list is what the
+  // connect-time pull merges into the shadow vault and what decides which
+  // binaries get staged. Merged rather than overwritten (so a concurrent
+  // fixture's id survives) and remembered, so `afterAll` can restore it.
+  remoteCommunityPluginsBefore = await remote.readFile(REMOTE_COMMUNITY_PLUGINS);
+  const enabledIds = new Set<string>(parseIdList(remoteCommunityPluginsBefore));
+  enabledIds.add(FS_PLUGIN_ID);
+  await remote.writeFile(REMOTE_COMMUNITY_PLUGINS, JSON.stringify([...enabledIds]));
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+
+  // Building blocks rather than `connectAndOpenShadow`, because the shadow
+  // vault PATH is itself part of the subject matter here: it is the local root
+  // that `adapter.basePath` hands out to plugins.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+
+  // The adapter is only patched at layout-ready, AFTER the SSH connect. Every
+  // test below reads `app.vault.adapter`, so they must all run against the
+  // PATCHED adapter — a red obtained from the stock FileSystemAdapter would
+  // prove nothing about the product.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  if (remote) {
+    for (const note of [CONTROL_NOTE, PLUGIN_NOTE, REMOTE_ONLY_NOTE, REAL_PLUGIN_NOTE]) {
+      await remote.removeFile(note).catch(() => {});
+    }
+    await remote.rmrf(`.obsidian/plugins/${FS_PLUGIN_ID}`).catch(() => {});
+    // Restore the remote's plugin list so this spec leaves no fixture plugin
+    // enabled for whatever runs next.
+    if (remoteCommunityPluginsBefore === null) {
+      await remote.removeFile(REMOTE_COMMUNITY_PLUGINS).catch(() => {});
+    } else {
+      await remote
+        .writeFile(REMOTE_COMMUNITY_PLUGINS, remoteCommunityPluginsBefore)
+        .catch(() => {});
+    }
+    await remote.disconnect();
+  }
+  scaffold?.cleanup();
+});
+
+/** Tolerant read of a `community-plugins.json` body: absent / junk → no ids. */
+function parseIdList(raw: string | null): string[] {
+  if (raw === null) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/** `app.vault.adapter.basePath`, as the renderer sees it. */
+function readBasePath(page: Page): Promise<unknown> {
+  return page.evaluate(() => {
+    const app = (window as unknown as {
+      app?: { vault?: { adapter?: { basePath?: unknown } } };
+    }).app;
+    return app?.vault?.adapter?.basePath;
+  });
+}
+
+/** Is `rel` in the vault model (file explorer, search, other plugins)? */
+function inVaultModel(page: Page, rel: string): Promise<boolean> {
+  return page.evaluate((p) => {
+    const app = (window as unknown as {
+      app?: { vault?: { getAbstractFileByPath?: (p: string) => unknown } };
+    }).app;
+    return app?.vault?.getAbstractFileByPath?.(p) != null;
+  }, rel);
+}
+
+/** Absolute path of a vault-relative note on the LOCAL shadow disk. */
+function localPathOf(relative: string): string {
+  return path.join(shadowVaultPath, ...relative.split('/'));
+}
+
+test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429)', () => {
+  /**
+   * CONTROL — PREDICT PASS. The vault API is the one surface that IS fully
+   * patched (`AdapterManager.PATCHED_METHODS` includes `write`), so a write
+   * through it must reach the remote. If this is red, every red below is
+   * uninterpretable.
+   */
+  test('control: a write through the vault API reaches the remote', async () => {
+    const writeErr = await obsidian.page.evaluate(
+      async ({ rel, body }) => {
+        const app = (window as unknown as {
+          app?: { vault?: { adapter?: { write?: (p: string, d: string) => Promise<void> } } };
+        }).app;
+        const adapter = app?.vault?.adapter;
+        if (!adapter?.write) return 'no adapter on app.vault.adapter';
+        try {
+          await adapter.write(rel, body);
+          return null;
+        } catch (e) {
+          return String(e);
+        }
+      },
+      { rel: CONTROL_NOTE, body: CONTROL_BODY },
+    );
+    expect(writeErr, 'the vault-API write itself failed').toBeNull();
+
+    await expect
+      .poll(() => remote.readFile(CONTROL_NOTE), {
+        message:
+          'a write through app.vault.adapter.write() never reached the remote. This is ' +
+          'the CONTROL: the harness (connect, adapter patch, SFTP verifier) is broken, ' +
+          'so treat every other result in this file as void until it is fixed.',
+        timeout: 15_000,
+      })
+      .toBe(CONTROL_BODY);
+  });
+
+  /**
+   * PRECONDITION — PREDICT PASS. The whole raw-fs vehicle rests on Obsidian's
+   * renderer exposing Node. Asserted explicitly and never worked around: a spec
+   * that quietly stopped exercising `require('fs')` would go green while the
+   * bug it exists for got worse.
+   */
+  test('window.require is available in the renderer (vehicle precondition)', async () => {
+    const requireType = await obsidian.page.evaluate(
+      () => typeof (window as unknown as { require?: unknown }).require,
+    );
+    expect(
+      requireType,
+      'window.require is missing — this Obsidian build\'s renderer has no ' +
+      'nodeIntegration, so a community plugin could not call require("fs") at all and ' +
+      'the raw-fs half of this spec is untestable as written. Do NOT paper over this ' +
+      'with a fallback: fix the vehicle.',
+    ).toBe('function');
+  });
+
+  /**
+   * PREDICT PASS — #170 made `basePath` a defined, real directory (before it,
+   * plugins joining onto `undefined` crashed outright), and this pins that fix.
+   * It is also the premise of every red below: the path IS real, which is
+   * exactly why plugins trust it and why their writes vanish into it.
+   */
+  test('basePath is defined and points at a real existing directory', async () => {
+    const basePath = await readBasePath(obsidian.page);
+    expect(typeof basePath, 'adapter.basePath must be a string (#170)').toBe('string');
+    expect(String(basePath).length, 'adapter.basePath must not be empty').toBeGreaterThan(0);
+
+    const exists = await obsidian.page.evaluate(() => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const bp = (window as unknown as {
+        app?: { vault?: { adapter?: { basePath?: string } } };
+      }).app?.vault?.adapter?.basePath;
+      if (typeof bp !== 'string') throw new Error(`basePath is not a string: ${String(bp)}`);
+      return (req('fs') as FsLike).existsSync(bp);
+    });
+    expect(
+      exists,
+      `adapter.basePath (${String(basePath)}) is not an existing directory on disk`,
+    ).toBe(true);
+  });
+
+  /**
+   * THE DEFECT — PREDICT FAIL.
+   *
+   * The literal #429 operation: a plugin joins a name onto `adapter.basePath`
+   * and writes it with Node's `fs`. The only sane expectation — `basePath` is
+   * advertised as the vault's folder — is that the note is now in the user's
+   * vault, i.e. on the remote.
+   *
+   * The corroborating local-disk assertion runs FIRST and is expected to PASS:
+   * it proves the bytes landed in the shadow root rather than nowhere, so the
+   * remote assertion's red is conclusively "wrong destination" and not "the
+   * write failed".
+   */
+  test('a file a plugin writes under adapter.basePath reaches the REMOTE vault', async () => {
+    const wrote = await obsidian.page.evaluate((rel) => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const bp = (window as unknown as {
+        app?: { vault?: { adapter?: { basePath?: string } } };
+      }).app?.vault?.adapter?.basePath;
+      if (typeof bp !== 'string') throw new Error(`basePath is not a string: ${String(bp)}`);
+      const target = (req('path') as PathLike).join(bp, rel.name);
+      (req('fs') as FsLike).writeFileSync(target, rel.body);
+      return target;
+    }, { name: PLUGIN_NOTE, body: PLUGIN_BODY });
+    expect(typeof wrote, 'the in-page fs.writeFileSync did not return its target path').toBe(
+      'string',
+    );
+
+    // Corroboration (expected to PASS): the file DID land — on the local shadow
+    // disk. Without this, the red below could be read as "the write threw".
+    expect(
+      fs.existsSync(localPathOf(PLUGIN_NOTE)),
+      `the plugin's write did not even reach the local shadow disk ` +
+      `(${localPathOf(PLUGIN_NOTE)}) — the raw-fs vehicle is broken, so the remote ` +
+      'assertion below would be inconclusive',
+    ).toBe(true);
+
+    // The actual contract.
+    await expect
+      .poll(() => remote.exists(PLUGIN_NOTE), {
+        message:
+          `#429: a plugin wrote ${PLUGIN_NOTE} under adapter.basePath (it landed at ` +
+          `${localPathOf(PLUGIN_NOTE)}, asserted above) and it never reached the remote ` +
+          'vault. SftpDataAdapter.basePath (SftpDataAdapter.ts:155-166) hands out the ' +
+          'LOCAL shadow root, and nothing mirrors or watches the note tree, so the bytes ' +
+          'stay there forever. Do NOT weaken this assertion: the fix is a mirrored note ' +
+          'tree plus a local→remote watcher, or an FS-backed view of the remote.',
+        timeout: 20_000,
+      })
+      .toBe(true);
+
+    expect(
+      await remote.readFile(PLUGIN_NOTE),
+      'the note reached the remote, but with the wrong content',
+    ).toBe(PLUGIN_BODY);
+  });
+
+  /**
+   * COROLLARY — PREDICT FAIL. Set the remote aside: the file is not even in the
+   * vault the user is looking at. Nothing watches the shadow disk, so the note
+   * never enters `vault.fileMap` — it is absent from the file explorer, from
+   * search, and from every other plugin. From the user's seat it does not exist.
+   */
+  test('a file a plugin writes under adapter.basePath appears in the vault model', async () => {
+    await obsidian.page.evaluate((rel) => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const bp = (window as unknown as {
+        app?: { vault?: { adapter?: { basePath?: string } } };
+      }).app?.vault?.adapter?.basePath;
+      if (typeof bp !== 'string') throw new Error(`basePath is not a string: ${String(bp)}`);
+      const target = (req('path') as PathLike).join(bp, rel.name);
+      (req('fs') as FsLike).writeFileSync(target, rel.body);
+      return target;
+    }, { name: PLUGIN_NOTE, body: PLUGIN_BODY });
+
+    await expect
+      .poll(() => inVaultModel(obsidian.page, PLUGIN_NOTE), {
+        message:
+          `#429 corollary: ${PLUGIN_NOTE} was written under adapter.basePath but never ` +
+          'entered vault.fileMap — it is invisible in the file explorer, in search, and ' +
+          'to every other plugin. The note tree is virtual (SftpDataAdapter.ts:155-166) ' +
+          'and nothing watches the shadow disk for a plugin\'s raw fs writes.',
+        timeout: 20_000,
+      })
+      .toBe(true);
+  });
+
+  /**
+   * READ SIDE — PREDICT FAIL. The mirror image of the write bug and just as
+   * common in the wild: a plugin that opens a note with `fs.readFileSync`
+   * (importers, exporters, "open in external editor", anything that shells out)
+   * gets ENOENT for a note that is plainly sitting there in the vault.
+   *
+   * The note was seeded in `beforeAll`, before the shadow window connected, so
+   * it is in the model by construction — asserted FIRST, so a red on the `fs`
+   * read cannot be dismissed as "it just hadn't synced yet".
+   */
+  test('a note that exists on the REMOTE is readable via raw fs under basePath', async () => {
+    await expect
+      .poll(() => inVaultModel(obsidian.page, REMOTE_ONLY_NOTE), {
+        message:
+          `${REMOTE_ONLY_NOTE} was seeded on the remote before connect but never appeared ` +
+          'in the vault model — that is the remote→vault path being broken, a different ' +
+          '(and worse) bug than the one this test is about',
+        timeout: 30_000,
+      })
+      .toBe(true);
+
+    const read = await obsidian.page.evaluate((rel) => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const bp = (window as unknown as {
+        app?: { vault?: { adapter?: { basePath?: string } } };
+      }).app?.vault?.adapter?.basePath;
+      if (typeof bp !== 'string') throw new Error(`basePath is not a string: ${String(bp)}`);
+      const target = (req('path') as PathLike).join(bp, rel);
+      try {
+        return { body: (req('fs') as FsLike).readFileSync(target, 'utf8'), error: null as string | null };
+      } catch (e) {
+        return { body: null as string | null, error: String(e) };
+      }
+    }, REMOTE_ONLY_NOTE);
+
+    expect(
+      read.error,
+      `#429 read side: ${REMOTE_ONLY_NOTE} IS in the vault (asserted above) but raw fs ` +
+      'under adapter.basePath cannot see it — the note tree is virtual, never mirrored ' +
+      'to the shadow disk (SftpDataAdapter.ts:155-166). Every plugin that reads notes ' +
+      'with fs (importer, exporter, external editor) gets ENOENT for a note the user is ' +
+      'looking at.',
+    ).toBeNull();
+
+    expect(
+      read.body,
+      'the file was readable, but its content is not the note that is on the remote',
+    ).toBe(REMOTE_ONLY_BODY);
+  });
+
+  /**
+   * PREDICT FAIL (on the existence check).
+   *
+   * `getFullPath` is NOT in `AdapterManager.PATCHED_METHODS`
+   * (AdapterManager.ts:33-52), so the stock `FileSystemAdapter.getFullPath`
+   * survives: it joins the vault-relative path onto the local base and returns
+   * a path that LOOKS right and points at nothing.
+   *
+   * Shape and existence are asserted SEPARATELY on purpose, so the diagnostic
+   * distinguishes "wrong path" from "right-looking path with no file behind it"
+   * — the latter being the actual product bug.
+   */
+  test('getFullPath returns a path that resolves to the file', async () => {
+    const basePath = String(await readBasePath(obsidian.page));
+
+    const fullPath = await obsidian.page.evaluate((rel) => {
+      const adapter = (window as unknown as {
+        app?: { vault?: { adapter?: { getFullPath?: (p: string) => string } } };
+      }).app?.vault?.adapter;
+      if (typeof adapter?.getFullPath !== 'function') return null;
+      return adapter.getFullPath(rel);
+    }, FIXTURE_NOTE);
+
+    expect(fullPath, 'app.vault.adapter has no getFullPath at all').not.toBeNull();
+
+    // Shape — likely PASSES: the stock implementation does join onto basePath.
+    expect(
+      fullPath!.startsWith(basePath),
+      `getFullPath('${FIXTURE_NOTE}') = ${fullPath} is not even under basePath (${basePath})`,
+    ).toBe(true);
+
+    // Behaviour — PREDICTED RED.
+    const probe = await obsidian.page.evaluate((p) => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const fsMod = req('fs') as FsLike;
+      if (!fsMod.existsSync(p)) return { exists: false, body: null as string | null };
+      try {
+        return { exists: true, body: fsMod.readFileSync(p, 'utf8') as string | null };
+      } catch (e) {
+        return { exists: true, body: `<<unreadable: ${String(e)}>>` as string | null };
+      }
+    }, fullPath!);
+
+    expect(
+      probe.exists,
+      `#429: getFullPath('${FIXTURE_NOTE}') returned ${fullPath}, which does not exist. ` +
+      'The note lives in the remote vault, but getFullPath is not in ' +
+      'AdapterManager.PATCHED_METHODS (AdapterManager.ts:33-52), so the stock ' +
+      'FileSystemAdapter implementation hands out a local path for a file that is only ' +
+      'on the remote. Every plugin that resolves a TFile to a real path is broken by this.',
+    ).toBe(true);
+
+    expect(
+      probe.body,
+      `the file at getFullPath('${FIXTURE_NOTE}') is not the note that is on the remote`,
+    ).toBe(await remote.readFile(FIXTURE_NOTE));
+  });
+
+  /**
+   * PREDICT FAIL. `getFilePath` is likewise absent from
+   * `AdapterManager.PATCHED_METHODS` (AdapterManager.ts:33-52). It is the
+   * `file://` surface plugins hand to `<img>`, `shell.openPath`, external
+   * editors and `URL`-based tooling — and it resolves to nothing.
+   */
+  test('getFilePath returns a file:// URL that resolves', async () => {
+    const filePath = await obsidian.page.evaluate((rel) => {
+      const adapter = (window as unknown as {
+        app?: { vault?: { adapter?: { getFilePath?: (p: string) => unknown } } };
+      }).app?.vault?.adapter;
+      if (typeof adapter?.getFilePath !== 'function') return null;
+      return String(adapter.getFilePath(rel));
+    }, FIXTURE_NOTE);
+
+    expect(filePath, 'app.vault.adapter has no getFilePath at all').not.toBeNull();
+
+    // Shape, separately: a non-file:// return is a different bug from a
+    // file:// URL that points at nothing, and the message must say which.
+    expect(
+      filePath!.startsWith('file://'),
+      `getFilePath('${FIXTURE_NOTE}') returned ${filePath}, which is not a file:// URL`,
+    ).toBe(true);
+
+    const onDisk = fileURLToPath(filePath!);
+    expect(
+      fs.existsSync(onDisk),
+      `#429: getFilePath('${FIXTURE_NOTE}') = ${filePath} resolves to ${onDisk}, which does ` +
+      'not exist. The note is on the remote; getFilePath is unpatched ' +
+      '(AdapterManager.ts:33-52), so anything that follows that URL — an <img>, ' +
+      'shell.openPath, an external editor — opens nothing.',
+    ).toBe(true);
+  });
+
+  /**
+   * PREDICT FAIL. The most literal statement of "the plugin cannot see the
+   * vault": a directory listing of `basePath` returns the `.obsidian` config
+   * tree (which IS mirrored, per the #342 write-through) and not one note. The
+   * actual listing is quoted in the failure message, because the shape of what
+   * a plugin DOES see is the diagnosis.
+   */
+  test('a plugin reading the vault via fs.readdirSync(basePath) sees the vault\'s notes', async () => {
+    const entries = await obsidian.page.evaluate(() => {
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+      if (typeof req !== 'function') throw new Error('window.require is unavailable');
+      const bp = (window as unknown as {
+        app?: { vault?: { adapter?: { basePath?: string } } };
+      }).app?.vault?.adapter?.basePath;
+      if (typeof bp !== 'string') throw new Error(`basePath is not a string: ${String(bp)}`);
+      return (req('fs') as FsLike).readdirSync(bp);
+    });
+
+    expect(
+      entries,
+      `#429: fs.readdirSync(adapter.basePath) does not list ${FIXTURE_NOTE}. A plugin that ` +
+      'enumerates the vault through the filesystem sees only what is mirrored onto the ' +
+      'shadow disk (the .obsidian config tree) and none of the notes — the note tree is ' +
+      `virtual (SftpDataAdapter.ts:155-166). Actual listing: ${JSON.stringify(entries)}`,
+    ).toContain(FIXTURE_NOTE);
+  });
+
+  /**
+   * THE FIELD REPORT, AS A STANDING TEST — PREDICT FAIL.
+   *
+   * Vehicle (b): a genuine, loadable community plugin whose `onload()` runs the
+   * exact code from #429. Nothing is simulated — Obsidian's own plugin loader
+   * executes it, with its own `require('fs')`, against its own
+   * `this.app.vault.adapter`.
+   *
+   * Its binary was seeded on the remote in `beforeAll` and staged onto the
+   * shadow disk by the connect-time pull (`src/main.ts:664-670`); Obsidian only
+   * scans the plugins dir at startup, so the shadow vault is relaunched here to
+   * load it. This test runs LAST for that reason — it leaves behind a fresh
+   * window that no earlier test depends on.
+   */
+  test('REAL-PLUGIN REPRODUCTION: a plugin\'s fs.writeFileSync in onload() reaches the remote', async () => {
+    expect(
+      fs.existsSync(path.join(shadowVaultPath, '.obsidian', 'plugins', FS_PLUGIN_ID, 'main.js')),
+      'the reproduction plugin was never staged onto the shadow disk from the remote — ' +
+      'the connect-time plugin-binary pull (src/main.ts:664-670) did not run, so this ' +
+      'test has no vehicle. That is a product/harness failure to FIX, not to skip.',
+    ).toBe(true);
+
+    // Relaunch so Obsidian's startup scan picks the plugin up.
+    await obsidian.cleanup();
+    obsidian = await launchObsidian(shadowVaultPath);
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+    // `launchObsidian` flips restricted mode off, which loads everything listed
+    // in community-plugins.json. Belt and braces for builds where the
+    // freshly-pulled id has not yet made it into the enabled set: enable it
+    // explicitly, exactly as a user would from the Community plugins pane.
+    await obsidian.page.evaluate(async (id) => {
+      const plugins = (window as unknown as {
+        app?: {
+          plugins?: {
+            plugins?: Record<string, unknown>;
+            enablePluginAndSave?: (id: string) => Promise<void>;
+            enablePlugin?: (id: string) => Promise<void>;
+          };
+        };
+      }).app?.plugins;
+      if (!plugins) throw new Error('app.plugins unavailable in the shadow window');
+      if (plugins.plugins?.[id]) return;
+      if (plugins.enablePluginAndSave) await plugins.enablePluginAndSave(id);
+      else if (plugins.enablePlugin) await plugins.enablePlugin(id);
+      else throw new Error('app.plugins has no enablePlugin/enablePluginAndSave');
+    }, FS_PLUGIN_ID);
+
+    const readProbe = (): Promise<FsProbeResult | null> =>
+      obsidian.page.evaluate(
+        () =>
+          (window as unknown as { __E2E_FS_PROBE__?: FsProbeResult }).__E2E_FS_PROBE__ ?? null,
+      );
+
+    await expect
+      .poll(async () => (await readProbe()) !== null, {
+        message:
+          `the ${FS_PLUGIN_ID} plugin never ran its onload() in the shadow vault — without ` +
+          'that, the #429 reproduction has no vehicle at all',
+        timeout: 30_000,
+      })
+      .toBe(true);
+
+    const probe = await readProbe();
+    expect(probe, 'the plugin probe vanished between polls').not.toBeNull();
+
+    expect(
+      probe!.error,
+      'the plugin\'s fs.writeFileSync(path.join(adapter.basePath, note)) THREW inside ' +
+      'onload(): a community plugin doing the most ordinary thing imaginable cannot even ' +
+      `complete its write against a remote vault. Error: ${probe!.error}`,
+    ).toBeNull();
+
+    await expect
+      .poll(() => remote.exists(REAL_PLUGIN_NOTE), {
+        message:
+          `#429, verbatim: the ${FS_PLUGIN_ID} plugin ran fs.writeFileSync(path.join(` +
+          `this.app.vault.adapter.basePath, '${REAL_PLUGIN_NOTE}')) in onload(), the write ` +
+          `SUCCEEDED (it wrote ${probe!.wrote}), and the note is nowhere on the remote ` +
+          'vault. This is exactly what users report: "Claudian creates .md files in the ' +
+          'local folder instead of the remote vault". The fix belongs in the product — ' +
+          'mirror the note tree and watch it, or give basePath / getFullPath / getFilePath ' +
+          'an FS-backed view of the remote — never in this assertion.',
+        timeout: 30_000,
+      })
+      .toBe(true);
+
+    expect(
+      await remote.readFile(REAL_PLUGIN_NOTE),
+      'the plugin\'s note reached the remote, but with the wrong content',
+    ).toBe(REAL_PLUGIN_BODY);
+  });
+});

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -593,6 +593,102 @@ export async function runCommandViaPalette(
 }
 
 /**
+ * Expand a folder in the File Explorer and wait until its children are
+ * actually IN the vault model.
+ *
+ * The remote tree is loaded lazily, one level per expand: connect only
+ * materialises the root's immediate children, and every folder below
+ * that is an initially-childless `TFolder` until it is opened
+ * (`LazyFolderLoader`). The product's hook for that is a delegated
+ * capture-phase click listener that reads
+ * `target.closest('.nav-folder-title')` and its `data-path`
+ * (`src/main.ts:923-924`) — so clicking exactly that element is not a UI
+ * convenience here, it IS the trigger. Dispatching to any other node (or
+ * calling an internal API) would test something the user cannot do.
+ *
+ * Waits on `vault.fileMap` rather than on rendered `.nav-file-title`
+ * nodes, for the same reason `waitForShadowVaultLoaded` does: headless
+ * Obsidian's File Explorer paint is lazy/virtualised under Xvfb and
+ * races, while the model is what the load actually produces.
+ */
+export async function expandFolderInExplorer(
+  page: Page,
+  folderPath: string,
+  timeoutMs = 20_000,
+): Promise<void> {
+  const title = page.locator(`.nav-folder-title[data-path="${folderPath}"]`).first();
+  await title
+    .waitFor({ state: 'attached', timeout: Math.min(timeoutMs, 10_000) })
+    .catch(() => { /* absent title IS the finding — reported below */ });
+
+  if (await title.count() === 0) {
+    throw new Error(
+      `expandFolderInExplorer: no .nav-folder-title[data-path="${folderPath}"] in the ` +
+      'File Explorer — the folder was never materialised by the connect populate, ' +
+      `so there is nothing to expand.\n${await dumpFolderState(page, folderPath)}`,
+    );
+  }
+
+  await title.click();
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await countChildrenInFileMap(page, folderPath) >= 1) return;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  throw new Error(
+    `expandFolderInExplorer: "${folderPath}" still had no children in vault.fileMap ` +
+    `within ${timeoutMs}ms of clicking its .nav-folder-title — the lazy folder ` +
+    'load never landed.\n' +
+    (await dumpFolderState(page, folderPath)),
+  );
+}
+
+/** How many `fileMap` keys sit under `folderPath/`. */
+async function countChildrenInFileMap(page: Page, folderPath: string): Promise<number> {
+  return page
+    .evaluate((prefix) => {
+      const app = (window as unknown as {
+        app?: { vault?: { fileMap?: Record<string, unknown> } };
+      }).app;
+      const keys = Object.keys(app?.vault?.fileMap ?? {});
+      return keys.filter((k) => k.startsWith(`${prefix}/`)).length;
+    }, folderPath)
+    .catch(() => 0);
+}
+
+/**
+ * What IS in `fileMap` around `folderPath`, for the timeout message. A
+ * bare "0 children" is ambiguous between "the folder isn't in the model
+ * at all" (populate bug) and "it's there but the expand didn't load it"
+ * (lazy-load bug); listing the folder itself, everything under its
+ * prefix, and the `data-path`s the explorer is actually rendering
+ * separates the two in one CI round.
+ */
+async function dumpFolderState(page: Page, folderPath: string): Promise<string> {
+  const state = await page
+    .evaluate((prefix) => {
+      const app = (window as unknown as {
+        app?: { vault?: { fileMap?: Record<string, unknown> } };
+      }).app;
+      const keys = Object.keys(app?.vault?.fileMap ?? {});
+      return {
+        fileMapKeys: keys.length,
+        folderItself: keys.includes(prefix),
+        under: keys.filter((k) => k.startsWith(`${prefix}/`)).slice(0, 20),
+        sample: keys.slice(0, 20),
+        navFolderTitles: Array.from(document.querySelectorAll('.nav-folder-title'))
+          .map((el) => el.getAttribute('data-path'))
+          .slice(0, 20),
+      };
+    }, folderPath)
+    .catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
+
+  return `vault.fileMap around "${folderPath}": ${JSON.stringify(state)}`;
+}
+
+/**
  * Diagnostic snapshot for the "File Explorer empty after a successful
  * SFTP connect+populate" failure. The bare Playwright "element(s) not
  * found" can't distinguish three very different root causes:

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -110,6 +110,24 @@ export async function launchObsidian(
   await ensurePluginLoaded(page, 'remote-ssh');
   await waitForPluginLoaded(page, 'remote-ssh', 30_000);
 
+  // `dismissTrustDialog` (inside ensurePluginLoaded) clicks "Trust author and
+  // enable plugins", and Obsidian's own reaction is to OPEN ITS SETTINGS
+  // DIALOG on the Community-plugins tab. That is a `.modal-container.mod-dim`
+  // full-window overlay, and Playwright cannot click through it: every later
+  // File-Explorer / editor click dies with "...intercepts pointer events".
+  //
+  // The suite has been running under that overlay in every window since the
+  // trust-dismiss path was added. It went unnoticed because model-level probes
+  // (page.evaluate over vault/metadataCache) and Node-side fetches are immune —
+  // so only click-driven tests were affected, and those just hung. `demo.spec`
+  // is the one place that ever knew (it presses Esc, with a comment saying
+  // exactly this); every other spec simply ate it.
+  //
+  // Close it here, once, for every spec. It logs whatever it closed, so a modal
+  // that IS meaningful (a host-key prompt, PendingPluginsModal) surfaces in the
+  // CI log instead of being silently swallowed.
+  await dismissBlockingModals(page);
+
   const cleanup = async () => {
     try { await browser.close(); } catch { /* best effort */ }
     if (!proc.killed) {
@@ -422,6 +440,118 @@ async function dismissTrustDialog(page: Page): Promise<boolean> {
   // button click "succeeded".
   await trustBtn.waitFor({ state: 'detached', timeout: 8_000 }).catch(() => {});
   return true;
+}
+
+/**
+ * Close any Obsidian modal that is covering the workspace, and report how many
+ * were closed.
+ *
+ * WHY THIS EXISTS (it is a HARNESS concern, not a product assertion)
+ * -----------------------------------------------------------------
+ * `launchObsidian` → `ensurePluginLoaded` → `dismissTrustDialog` clicks
+ * "Trust author and enable plugins". Obsidian's own response to that gesture is
+ * to OPEN ITS SETTINGS DIALOG on the Community-plugins tab — `demo.spec.ts:131`
+ * has known this for as long as it has existed ("Esc closes the Settings panel
+ * auto-opened by the trust-dismiss path") and was the only spec that ever acted
+ * on it. That dialog is a `.modal-container.mod-dim`: a full-viewport overlay
+ * that INTERCEPTS POINTER EVENTS for the whole window. Every subsequent
+ * `click()` on a File Explorer row or an editor link is then un-actionable, and
+ * Playwright reports it as
+ *
+ *     <div data-setting-id="plugins" class="vertical-tab-nav-item"> from
+ *     <div class="modal-container mod-dim"> subtree intercepts pointer events
+ *
+ * — i.e. the element the test wanted is visible, enabled and stable, and the
+ * click still cannot land. Model-level probes (`page.evaluate` over `vault` /
+ * `metadataCache`) are unaffected, which is exactly why a spec can pass all of
+ * its index assertions and fail only the ones that touch the UI.
+ *
+ * A covered element is not a product defect. Dismissing the overlay restores a
+ * precondition the tests always assumed; it does not relax anything they assert.
+ *
+ * WHAT IT DOES NOT DO
+ * -------------------
+ * It does not silently swallow product surfaces. Every modal it closes is
+ * `console.warn`'d with its title, its active settings tab and its classes, so
+ * a modal nobody expected (a `PendingPluginsModal`, a host-key prompt, a write
+ * conflict) shows up in the CI log against the spec that hit it rather than
+ * vanishing. If Escape does not close a modal, that is logged too and the loop
+ * gives up rather than spinning — the click that follows then fails with
+ * Playwright's own intercept diagnostic, which is the honest outcome.
+ *
+ * Do NOT call this while a palette / Quick Switcher is deliberately open —
+ * those are `.modal-container`s too and Escape will close them. Call it BEFORE
+ * an interaction sequence, never inside one.
+ *
+ * @returns how many modals were actually closed (0 when the workspace was clear).
+ */
+export async function dismissBlockingModals(
+  page: Page,
+  timeoutMs = 10_000,
+): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  let closed = 0;
+
+  // Bounded: a handful of stacked modals is already pathological, and an
+  // Escape-proof modal must fail LOUDLY rather than spin until the deadline.
+  for (let attempt = 0; attempt < 5 && Date.now() < deadline; attempt++) {
+    const open = await describeOpenModals(page);
+    if (open.length === 0) break;
+
+    console.warn(
+      `[e2e] dismissBlockingModals: ${open.length} Obsidian modal(s) are covering ` +
+      'the workspace and would intercept every click. Closing with Escape. ' +
+      `Modal(s): ${JSON.stringify(open)}`,
+    );
+    await page.keyboard.press('Escape').catch(() => { /* best effort */ });
+
+    // Obsidian tears modals down asynchronously; poll for the count to drop
+    // rather than sleeping a fixed amount.
+    const settleBy = Math.min(Date.now() + 3_000, deadline);
+    let remaining = open.length;
+    while (Date.now() < settleBy) {
+      remaining = (await describeOpenModals(page)).length;
+      if (remaining < open.length) break;
+      await new Promise((r) => setTimeout(r, 150));
+    }
+
+    if (remaining >= open.length) {
+      console.warn(
+        '[e2e] dismissBlockingModals: Escape did NOT close ' +
+        `${JSON.stringify(open)} — it is not Escape-dismissable. Leaving it up.`,
+      );
+      break;
+    }
+    closed += open.length - remaining;
+  }
+
+  return closed;
+}
+
+/**
+ * One identifying line per open `.modal-container`, for the warn above. The
+ * title, the active settings tab (`data-setting-id` — the field that pins
+ * Obsidian's own auto-opened Settings dialog as the culprit) and the classes
+ * are enough to tell that dialog apart from a genuine product modal.
+ */
+async function describeOpenModals(page: Page): Promise<string[]> {
+  return page
+    .evaluate(() =>
+      Array.from(document.querySelectorAll('.modal-container')).map((c) => {
+        const title = c.querySelector('.modal-title')?.textContent?.trim() ?? '';
+        const activeTab = c
+          .querySelector('.vertical-tab-nav-item.is-active')
+          ?.getAttribute('data-setting-id') ?? '';
+        const modal = c.querySelector('.modal');
+        return JSON.stringify({
+          title: title || '(untitled)',
+          settingTab: activeTab || null,
+          containerClass: c.className,
+          modalClass: modal?.className ?? null,
+        });
+      }),
+    )
+    .catch(() => []);
 }
 
 /**

--- a/plugin/e2e/helpers/remote-fixtures.ts
+++ b/plugin/e2e/helpers/remote-fixtures.ts
@@ -1,0 +1,248 @@
+import * as crypto from 'node:crypto';
+import * as zlib from 'node:zlib';
+import type { RemoteVerifier } from './remote-verifier';
+
+/**
+ * Binary fixtures for the E2E suite: real, decodable files rather than
+ * placeholder blobs.
+ *
+ * Why this exists: `reflect.spec.ts` seeds its image with a hand-rolled
+ * "PNG" that is a 1x1 header followed by zero padding. It is enough to
+ * prove *bytes moved*, and nothing more — nothing can decode it, so no
+ * spec built on it can ever assert what a user actually cares about
+ * ("the image renders at 2048x1536", "the thumbnail resized"). Every
+ * fixture here is the real format, so an assertion can be made against
+ * the thing itself.
+ */
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Standard PNG/zlib CRC-32 table (polynomial 0xEDB88320). */
+const CRC_TABLE = ((): Uint32Array => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) !== 0 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buf: Buffer): number {
+  let c = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) {
+    c = CRC_TABLE[(c ^ buf[i]) & 0xff] ^ (c >>> 8);
+  }
+  return (c ^ 0xffffffff) >>> 0;
+}
+
+/** One PNG chunk: length, 4-byte ASCII type, payload, CRC of type+payload. */
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length, 0);
+
+  const typeBytes = Buffer.from(type, 'ascii');
+
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(Buffer.concat([typeBytes, data])), 0);
+
+  return Buffer.concat([length, typeBytes, data, crc]);
+}
+
+/**
+ * A REAL PNG of exactly `width` x `height`: signature, IHDR (8-bit RGBA,
+ * colour type 6), a single zlib-deflated IDAT of unfiltered scanlines,
+ * IEND — every chunk CRC-correct. Any decoder (including Obsidian's
+ * `<img>`) will render it, so a spec can assert on `naturalWidth` /
+ * `naturalHeight`, not merely on byte count.
+ *
+ * Pixels are RANDOM on purpose. A solid-colour image of any size
+ * deflates to a few hundred bytes, which quietly destroys the premise of
+ * every "large image" test: the payload the transport actually carries
+ * would be tiny. Random RGB is incompressible, so the file size tracks
+ * the dimensions — a 2048x1536 lands in the multi-MB range (~12 MB), the
+ * regime the streaming/chunking paths are supposed to handle.
+ *
+ * Alpha is forced opaque so the image is visible when rendered.
+ */
+export function makePng(width: number, height: number): Buffer {
+  if (!Number.isInteger(width) || !Number.isInteger(height) || width < 1 || height < 1) {
+    throw new Error(`makePng: width/height must be positive integers (got ${width}x${height})`);
+  }
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 6; // colour type 6 = truecolour + alpha (RGBA)
+  ihdr[10] = 0; // compression: deflate (the only defined value)
+  ihdr[11] = 0; // filter: adaptive (the only defined value)
+  ihdr[12] = 0; // interlace: none
+
+  // Raw scanlines: each row is a filter byte (0 = None) + width RGBA pixels.
+  const stride = width * 4;
+  const raw = Buffer.alloc(height * (stride + 1));
+  const pixels = crypto.randomBytes(height * stride);
+  for (let y = 0; y < height; y++) {
+    const rowStart = y * (stride + 1);
+    raw[rowStart] = 0;
+    pixels.copy(raw, rowStart + 1, y * stride, (y + 1) * stride);
+    for (let x = 0; x < width; x++) {
+      raw[rowStart + 1 + x * 4 + 3] = 0xff;
+    }
+  }
+
+  return Buffer.concat([
+    PNG_SIGNATURE,
+    pngChunk('IHDR', ihdr),
+    pngChunk('IDAT', zlib.deflateSync(raw)),
+    pngChunk('IEND', Buffer.alloc(0)),
+  ]);
+}
+
+/**
+ * A minimal valid SVG of the given intrinsic size. Text, not bytes — SVG
+ * is the case where the vault stores an *image* that is really a UTF-8
+ * document, so it exercises the text path while still being an image to
+ * the renderer.
+ */
+export function makeSvg(width: number, height: number): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" ` +
+    `viewBox="0 0 ${width} ${height}">`,
+    `  <rect width="${width}" height="${height}" fill="#2b3a55"/>`,
+    `  <circle cx="${width / 2}" cy="${height / 2}" r="${Math.min(width, height) / 4}" fill="#e8b04b"/>`,
+    '</svg>',
+    '',
+  ].join('\n');
+}
+
+/**
+ * A minimal but VALID single-page PDF: header, catalog, pages, page (with
+ * a content stream and a Helvetica font), a byte-accurate xref table,
+ * trailer, `%%EOF`. Offsets are computed from the assembled bytes rather
+ * than hardcoded, so the file survives edits to the object bodies.
+ *
+ * Latin-1 throughout: PDF offsets are BYTE offsets, and the binary
+ * marker comment in the header is above U+007F — encoding it as UTF-8
+ * would shift every xref entry and produce a file strict readers reject.
+ */
+export function makePdf(): Buffer {
+  const content = 'BT /F1 24 Tf 72 700 Td (remote-ssh e2e fixture) Tj ET\n';
+
+  const bodies = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] ' +
+    '/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>',
+    `<< /Length ${Buffer.byteLength(content, 'latin1')} >>\nstream\n${content}endstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+
+  // `%âãÏÓ` — the conventional high-byte comment marking the file binary.
+  let pdf = '%PDF-1.4\n%âãÏÓ\n';
+  const offsets: number[] = [];
+  for (let i = 0; i < bodies.length; i++) {
+    offsets.push(Buffer.byteLength(pdf, 'latin1'));
+    pdf += `${i + 1} 0 obj\n${bodies[i]}\nendobj\n`;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf, 'latin1');
+  const size = bodies.length + 1; // +1 for the free object 0
+  pdf += `xref\n0 ${size}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (const offset of offsets) {
+    pdf += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${size} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return Buffer.from(pdf, 'latin1');
+}
+
+export interface FakePluginOptions {
+  /** Plugin id — also the `.obsidian/plugins/<id>/` directory name. */
+  id: string;
+  /**
+   * Manifest version. A REAL parameter, not decoration: plugin-code
+   * convergence is VERSION-ORDERED (`ShadowVaultBootstrap.ts:762,806`
+   * compares manifest versions to decide which copy wins), so a spec that
+   * wants to pin which side of a local/remote race survives must control it.
+   */
+  version: string;
+  /**
+   * Body of `onload()`. Defaults to a probe that stamps
+   * `window.__E2E_PROBE__ = { id: '<id>', loaded: true }` — i.e. proof
+   * that Obsidian actually EXECUTED this plugin, which no on-disk
+   * assertion can give you. Note the default does NOT expose the version;
+   * a version-ordering spec should pass its own body (e.g. one that also
+   * writes `version`).
+   */
+  onloadBody?: string;
+}
+
+export interface FakePluginFiles {
+  'manifest.json': string;
+  'main.js': string;
+  'styles.css': string;
+}
+
+/**
+ * The three files of a genuinely LOADABLE Obsidian community plugin.
+ * `main.js` is CommonJS exporting a real `obsidian.Plugin` subclass, so
+ * Obsidian's loader will run it — the point being that a spec can assert
+ * a third-party plugin *works* against a remote vault, not merely that
+ * its files were copied around.
+ */
+export function makeFakePlugin(opts: FakePluginOptions): FakePluginFiles {
+  const { id, version } = opts;
+  const onloadBody = opts.onloadBody
+    ?? `window.__E2E_PROBE__ = { id: ${JSON.stringify(id)}, loaded: true };`;
+
+  const manifest = {
+    id,
+    name: `E2E fixture ${id}`,
+    version,
+    minAppVersion: '1.5.0',
+    description: 'Disposable plugin fixture seeded by the remote-ssh E2E suite.',
+    author: 'remote-ssh e2e',
+    isDesktopOnly: true,
+  };
+
+  const mainJs = [
+    "const obsidian = require('obsidian');",
+    '',
+    'module.exports = class extends obsidian.Plugin {',
+    '  async onload() {',
+    `    ${onloadBody}`,
+    '  }',
+    '};',
+    '',
+  ].join('\n');
+
+  return {
+    'manifest.json': `${JSON.stringify(manifest, null, 2)}\n`,
+    'main.js': mainJs,
+    'styles.css': `/* ${id} v${version} — e2e fixture */\n`,
+  };
+}
+
+/**
+ * Seed a plugin's files under `.obsidian/plugins/<id>/` on the REMOTE, via
+ * the ground-truth SFTP connection (not through the plugin). `mkdirp`
+ * first: SFTP will not create the intermediate directories, and a fresh
+ * fixture vault has no `.obsidian/plugins/` at all.
+ */
+export async function seedPluginOnRemote(
+  remote: RemoteVerifier,
+  id: string,
+  files: Record<string, string>,
+): Promise<void> {
+  const dir = `.obsidian/plugins/${id}`;
+  await remote.mkdirp(dir);
+  for (const [name, content] of Object.entries(files)) {
+    await remote.writeFile(`${dir}/${name}`, content);
+  }
+}

--- a/plugin/e2e/helpers/remote-reset.ts
+++ b/plugin/e2e/helpers/remote-reset.ts
@@ -1,0 +1,199 @@
+import type { RemoteVerifier } from './remote-verifier';
+
+/**
+ * Force-revert of the REMOTE fixture state a spec seeded.
+ *
+ * Why this has to exist at all
+ * ---------------------------
+ * The docker test vault is SHARED, single-worker, and PERSISTS across specs
+ * within a run. Anything a spec leaves on the remote is inherited by every spec
+ * that runs after it — and a fixture plugin left enabled in the remote
+ * `.obsidian/community-plugins.json` is not inert: the next spec's shadow vault
+ * PULLS it in at connect (`src/main.ts:632-670` → pullCommunityPlugins →
+ * pullPluginBinaries), stages its code, and loads it. That is how a fixture from
+ * one spec reddens an unrelated, previously-passing spec (`sync.spec.ts`).
+ *
+ * And the remote does NOT clean itself up. `pushCommunityPlugins`
+ * (`ShadowVaultBootstrap.ts:698-702`) computes a monotonic UNION of remote+local:
+ * the enabled list can only ever GROW. Deleting a fixture plugin locally cannot
+ * remove it from the remote list — that is exactly the product defect
+ * `plugin-code-roundtrip.spec.ts` test 6 pins, and it means test-harness cleanup
+ * is the ONLY thing standing between a fixture and the rest of the suite.
+ *
+ * So every reverting step here is deliberately unconditional and independent:
+ * each is wrapped so one failure cannot abort the rest, and the whole thing runs
+ * from `afterAll` (never `afterEach`, never inside a test) so a FAILING test —
+ * which is the expected outcome for the specs that pin defects — still cleans up.
+ */
+
+/** The shared (identity-scoped) enabled-plugin list on the remote. */
+export const COMMUNITY_PLUGINS_REL = '.obsidian/community-plugins.json';
+
+/** Root of the per-device config subtree: `.obsidian/user/<clientId>/…`. */
+const USER_ROOT_REL = '.obsidian/user';
+
+/**
+ * The remote's `community-plugins.json` exactly as it was before a spec touched
+ * it. `raw === null` means the file DID NOT EXIST — restoring must then delete
+ * it, not write `[]`: an empty list and no list are different inputs to
+ * `pullCommunityPlugins`, and a fresh docker vault has no list at all.
+ */
+export interface CommunityPluginsSnapshot {
+  readonly raw: string | null;
+}
+
+/** Tolerant read of a `community-plugins.json` body: absent / junk → no ids. */
+export function parseIdList(raw: string | null): string[] {
+  if (raw === null) return [];
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Capture the remote enabled list byte-for-byte (null when absent). */
+export async function captureCommunityPlugins(
+  remote: RemoteVerifier,
+): Promise<CommunityPluginsSnapshot> {
+  return { raw: await remote.readFile(COMMUNITY_PLUGINS_REL) };
+}
+
+/**
+ * Put the remote enabled list back to EXACTLY the captured bytes — or delete it
+ * if there was no such file. Byte-exact rather than "remove our ids" on purpose:
+ * a re-serialised list differs in whitespace and member order from whatever
+ * wrote it, and the point is that the next spec sees the remote it would have
+ * seen had this spec never run.
+ */
+export async function restoreCommunityPlugins(
+  remote: RemoteVerifier,
+  snapshot: CommunityPluginsSnapshot,
+): Promise<void> {
+  if (snapshot.raw === null) {
+    await remote.removeFile(COMMUNITY_PLUGINS_REL);
+  } else {
+    await remote.writeFile(COMMUNITY_PLUGINS_REL, snapshot.raw);
+  }
+}
+
+/** Drop `ids` from the remote enabled list, leaving every other id untouched. */
+export async function dropFromCommunityPlugins(
+  remote: RemoteVerifier,
+  ids: readonly string[],
+): Promise<void> {
+  const raw = await remote.readFile(COMMUNITY_PLUGINS_REL);
+  if (raw === null) return;
+  const kept = parseIdList(raw).filter((id) => !ids.includes(id));
+  await remote.writeFile(COMMUNITY_PLUGINS_REL, `${JSON.stringify(kept)}\n`);
+}
+
+/**
+ * Remove every trace of a fixture plugin's CODE from the remote: the shared
+ * identity path `.obsidian/plugins/<id>/`, and any per-device copy the product
+ * made under `.obsidian/user/<clientId>/plugins/<id>/` (`PathMapper.ts:19,289`).
+ *
+ * The client dirs are DISCOVERED (`listDir('.obsidian/user')`), never computed:
+ * the client id is derived at runtime by the plugin, and a harness that
+ * re-derived it (from the hostname, say) would silently miss the real directory
+ * the moment that derivation changed — leaving the fixture behind while looking
+ * like it had cleaned up.
+ *
+ * Does NOT touch the enabled list: `afterAll` restores that byte-exactly from a
+ * snapshot, and the `beforeAll` pre-clean uses `dropFromCommunityPlugins`.
+ */
+export async function purgeFixturePlugin(remote: RemoteVerifier, id: string): Promise<void> {
+  await remote.rmrf(`.obsidian/plugins/${id}`);
+  for (const clientDir of await remote.listDir(USER_ROOT_REL)) {
+    await remote.rmrf(`${USER_ROOT_REL}/${clientDir}/plugins/${id}`);
+  }
+}
+
+/**
+ * Remove every remote entry under `dir` whose name starts with one of
+ * `prefixes` — the notes and folders a spec seeds under a run STAMP. Prefix
+ * matching (rather than the exact names of THIS run) is what makes a crashed
+ * previous run, whose stamp is long gone, still cleanable.
+ */
+export async function purgePrefixedEntries(
+  remote: RemoteVerifier,
+  prefixes: readonly string[],
+  dir = '',
+): Promise<void> {
+  if (prefixes.length === 0) return;
+  for (const entry of await remote.listDir(dir)) {
+    if (!prefixes.some((prefix) => entry.startsWith(prefix))) continue;
+    await remote.rmrf(dir ? `${dir}/${entry}` : entry);
+  }
+}
+
+/** Everything a spec puts on the shared remote, and therefore owes back. */
+export interface FixtureFootprint {
+  /** Plugin ids the spec seeds under `.obsidian/plugins/`. */
+  readonly pluginIds: readonly string[];
+  /**
+   * Filename PREFIXES (not the stamped names of a single run) of the notes and
+   * folders the spec seeds at the vault root — e.g. `e2e-fs-` for
+   * `e2e-fs-<stamp>-control.md`.
+   */
+  readonly notePrefixes?: readonly string[];
+}
+
+/** Run `step`, swallowing its failure: one broken step must not abort the rest. */
+async function attempt(label: string, step: () => Promise<void>): Promise<void> {
+  try {
+    await step();
+  } catch (err) {
+    // Cleanup is best-effort by construction — an `afterAll` that throws turns
+    // one honest red into a cascade of harness reds and buries the real one.
+    console.warn(`[remote-reset] ${label} failed: ${String(err)}`);
+  }
+}
+
+/**
+ * DEFENSIVE PRE-CLEAN, for `beforeAll`. A previous run that crashed (or was
+ * killed mid-spec) leaves its fixtures on the shared remote; without this, a
+ * spec inherits them and its very first assertion is already testing someone
+ * else's garbage.
+ *
+ * Call this BEFORE `captureCommunityPlugins`, so the snapshot — and therefore
+ * what `afterAll` restores — is a CLEAN baseline rather than one that still
+ * names the fixture ids.
+ */
+export async function preCleanRemoteFixtures(
+  remote: RemoteVerifier,
+  footprint: FixtureFootprint,
+): Promise<void> {
+  for (const id of footprint.pluginIds) {
+    await attempt(`pre-clean plugin ${id}`, () => purgeFixturePlugin(remote, id));
+  }
+  await attempt('pre-clean enabled list', () =>
+    dropFromCommunityPlugins(remote, footprint.pluginIds),
+  );
+  await attempt('pre-clean seeded notes', () =>
+    purgePrefixedEntries(remote, footprint.notePrefixes ?? []),
+  );
+}
+
+/**
+ * FULL REVERT, for `afterAll`. Runs regardless of how the tests ended (Playwright
+ * runs `afterAll` after failures too), and every step is independently guarded so
+ * a failure in one cannot skip the others — a half-reverted remote is precisely
+ * the cross-spec contamination this file exists to prevent.
+ */
+export async function resetRemoteFixtures(
+  remote: RemoteVerifier,
+  footprint: FixtureFootprint,
+  snapshot: CommunityPluginsSnapshot,
+): Promise<void> {
+  await attempt('restore community-plugins.json', () =>
+    restoreCommunityPlugins(remote, snapshot),
+  );
+  for (const id of footprint.pluginIds) {
+    await attempt(`purge plugin ${id}`, () => purgeFixturePlugin(remote, id));
+  }
+  await attempt('purge seeded notes', () =>
+    purgePrefixedEntries(remote, footprint.notePrefixes ?? []),
+  );
+}

--- a/plugin/e2e/helpers/remote-verifier.ts
+++ b/plugin/e2e/helpers/remote-verifier.ts
@@ -1,4 +1,4 @@
-import { Client } from 'ssh2';
+import { Client, type FileEntryWithStats, type SFTPWrapper } from 'ssh2';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -165,6 +165,85 @@ export class RemoteVerifier {
     });
   }
 
+  /**
+   * Binary read. The utf8 `readFile` above round-trips bytes through a
+   * string decode, which silently mangles any non-UTF8 payload (a PNG
+   * comes back with U+FFFD where its IDAT bytes were) — so a spec that
+   * wants to prove "the image that landed on the remote is byte-identical
+   * to the one the vault reflected" has to read it as a Buffer.
+   * Returns null if the path is missing.
+   */
+  async readBinaryFile(relativePath: string): Promise<Buffer | null> {
+    const fullPath = `${TEST_VAULT_REMOTE}/${relativePath}`;
+    return new Promise((resolve) => {
+      this.requireClient().sftp((err, sftp) => {
+        if (err) { resolve(null); return; }
+        sftp.readFile(fullPath, (readErr, data) => {
+          sftp.end();
+          if (readErr || !data) { resolve(null); return; }
+          resolve(data);
+        });
+      });
+    });
+  }
+
+  /**
+   * `mkdir -p` on the remote. SFTP's `mkdir` is a single POSIX
+   * `mkdir(2)`: it does NOT create intermediate directories, so
+   * `writeFile('Sub/x.md')` against a vault with no `Sub/` fails with a
+   * bare ENOENT that reads like a broken connection. Creates each path
+   * segment in turn and tolerates the segments that already exist.
+   *
+   * "Already exists" cannot be discriminated by code alone — the server
+   * reports it as SSH_FX_FAILURE, the same generic code as a real
+   * failure — so a failed `mkdir` is only swallowed once a `stat`
+   * confirms a directory is genuinely sitting there.
+   */
+  async mkdirp(relativePath: string): Promise<void> {
+    const segments = relativePath.split('/').filter((s) => s.length > 0);
+    await this.withSftp(async (sftp) => {
+      let current = TEST_VAULT_REMOTE;
+      for (const segment of segments) {
+        current += `/${segment}`;
+        await mkdirTolerant(sftp, current);
+      }
+    });
+  }
+
+  /**
+   * `rm -rf` on the remote: depth-first unlink of files, rmdir of the
+   * directories on the way back up. Tolerant of a missing path (an
+   * `afterAll` must not turn a red test into two red tests) and of a
+   * plain file being passed instead of a directory.
+   */
+  async rmrf(relativePath: string): Promise<void> {
+    await this.withSftp((sftp) =>
+      removeRecursive(sftp, `${TEST_VAULT_REMOTE}/${relativePath}`),
+    );
+  }
+
+  /**
+   * Force a file's mtime (POSIX seconds, as SFTP carries it). The
+   * cache-staleness scenarios need the remote to report the SAME mtime
+   * across two different contents — otherwise the mtime moves on its own
+   * and any cache keyed on it invalidates for the wrong reason, so the
+   * test would pass without exercising the thing it names. atime is set
+   * to the same value; nothing here reads it.
+   */
+  async setMtime(relativePath: string, mtimeSeconds: number): Promise<void> {
+    const fullPath = `${TEST_VAULT_REMOTE}/${relativePath}`;
+    return new Promise((resolve, reject) => {
+      this.requireClient().sftp((err, sftp) => {
+        if (err) { reject(err); return; }
+        sftp.utimes(fullPath, mtimeSeconds, mtimeSeconds, (utimesErr) => {
+          sftp.end();
+          if (utimesErr) reject(utimesErr);
+          else resolve();
+        });
+      });
+    });
+  }
+
   /** Delete a file on the remote (for test cleanup). */
   async removeFile(relativePath: string): Promise<void> {
     const fullPath = `${TEST_VAULT_REMOTE}/${relativePath}`;
@@ -188,4 +267,65 @@ export class RemoteVerifier {
     if (!this.client) throw new Error('RemoteVerifier: not connected');
     return this.client;
   }
+
+  /**
+   * Run `fn` against ONE sftp session and close it afterwards. The
+   * single-shot methods above open a session per call, which is fine for
+   * one round-trip; the multi-round-trip ones (`mkdirp` walking segments,
+   * `rmrf` recursing a tree) would otherwise open a channel per node and
+   * exhaust the server's channel limit on a deep tree.
+   */
+  private withSftp<T>(fn: (sftp: SFTPWrapper) => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.requireClient().sftp((err, sftp) => {
+        if (err) { reject(err); return; }
+        fn(sftp).then(
+          (value) => { sftp.end(); resolve(value); },
+          (fnErr: unknown) => { sftp.end(); reject(fnErr); },
+        );
+      });
+    });
+  }
+}
+
+/** `mkdir` one segment, treating "it's already a directory" as success. */
+function mkdirTolerant(sftp: SFTPWrapper, fullPath: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    sftp.mkdir(fullPath, (err) => {
+      if (!err) { resolve(); return; }
+      sftp.stat(fullPath, (statErr, attrs) => {
+        if (!statErr && attrs?.isDirectory()) resolve();
+        else reject(err);
+      });
+    });
+  });
+}
+
+/**
+ * Depth-first delete of `fullPath`. A missing path resolves silently —
+ * cleanup is best-effort by design.
+ */
+async function removeRecursive(sftp: SFTPWrapper, fullPath: string): Promise<void> {
+  const isDir = await new Promise<boolean | null>((resolve) => {
+    sftp.lstat(fullPath, (err, attrs) => {
+      if (err || !attrs) { resolve(null); return; } // ENOENT — nothing to remove
+      resolve(attrs.isDirectory());
+    });
+  });
+  if (isDir === null) return;
+
+  if (!isDir) {
+    await new Promise<void>((resolve) => { sftp.unlink(fullPath, () => resolve()); });
+    return;
+  }
+
+  const entries = await new Promise<FileEntryWithStats[]>((resolve) => {
+    sftp.readdir(fullPath, (err, list) => { resolve(err || !list ? [] : list); });
+  });
+  for (const entry of entries) {
+    if (entry.filename === '.' || entry.filename === '..') continue;
+    await removeRecursive(sftp, `${fullPath}/${entry.filename}`);
+  }
+
+  await new Promise<void>((resolve) => { sftp.rmdir(fullPath, () => resolve()); });
 }

--- a/plugin/e2e/images.spec.ts
+++ b/plugin/e2e/images.spec.ts
@@ -6,6 +6,7 @@ import {
   waitForShadowVaultLoaded,
   expandFolderInExplorer,
   runCommandViaPalette,
+  dismissBlockingModals,
   type ObsidianHandle,
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
@@ -105,13 +106,10 @@ import { logPathFor } from './helpers/log-oracle';
  *      we control. Whatever this test does IS the finding, and it tells the
  *      maintainer whether the fix for (5) is "walk deeper on connect" or
  *      "invalidate metadata after a lazy insert".
- *      Every step of it is under an explicit `withDeadline`, because the config
- *      sets no `actionTimeout` (so Playwright's default is 0 = WAIT FOREVER) and
- *      `expandFolderInExplorer` clicks a `.nav-folder-title` it has only waited
- *      for as *attached* — under Xvfb's virtualised File Explorer that click can
- *      block indefinitely, which is exactly how this test ate the full 180 s test
- *      timeout and reported nothing. An unknown verdict is only useful if it gets
- *      REPORTED, so each step now fails fast with a `fileMap`/`<img>` dump.
+ *      Its expand step keeps a `withDeadline` BACKSTOP (see the note on the
+ *      constants below), but the click inside it is now bounded by the config's
+ *      `actionTimeout: 30_000` and fails with Playwright's own locator
+ *      diagnostic. An unknown verdict is only useful if it gets REPORTED.
  *   7. SVG via the full-binary path ....... PASS (svg is not in
  *      THUMBNAIL_EXTENSIONS → no `thumb=`, so it takes `serveFullBinary` and
  *      gets its MIME from `guessMimeType`).
@@ -149,18 +147,26 @@ const BRIDGE_TIMEOUT_MS = 60_000;
 const RENDER_TIMEOUT_MS = 30_000;
 
 /**
- * Hard ceilings on the two UI steps that can WEDGE rather than fail.
+ * BACKSTOP for `expandFolderInExplorer` — not a bound on the click.
  *
- * `playwright.config.ts` sets no `actionTimeout`, so Playwright's default of
- * `0` — wait forever — applies to every `click()`. `expandFolderInExplorer`
- * waits for its `.nav-folder-title` to be *attached* and then clicks it; under
- * Xvfb the File Explorer is virtualised, so an attached-but-never-actionable
- * node makes that click hang until the TEST timeout kills the whole run with no
- * diagnostic at all. These deadlines convert that into a fast, explained red.
- * They are bounds on WAITING, not on any assertion.
+ * `playwright.config.ts` now sets `actionTimeout: 30_000`, so the click inside
+ * that helper can no longer wait forever: it fails with Playwright's own locator
+ * diagnostic ("<div …> from <div class='modal-container mod-dim'> subtree
+ * intercepts pointer events"), which is far better evidence than any deadline
+ * message, and it must be allowed to propagate. What is still unbounded is the
+ * helper's `vault.fileMap` POLL and its `page.evaluate` probes — a wedged
+ * renderer never answers those. This deadline covers that, and is deliberately
+ * set ABOVE the sum of the helper's internal bounds (10 s attach + 30 s click +
+ * 30 s poll) so it can only ever fire when something genuinely hung, never
+ * pre-empting Playwright's better message.
+ *
+ * The reading-view sequence no longer has a deadline at all: every step in it is
+ * a bounded Playwright wait or click that already fails with a locator in the
+ * message, and racing those against a 60 s wrapper only ever DISCARDED that
+ * message (the wrapper's own 60 s could expire before two 30 s clicks had
+ * finished retrying).
  */
-const EXPAND_DEADLINE_MS = 45_000;
-const READING_VIEW_DEADLINE_MS = 60_000;
+const EXPAND_DEADLINE_MS = 90_000;
 
 /** The 8 bytes every PNG starts with (`\x89PNG\r\n\x1a\n`). */
 const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -218,6 +224,14 @@ test.beforeAll(async () => {
   // FileSystemAdapter returns an `app://local/...` URL for a file that does
   // not exist locally), so we must not touch it before this returns.
   await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+  // `launchObsidian` dismissed the trust dialog; Obsidian answered by auto-opening
+  // its Settings dialog on the Community-plugins tab. That `.modal-container.mod-dim`
+  // covers the whole window and intercepts pointer events, so no File Explorer row
+  // can be clicked while it is up — which is why the bridge-level tests (pure
+  // `page.evaluate` + Node `fetch`) passed while every renderer-level test failed.
+  // Anything this closes is logged.
+  await dismissBlockingModals(obsidian.page);
 });
 
 test.afterAll(async () => {
@@ -463,12 +477,17 @@ test.describe('remote images & binaries: getResourcePath → ResourceBridge → 
     // fix must also invalidate metadata after a lazy load. Either way the run
     // reports something the code does not currently tell us.
     //
-    // Budget: the steps below are each individually deadlined (45s + 30s + 60s
-    // + 60s + 30s worst case = 225s), and every deadline emits a diagnostic. The
-    // per-test timeout is raised above that sum on purpose: a step that blows its
-    // own bound must be the thing that fails, so the report survives. Under the
-    // inherited 180s the harness killed the test first and we learned nothing.
+    // Budget: the steps below are each individually bounded (the expand's 90s
+    // backstop, then Playwright's own 30s action/expect timeouts), and each emits
+    // a diagnostic. The per-test timeout is raised above their sum on purpose: a
+    // step that blows its own bound must be the thing that fails, so the report
+    // survives. Under the inherited 180s the harness killed the test first and we
+    // learned nothing.
     test.setTimeout(300_000);
+
+    // The folder title is un-clickable under an open modal, and that red would
+    // libel LazyFolderLoader rather than naming the overlay.
+    await dismissBlockingModals(obsidian.page);
 
     await withDeadline(
       obsidian.page,
@@ -713,15 +732,19 @@ async function bridgeFetch(
 }
 
 /**
- * Run `work()` under a hard deadline, and on expiry raise an EXPLAINED failure
- * instead of letting the test timeout swallow it.
+ * Run `work()` under a hard BACKSTOP deadline, and on expiry raise an EXPLAINED
+ * failure instead of letting the test timeout swallow it.
  *
- * Needed because Playwright's `actionTimeout` defaults to 0 (wait forever) and
- * this config does not override it: a `click()` on an attached-but-unactionable
- * node — routine in Xvfb's virtualised File Explorer — never settles, so the
- * whole test dies at the 180s harness timeout with no stack, no message and no
- * state. Whatever the deadline catches, the maintainer gets the vault model and
- * the DOM alongside it.
+ * Reserved for waits that have no timeout of their own — `page.evaluate` probes
+ * and the `vault.fileMap` polling loop inside `expandFolderInExplorer`. A wedged
+ * renderer never answers those, and the test would die at the harness timeout
+ * with no stack, no message and no state.
+ *
+ * It is NOT used to bound clicks. `playwright.config.ts` sets
+ * `actionTimeout: 30_000`, so an un-actionable element fails on its own with a
+ * locator diagnostic naming the element that covered it — evidence this wrapper
+ * could only discard by winning the race first. Deadlines passed in here must
+ * therefore sit safely ABOVE the sum of the bounded steps they enclose.
  *
  * `work()` is left running (with its rejection swallowed) rather than cancelled:
  * there is nothing to cancel a pending Playwright action with, and an
@@ -747,9 +770,12 @@ async function withDeadline<T>(
     if (outcome === expired) {
       throw new Error(
         `${label} did not settle within ${ms}ms and was still waiting — it would ` +
-        'otherwise have hung until the test timeout with no diagnostic. Playwright ' +
-        "has no actionTimeout in this config, so a click on a node that never " +
-        'becomes actionable waits forever.\n' +
+        'otherwise have hung until the test timeout with no diagnostic. This bound ' +
+        "sits ABOVE every click's own actionTimeout (30s, set in " +
+        'playwright.config.ts), so an un-actionable element would have failed with ' +
+        "Playwright's locator diagnostic before reaching here: what expired instead " +
+        'is an unbounded wait — a `page.evaluate` the renderer never answered, or ' +
+        'the vault.fileMap poll never landing.\n' +
         (await explorerDiagnostic(page)),
       );
     }
@@ -844,36 +870,42 @@ async function inVaultModel(page: Page, vaultPath: string): Promise<boolean> {
  * straight back to editing. So the command only fires when the preview pane is
  * not already up.
  *
- * The whole sequence sits under a `withDeadline`: each inner wait is bounded,
- * but the `click()`s are not (no `actionTimeout` in the config), so this is the
- * other place a test could wedge instead of failing.
+ * NO `withDeadline` HERE, on purpose. Every step below is a bounded Playwright
+ * wait or click (`actionTimeout: 30_000` from the config), so none of them can
+ * wedge — and each fails with a locator diagnostic that a deadline wrapper can
+ * only destroy. That diagnostic is precisely what diagnosed this function's last
+ * red: "element is visible, enabled and stable … <div class='modal-container
+ * mod-dim'> subtree intercepts pointer events". A 60 s wrapper around two 30 s
+ * clicks would have expired first and reported nothing but "did not settle".
+ *
+ * The modal sweep is the fix for that red, and it comes first: while Obsidian's
+ * auto-opened Settings dialog is up, the File Explorer row is un-clickable no
+ * matter how healthy ResourceBridge is.
  */
 async function openInReadingView(page: Page, notePath: string): Promise<void> {
-  await withDeadline(
-    page,
-    `openInReadingView("${notePath}")`,
-    READING_VIEW_DEADLINE_MS,
-    async () => {
-      const nav = page.locator(`.nav-file-title[data-path="${notePath}"]`);
-      await expect(
-        nav,
-        `${notePath} is not in the File Explorer — the connect walk never ` +
-        'materialised it, so there is nothing to open',
-      ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
-      await nav.click();
+  await dismissBlockingModals(page);
 
-      const preview = page.locator('.markdown-preview-view').first();
-      const alreadyReading = await preview
-        .isVisible({ timeout: 2_000 })
-        .catch(() => false);
-      if (!alreadyReading) {
-        await runCommandViaPalette(page, 'Toggle reading view');
-      }
+  const nav = page.locator(`.nav-file-title[data-path="${notePath}"]`);
+  await expect(
+    nav,
+    `${notePath} is not in the File Explorer — the connect walk never ` +
+    'materialised it, so there is nothing to open',
+  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+  await nav.click();
 
-      await expect(
-        preview,
-        `${notePath} never entered reading view — no .markdown-preview-view appeared`,
-      ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
-    },
-  );
+  const preview = page.locator('.markdown-preview-view').first();
+  const alreadyReading = await preview
+    .isVisible({ timeout: 2_000 })
+    .catch(() => false);
+  if (!alreadyReading) {
+    // Before the palette opens, never after: the palette is a `.modal-container`
+    // itself and a sweep would close it.
+    await dismissBlockingModals(page);
+    await runCommandViaPalette(page, 'Toggle reading view');
+  }
+
+  await expect(
+    preview,
+    `${notePath} never entered reading view — no .markdown-preview-view appeared`,
+  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
 }

--- a/plugin/e2e/images.spec.ts
+++ b/plugin/e2e/images.spec.ts
@@ -1,0 +1,636 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  expandFolderInExplorer,
+  runCommandViaPalette,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { makePng, makeSvg, makePdf } from './helpers/remote-fixtures';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+
+/**
+ * Binary assets over SSH: `SftpDataAdapter.getResourcePath` →
+ * `ResourceBridge` → Obsidian's webview.
+ *
+ * Why this spec exists
+ * --------------------
+ * A remote vault's images do not live on the local disk, so Obsidian cannot
+ * render them the way it normally does (`app://local/<abs-path>`). The plugin
+ * substitutes a localhost HTTP server: `getResourcePath()` hands the webview a
+ * `http://127.0.0.1:<port>/r/<token>?p=<vault-path>[&thumb=1024]` URL
+ * (`SftpDataAdapter.ts:408-418`), and `ResourceBridge.handleRequest`
+ * (`ResourceBridge.ts:240-282`) answers it out of the daemon — thumbnail RPC
+ * for `png|jpg|jpeg|gif` (`THUMBNAIL_EXTENSIONS`), `fs.readBinaryRange` for
+ * `Range:` requests, full binary otherwise.
+ *
+ * Nothing in the existing suite covers that chain end-to-end. `reflect.spec.ts`
+ * had the only image scenario and it is (a) `test.fixme`'d and (b) seeded with a
+ * 1x1 PNG followed by a megabyte of zero padding — a fixture that can only ever
+ * prove "bytes moved". It cannot distinguish "the bridge served a correct,
+ * DOWNSCALED image" from "the bridge silently fell back to shipping the whole
+ * 10 MB original", because a 1x1 image has no size to lose. Every fixture here
+ * is a real, decodable file of a known size (`helpers/remote-fixtures.ts`), so
+ * the assertions are about the artefact itself, not about a byte count.
+ *
+ * Ordering
+ * --------
+ * The bridge-level `fetch` tests (2, 3, 7, 8) run BEFORE any preview-rendering
+ * test on purpose: if Obsidian's markdown renderer falls over under Xvfb, the
+ * run still tells the maintainer whether ResourceBridge served the right bytes
+ * with the right headers — the two failure surfaces stay separable.
+ *
+ * PREDICTIONS (a red test here is a real defect, not a broken test — nothing
+ * below is weakened, skipped or `fixme`'d):
+ *
+ *   1. getResourcePath URL shape .......... PASS
+ *   2. bridge serves a decodable PNG ...... PASS
+ *   3. 2048px → 1024px cap ................ PASS, and this is the one that
+ *      catches `ResourceBridge.serveThumbnail` (ResourceBridge.ts:306-312)
+ *      SWALLOWING a failed thumbnail RPC and falling through to the full
+ *      binary: the user then silently pulls the 10 MB original over SSH for
+ *      an inline preview. The `byteLength < remote size` half of the assertion
+ *      is what makes that fallback visible; the dimension half alone would
+ *      pass on the fallback (a full-size 2048px image still decodes).
+ *   4. root-note embed renders ............ PASS
+ *   5. embed inside an UNEXPANDED folder .. **FAIL, EXPECTED**. The remote tree
+ *      is loaded LAZILY, one level per expand: connect walks the ROOT only
+ *      (`main.ts` populate + `LazyFolderLoader`), so `<S>-sub/nested.png` is
+ *      not in `vault.fileMap` and Obsidian's link resolver cannot resolve
+ *      `![[<S>-sub/nested.png]]` to a TFile — there is no file to hand to
+ *      `getResourcePath`, so no bridge URL is ever minted and the embed stays
+ *      unresolved. This is a genuine user-visible bug (an image in a subfolder
+ *      does not render until you happen to click the folder open), and it is
+ *      why the failure message below reports whether the file was in the vault
+ *      model: the red must be conclusive about WHY, not just "no img".
+ *   6. expanding the folder fixes it ...... **GENUINELY UNKNOWN**. Whether a
+ *      lazy `fileMap` insert re-triggers Obsidian's link resolution (and hence
+ *      re-renders an already-parsed embed) is not decided anywhere in the code
+ *      we control. Whatever this test does IS the finding, and it tells the
+ *      maintainer whether the fix for (5) is "walk deeper on connect" or
+ *      "invalidate metadata after a lazy insert".
+ *   7. SVG via the full-binary path ....... PASS (svg is not in
+ *      THUMBNAIL_EXTENSIONS → no `thumb=`, so it takes `serveFullBinary` and
+ *      gets its MIME from `guessMimeType`).
+ *   8. PDF + Range → 206 .................. PASS (`serveRangeFastPath`, or the
+ *      post-hoc slice in `serveFullBinary` if the daemon lacks
+ *      `fs.readBinaryRange` — both must produce a correct 206).
+ *   9. remotely-REPLACED image ............ PASS on rpc. Three caches sit between
+ *      the remote bytes and the `<img>`: the adapter's `ReadCache`, the
+ *      bridge's mtime cache, and the daemon's thumbnail path. A watch event
+ *      must invalidate them; serving the OLD generation forever is data being
+ *      shown to the user that no longer exists.
+ *
+ * HARD-FAILS, never skips.
+ */
+
+const STAMP = Date.now().toString(36);
+
+/** 640x480 — under the 1024 thumbnail cap, so its dimensions survive a resize. */
+const SMALL_PNG = `${STAMP}-small.png`;
+/** 2048x1536 — over the cap. Random pixels ⇒ ~10 MB on the wire if NOT resized. */
+const BIG_PNG = `${STAMP}-big.png`;
+const SVG = `${STAMP}-vec.svg`;
+const PDF = `${STAMP}-doc.pdf`;
+const EMBED_NOTE = `${STAMP}-embed.md`;
+const SUB_DIR = `${STAMP}-sub`;
+const NESTED_PNG = `${SUB_DIR}/nested.png`;
+const SUBEMBED_NOTE = `${STAMP}-subembed.md`;
+
+/** `getResourcePath` on a png must carry the thumbnail hint (DEFAULT_THUMB_MAX_DIM). */
+const THUMB_MAX_DIM = 1024;
+
+/** Multi-MB payloads over SSH + a daemon-side resize. Generous but bounded. */
+const BRIDGE_TIMEOUT_MS = 60_000;
+/** Renderer-side: File Explorer paint + reading-view switch under Xvfb. */
+const RENDER_TIMEOUT_MS = 30_000;
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+
+test.beforeAll(async () => {
+  // Seeding ~13 MB of PNG over SFTP plus two Obsidian launches. The default
+  // 120 s hook budget is not enough on a cold container.
+  test.setTimeout(300_000);
+
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken
+  // connect is a broken plugin. Both must be red, not green-by-skipping.
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though ' +
+      'the port is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  // Seed BEFORE the connect: the plugin's populate walks the remote once, at
+  // connect time. A fixture written afterwards would arrive through the
+  // fs.watch → RPC-push reflect path instead, which is `reflect.spec.ts`'s
+  // subject, not this one — and test 5's whole point is what the CONNECT WALK
+  // did (and didn't) put into `vault.fileMap`.
+  await remote.writeBinaryFile(SMALL_PNG, makePng(640, 480));
+  await remote.writeBinaryFile(BIG_PNG, makePng(2048, 1536));
+  await remote.writeFile(SVG, makeSvg(320, 240));
+  await remote.writeBinaryFile(PDF, makePdf());
+  await remote.writeFile(EMBED_NOTE, `# embed\n\n![[${SMALL_PNG}]]\n`);
+  await remote.mkdirp(SUB_DIR);
+  await remote.writeBinaryFile(NESTED_PNG, makePng(640, 480));
+  await remote.writeFile(SUBEMBED_NOTE, `# sub embed\n\n![[${NESTED_PNG}]]\n`);
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+
+  // Building blocks rather than `connectAndOpenShadow`, so we keep the shadow
+  // vault PATH — `waitForShadowVaultLoaded` needs its console.log for the
+  // diagnostic dump on timeout.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+
+  // `launchObsidian` returns once the plugin has LOADED; the SSH connect and
+  // the adapter patch land later, at layout-ready. Every assertion here goes
+  // through the PATCHED adapter (`getResourcePath` on the stock
+  // FileSystemAdapter returns an `app://local/...` URL for a file that does
+  // not exist locally), so we must not touch it before this returns.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  if (remote) {
+    await Promise.allSettled([
+      remote.removeFile(SMALL_PNG),
+      remote.removeFile(BIG_PNG),
+      remote.removeFile(SVG),
+      remote.removeFile(PDF),
+      remote.removeFile(EMBED_NOTE),
+      remote.removeFile(SUBEMBED_NOTE),
+      remote.rmrf(SUB_DIR),
+    ]);
+    await remote.disconnect();
+  }
+  scaffold?.cleanup();
+});
+
+test.describe('remote images & binaries: getResourcePath → ResourceBridge → webview', () => {
+  test.beforeEach(() => {
+    // Images are multi-MB over SSH and the 2048px fixture is resized daemon-side.
+    test.setTimeout(180_000);
+  });
+
+  // ─── bridge level: run FIRST, so a broken renderer can't mask bad bytes ───
+
+  test('getResourcePath returns a live ResourceBridge URL with the thumbnail hint', async () => {
+    const pngUrl = await resourcePath(obsidian.page, SMALL_PNG);
+
+    // A `data:` URL is `SftpDataAdapter.getResourcePath`'s fallback for "the
+    // bridge is not running" (SftpDataAdapter.ts:417). It renders nothing, and
+    // it is indistinguishable from a broken image at the DOM level — so it has
+    // to be caught HERE, at the source, not downstream.
+    expect(
+      pngUrl,
+      'getResourcePath handed back a data: URL — the ResourceBridge never ' +
+      'bound, so no remote asset can render at all',
+    ).not.toMatch(/^data:/);
+
+    expect(
+      pngUrl,
+      'png must get a live bridge URL carrying the thumbnail hint ' +
+      `(THUMBNAIL_EXTENSIONS ∋ png, DEFAULT_THUMB_MAX_DIM=${THUMB_MAX_DIM})`,
+    ).toMatch(
+      new RegExp(String.raw`^http://127\.0\.0\.1:\d+/r/[0-9a-f]+\?p=.*thumb=${THUMB_MAX_DIM}`),
+    );
+
+    // A PDF is not an image: asking the daemon to "resize" it would fail the
+    // thumbnail RPC and burn a round-trip before falling back. The hint must
+    // simply not be there.
+    const pdfUrl = await resourcePath(obsidian.page, PDF);
+    expect(pdfUrl, 'pdf must still get a live bridge URL').toMatch(
+      /^http:\/\/127\.0\.0\.1:\d+\/r\/[0-9a-f]+\?p=/,
+    );
+    expect(
+      pdfUrl,
+      'pdf carries a thumb= hint — it is not in THUMBNAIL_EXTENSIONS and the ' +
+      'daemon cannot decode it, so this is a guaranteed-failing RPC per request',
+    ).not.toContain('thumb=');
+  });
+
+  test('bridge serves a decodable PNG with the right Content-Type', async () => {
+    const probe = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
+
+    expect(probe.error, `bridge fetch threw for ${SMALL_PNG}`).toBeNull();
+    expect(probe.status, `bridge returned ${probe.status} for ${SMALL_PNG}`).toBe(200);
+    expect(probe.contentType).toBe('image/png');
+    expect(probe.byteLength, 'bridge served an empty body').toBeGreaterThan(0);
+
+    // The real assertion: the bytes are a PNG a browser can DECODE. A bridge
+    // that serves truncated / mis-sliced / mis-typed content still yields a
+    // 200 with a plausible byte count; only a decode proves the payload.
+    expect(probe.width, 'served PNG did not decode').toBeGreaterThan(0);
+    expect(probe.height, 'served PNG did not decode').toBeGreaterThan(0);
+  });
+
+  test('a 2048px source is downscaled to the 1024px cap, not sent whole', async () => {
+    const onRemote = await remote.stat(BIG_PNG);
+    expect(onRemote, `${BIG_PNG} is missing from the remote`).not.toBeNull();
+
+    const probe = await bridgeFetch(obsidian.page, BIG_PNG, { decode: true });
+    expect(probe.error, `bridge fetch threw for ${BIG_PNG}`).toBeNull();
+    expect(probe.status).toBe(200);
+
+    // (a) The daemon actually resized: longer side lands exactly on the cap.
+    expect(
+      Math.max(probe.width, probe.height),
+      `${BIG_PNG} is 2048x1536 on the remote; the bridge served ` +
+      `${probe.width}x${probe.height}. getResourcePath asked for ` +
+      `thumb=${THUMB_MAX_DIM}, so the longer side must come back at ` +
+      `exactly ${THUMB_MAX_DIM}`,
+    ).toBe(THUMB_MAX_DIM);
+
+    // (b) …and the wire payload is genuinely smaller than the original.
+    //
+    // This half is the point of the test. `ResourceBridge.serveThumbnail`
+    // catches ANY thumbnail failure, logs a warning, and returns false —
+    // which falls through to `serveFullBinary` (ResourceBridge.ts:306-312).
+    // The webview still gets a valid image, so nothing looks broken, while
+    // every inline preview quietly drags the multi-MB original across the SSH
+    // link. A dimension-only assertion would not see it (the original decodes
+    // fine); a byte-count assertion does.
+    expect(
+      probe.byteLength,
+      `the bridge sent ${probe.byteLength} B for a ${onRemote!.size} B source. ` +
+      'That is the full original: the thumbnail RPC failed and ' +
+      'serveThumbnail() swallowed it, falling back to the whole binary',
+    ).toBeLessThan(onRemote!.size);
+  });
+
+  test('SVG renders via the full-binary path (no thumbnail)', async () => {
+    // SVG is an image to the renderer but a UTF-8 document on disk, and it is
+    // deliberately NOT in THUMBNAIL_EXTENSIONS (the daemon's image.Decode
+    // cannot rasterise it). So it must take `serveFullBinary` and get its MIME
+    // from `guessMimeType` — an `application/octet-stream` here means the
+    // webview downloads it instead of drawing it.
+    const url = await resourcePath(obsidian.page, SVG);
+    expect(url, 'svg must not carry a thumb= hint — the daemon cannot decode it')
+      .not.toContain('thumb=');
+
+    const probe = await bridgeFetch(obsidian.page, SVG);
+    expect(probe.error, `bridge fetch threw for ${SVG}`).toBeNull();
+    expect(probe.status).toBe(200);
+    expect(probe.contentType).toBe('image/svg+xml');
+    expect(probe.byteLength, 'bridge served an empty SVG').toBeGreaterThan(0);
+  });
+
+  test('PDF is served as application/pdf and honours a Range request', async () => {
+    const onRemote = await remote.stat(PDF);
+    expect(onRemote, `${PDF} is missing from the remote`).not.toBeNull();
+
+    // Obsidian's PDF viewer (pdf.js) does exactly this: it opens with a small
+    // ranged read rather than pulling the whole document. A bridge that
+    // answers 200-with-the-whole-file instead of 206 makes every PDF a
+    // full-file download before the first page paints.
+    const probe = await bridgeFetch(obsidian.page, PDF, { range: 'bytes=0-99' });
+
+    expect(probe.error, `bridge fetch threw for ${PDF}`).toBeNull();
+    expect(
+      probe.status,
+      `Range: bytes=0-99 returned ${probe.status}, not 206 — the bridge ignored ` +
+      'the header and served the whole document',
+    ).toBe(206);
+    expect(probe.contentType).toBe('application/pdf');
+    expect(probe.contentRange).toBe(`bytes 0-99/${onRemote!.size}`);
+    expect(probe.byteLength, 'a 100-byte range must return exactly 100 bytes').toBe(100);
+  });
+
+  // ─── renderer level ──────────────────────────────────────────────────────
+
+  test('embedded image in a root note renders (naturalWidth > 0)', async () => {
+    await openInReadingView(obsidian.page, EMBED_NOTE);
+
+    const img = obsidian.page.locator('.markdown-preview-view img').first();
+    await expect(
+      img,
+      `${EMBED_NOTE} embeds ${SMALL_PNG} but the preview pane has no <img> at all — ` +
+      'the wikilink never resolved to a TFile',
+    ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+
+    const shot = await img.evaluate((el: HTMLImageElement) => ({
+      src: el.src,
+      naturalWidth: el.naturalWidth,
+      naturalHeight: el.naturalHeight,
+    }));
+
+    // A broken bridge still renders the <img> TAG — it just never decodes.
+    // naturalWidth is the only property that separates "Obsidian resolved the
+    // embed" from "the pixels actually arrived".
+    expect(
+      shot.naturalWidth,
+      `the embedded <img> (src=${shot.src}) never decoded — ResourceBridge did ` +
+      'not deliver renderable bytes',
+    ).toBeGreaterThan(0);
+    expect(shot.naturalHeight).toBeGreaterThan(0);
+
+    expect(
+      shot.src,
+      'the embed is not going through the ResourceBridge — a src that is not a ' +
+      'bridge URL means the adapter handed Obsidian an app://local path for a ' +
+      'file that only exists on the remote',
+    ).toMatch(/^http:\/\/127\.0\.0\.1:/);
+  });
+
+  test('embedded image inside an UNEXPANDED subfolder renders', async () => {
+    // PREDICTED FAIL — see the docblock. The connect walk is root-only, so
+    // `<S>-sub/nested.png` is not in `vault.fileMap` and the wikilink cannot
+    // resolve. Written at full strength: the correct behaviour is that an
+    // embed renders regardless of whether the user has ever clicked the
+    // folder open in the File Explorer.
+    //
+    // The vault-model probe is taken FIRST and folded into the failure
+    // message, so the red says WHY (file absent from the model) rather than
+    // just "no <img>". It is a DIAGNOSTIC, deliberately not an `expect` of its
+    // own: asserting `getAbstractFileByPath(...) === null` would be encoding
+    // the BUG as the expected behaviour, which is exactly backwards.
+    const inModel = await inVaultModel(obsidian.page, NESTED_PNG);
+
+    await openInReadingView(obsidian.page, SUBEMBED_NOTE);
+
+    const img = obsidian.page.locator('.markdown-preview-view img').first();
+    await expect(
+      img,
+      `${SUBEMBED_NOTE} embeds ${NESTED_PNG} but the preview pane has no <img>.\n` +
+      `DIAGNOSTIC — app.vault.getAbstractFileByPath('${NESTED_PNG}') is ` +
+      `${inModel ? 'a TFile' : 'null'}. If it is null, the cause is LAZY FOLDER ` +
+      'LOADING: the connect populate walks the vault ROOT only, so nothing under ' +
+      `${SUB_DIR}/ exists in vault.fileMap until the user clicks the folder open — ` +
+      'and an unresolvable wikilink never reaches getResourcePath, so no bridge ' +
+      'URL is ever minted. The fix is on the vault-model side, not the bridge.',
+    ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+
+    const decoded = await img.evaluate((el: HTMLImageElement) => ({
+      src: el.src,
+      naturalWidth: el.naturalWidth,
+      naturalHeight: el.naturalHeight,
+    }));
+    expect(
+      decoded.naturalWidth,
+      `the nested embed's <img> (src=${decoded.src}) never decoded`,
+    ).toBeGreaterThan(0);
+    expect(decoded.naturalHeight).toBeGreaterThan(0);
+  });
+
+  test('expanding the folder in File Explorer makes the embed render', async () => {
+    // GENUINELY UNKNOWN, and that is the value: this is the question the
+    // maintainer has to answer before fixing the previous test. Expanding the
+    // folder is the user's own workaround — it drives the product's real hook
+    // (a delegated click listener on `.nav-folder-title`, `main.ts:923-924`)
+    // and inserts the folder's children into `vault.fileMap` via
+    // `LazyFolderLoader`.
+    //
+    // If this PASSES, the lazy insert does re-resolve embeds and the fix for
+    // test 5 is simply to make the model complete (walk deeper, or resolve the
+    // embed's folder on demand). If it FAILS, Obsidian's metadata cache has
+    // already parsed the note and does not re-resolve on a late insert, so the
+    // fix must also invalidate metadata after a lazy load. Either way the run
+    // reports something the code does not currently tell us.
+    await expandFolderInExplorer(obsidian.page, SUB_DIR, RENDER_TIMEOUT_MS);
+
+    await expect
+      .poll(() => inVaultModel(obsidian.page, NESTED_PNG), {
+        message:
+          `expandFolderInExplorer("${SUB_DIR}") reported children in vault.fileMap ` +
+          `but ${NESTED_PNG} itself is still not a TFile — the lazy load inserted ` +
+          "something other than the folder's actual contents",
+        timeout: RENDER_TIMEOUT_MS,
+      })
+      .toBe(true);
+
+    // Bounce off the note and back so the preview is rendered AFTER the insert
+    // — the question is whether a freshly-opened reading view resolves the
+    // embed now that the target exists, not whether an already-painted pane
+    // repaints itself.
+    await openInReadingView(obsidian.page, EMBED_NOTE);
+    await openInReadingView(obsidian.page, SUBEMBED_NOTE);
+
+    const img = obsidian.page.locator('.markdown-preview-view img').first();
+    await expect(
+      img,
+      `after expanding ${SUB_DIR} (so ${NESTED_PNG} IS in vault.fileMap), ` +
+      `re-opening ${SUBEMBED_NOTE} still renders no <img>. Obsidian's metadata ` +
+      'cache is not re-resolving the embed after a lazy folder insert — fixing ' +
+      'the vault walk alone will not be enough.',
+    ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+
+    const decoded = await img.evaluate((el: HTMLImageElement) => ({
+      src: el.src,
+      naturalWidth: el.naturalWidth,
+    }));
+    expect(
+      decoded.naturalWidth,
+      `the nested embed resolved (src=${decoded.src}) but never decoded — the ` +
+      'lazy-inserted TFile reached getResourcePath, so this is a BRIDGE failure ' +
+      'on the subfolder path, not a vault-model one',
+    ).toBeGreaterThan(0);
+  });
+
+  // ─── cache coherence: mutates SMALL_PNG, so it runs last ──────────────────
+
+  test('a remotely-REPLACED image is not served from a stale generation', async () => {
+    // Warm every cache in the chain (adapter ReadCache, bridge mtime cache,
+    // daemon thumbnail path) on the ORIGINAL 640x480 bytes.
+    const before = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
+    expect(before.error, `bridge fetch threw for ${SMALL_PNG}`).toBeNull();
+    expect(before.status).toBe(200);
+    expect(
+      before.width,
+      'the 640x480 fixture did not come back at its own size — it is under the ' +
+      `${THUMB_MAX_DIM} cap, so the resize must be a no-op`,
+    ).toBe(640);
+    expect(before.height).toBe(480);
+
+    // Replace it out-of-band, at a DIFFERENT size. Different dimensions —
+    // rather than different pixels at the same size — make staleness provable
+    // from the decoded bitmap alone: no byte comparison, no ambiguity about
+    // whether a resize re-encoded the payload.
+    await remote.writeBinaryFile(SMALL_PNG, makePng(300, 200));
+
+    await expect
+      .poll(
+        async () => {
+          const p = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
+          return `${p.width}x${p.height}`;
+        },
+        {
+          message:
+            `${SMALL_PNG} was replaced on the remote with a 300x200 image, but the ` +
+            'bridge keeps serving the 640x480 generation. Something in the chain — ' +
+            'the adapter ReadCache, the bridge mtime cache, or the daemon thumbnail ' +
+            'path — is not being invalidated by the watch event, so the user is ' +
+            'looking at an image that no longer exists on the remote.',
+          timeout: BRIDGE_TIMEOUT_MS,
+        },
+      )
+      .toBe('300x200');
+  });
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────
+
+interface BridgeProbe {
+  url: string;
+  /** HTTP status, or -1 if `fetch` itself threw (see `error`). */
+  status: number;
+  contentType: string | null;
+  contentRange: string | null;
+  byteLength: number;
+  /** Decoded bitmap size; -1 when `decode` was not requested or the fetch failed. */
+  width: number;
+  height: number;
+  error: string | null;
+}
+
+/** `app.vault.adapter.getResourcePath(p)` as the webview would call it. */
+async function resourcePath(page: Page, vaultPath: string): Promise<string> {
+  return page.evaluate((p) => {
+    const adapter = (window as unknown as {
+      app?: { vault?: { adapter?: { getResourcePath?: (path: string) => string } } };
+    }).app?.vault?.adapter;
+    if (!adapter?.getResourcePath) {
+      throw new Error(
+        'app.vault.adapter.getResourcePath is missing — the adapter was never ' +
+        'patched, so this window is not talking to the remote',
+      );
+    }
+    return adapter.getResourcePath(p);
+  }, vaultPath);
+}
+
+/**
+ * Fetch a vault asset THROUGH the bridge, from inside the Obsidian renderer —
+ * i.e. exactly the request an `<img>` / `<iframe>` makes. Done in-page rather
+ * than from Node on purpose: the port and the token are per-session secrets
+ * that only `getResourcePath` knows, and a Node-side fetch would bypass the
+ * webview's own origin handling and prove less.
+ *
+ * `decode: true` additionally runs the body through `createImageBitmap`, which
+ * is the only way to assert on what the user actually SEES (dimensions) as
+ * opposed to what the server claimed to send.
+ */
+async function bridgeFetch(
+  page: Page,
+  vaultPath: string,
+  opts: { range?: string; decode?: boolean } = {},
+): Promise<BridgeProbe> {
+  return page.evaluate(
+    async ({ p, range, decode }) => {
+      const fail = (failedUrl: string, error: string) => ({
+        url: failedUrl,
+        status: -1,
+        contentType: null as string | null,
+        contentRange: null as string | null,
+        byteLength: -1,
+        width: -1,
+        height: -1,
+        error,
+      });
+
+      const adapter = (window as unknown as {
+        app?: { vault?: { adapter?: { getResourcePath?: (path: string) => string } } };
+      }).app?.vault?.adapter;
+      if (!adapter?.getResourcePath) {
+        return fail('', 'app.vault.adapter.getResourcePath is missing');
+      }
+
+      const url = adapter.getResourcePath(p);
+      if (url.startsWith('data:')) {
+        return fail(
+          url,
+          'getResourcePath returned a data: URL — the ResourceBridge is not running',
+        );
+      }
+
+      try {
+        const res = await fetch(url, range ? { headers: { Range: range } } : undefined);
+        const body = await res.arrayBuffer();
+        let width = -1;
+        let height = -1;
+        if (decode && res.ok) {
+          const type = res.headers.get('content-type') ?? '';
+          const bitmap = await createImageBitmap(new Blob([body], { type }));
+          width = bitmap.width;
+          height = bitmap.height;
+          bitmap.close();
+        }
+        return {
+          url,
+          status: res.status,
+          contentType: res.headers.get('content-type'),
+          contentRange: res.headers.get('content-range'),
+          byteLength: body.byteLength,
+          width,
+          height,
+          error: null as string | null,
+        };
+      } catch (e) {
+        return fail(url, String(e));
+      }
+    },
+    { p: vaultPath, range: opts.range ?? null, decode: opts.decode ?? false },
+  );
+}
+
+/** Is `vaultPath` a real entry in Obsidian's vault model? */
+async function inVaultModel(page: Page, vaultPath: string): Promise<boolean> {
+  return page.evaluate((p) => {
+    const vault = (window as unknown as {
+      app?: { vault?: { getAbstractFileByPath?: (path: string) => unknown } };
+    }).app?.vault;
+    return vault?.getAbstractFileByPath?.(p) != null;
+  }, vaultPath);
+}
+
+/**
+ * Open a note and make sure the READING view is the one on screen.
+ *
+ * Obsidian's default mode is Live Preview — a CodeMirror editing mode in which
+ * `.markdown-preview-view` does not exist at all, so an assertion against it
+ * times out as "element(s) not found" no matter how healthy ResourceBridge is
+ * (`reflect.spec.ts:210-218` documents exactly this misdiagnosis). Hence the
+ * explicit toggle.
+ *
+ * `Toggle reading view` is a TOGGLE, and the mode sticks to the leaf: blindly
+ * running it on every open would flip a note that is already in reading view
+ * straight back to editing. So the command only fires when the preview pane is
+ * not already up.
+ */
+async function openInReadingView(page: Page, notePath: string): Promise<void> {
+  const nav = page.locator(`.nav-file-title[data-path="${notePath}"]`);
+  await expect(
+    nav,
+    `${notePath} is not in the File Explorer — the connect walk never ` +
+    'materialised it, so there is nothing to open',
+  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+  await nav.click();
+
+  const preview = page.locator('.markdown-preview-view').first();
+  const alreadyReading = await preview
+    .isVisible({ timeout: 2_000 })
+    .catch(() => false);
+  if (!alreadyReading) {
+    await runCommandViaPalette(page, 'Toggle reading view');
+  }
+
+  await expect(
+    preview,
+    `${notePath} never entered reading view — no .markdown-preview-view appeared`,
+  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+}

--- a/plugin/e2e/images.spec.ts
+++ b/plugin/e2e/images.spec.ts
@@ -38,12 +38,43 @@ import { logPathFor } from './helpers/log-oracle';
  * is a real, decodable file of a known size (`helpers/remote-fixtures.ts`), so
  * the assertions are about the artefact itself, not about a byte count.
  *
+ * WHERE EACH ASSERTION IS MADE (and why)
+ * --------------------------------------
+ * Obsidian's renderer runs under a Content-Security-Policy whose `connect-src`
+ * does NOT cover `http://127.0.0.1:<port>`, so page-JS `fetch()` at the bridge
+ * dies with a bare `TypeError: Failed to fetch` before a socket is ever opened.
+ * `img-src` IS allowed — which is why `<img src="http://127.0.0.1:…/r/…">` loads
+ * perfectly (test 4 proves it, in the same run in which every in-page `fetch()`
+ * of the SAME URL failed). A renderer-side `fetch` therefore measures the CSP,
+ * not ResourceBridge, and it is the wrong vehicle for a bytes-and-headers test.
+ *
+ * So the two surfaces are probed where each one actually lives:
+ *
+ *   • BYTES + HEADERS (tests 2, 3, 7, 8, 9) — from the NODE test process, using
+ *     Node's global `fetch` (Node 20 in CI; `page.request` was the alternative,
+ *     but it drags in a Playwright APIRequestContext and buys nothing here — the
+ *     bridge does no cookie/origin handling, see `ResourceBridge.handleRequest`).
+ *     The bridge listens on `127.0.0.1` and CI runs Obsidian on the same host, so
+ *     Node reaches it directly with no CSP in the way. `page.evaluate` is still
+ *     used, but ONLY to mint the URL via `app.vault.adapter.getResourcePath(p)`:
+ *     the port and the token are per-session secrets that only the patched
+ *     adapter knows, so the URL under test is the very one the webview would use.
+ *     Status, `content-type` and `content-range` then come straight off the
+ *     `Response` — strictly more faithful than the in-page version.
+ *     Node has no `createImageBitmap`, so dimensions come from `pngSize()` below,
+ *     which validates the PNG signature and reads the IHDR: still a decode of the
+ *     served artefact, not a byte count.
+ *
+ *   • RENDERING (tests 4, 5, 6) — in the page, against real `<img>` elements and
+ *     their `naturalWidth`. That IS the user's path, it is unaffected by
+ *     `connect-src`, and it stays exactly where it was.
+ *
  * Ordering
  * --------
- * The bridge-level `fetch` tests (2, 3, 7, 8) run BEFORE any preview-rendering
- * test on purpose: if Obsidian's markdown renderer falls over under Xvfb, the
- * run still tells the maintainer whether ResourceBridge served the right bytes
- * with the right headers — the two failure surfaces stay separable.
+ * The bridge-level tests (2, 3, 7, 8) run BEFORE any preview-rendering test on
+ * purpose: if Obsidian's markdown renderer falls over under Xvfb, the run still
+ * tells the maintainer whether ResourceBridge served the right bytes with the
+ * right headers — the two failure surfaces stay separable.
  *
  * PREDICTIONS (a red test here is a real defect, not a broken test — nothing
  * below is weakened, skipped or `fixme`'d):
@@ -74,6 +105,13 @@ import { logPathFor } from './helpers/log-oracle';
  *      we control. Whatever this test does IS the finding, and it tells the
  *      maintainer whether the fix for (5) is "walk deeper on connect" or
  *      "invalidate metadata after a lazy insert".
+ *      Every step of it is under an explicit `withDeadline`, because the config
+ *      sets no `actionTimeout` (so Playwright's default is 0 = WAIT FOREVER) and
+ *      `expandFolderInExplorer` clicks a `.nav-folder-title` it has only waited
+ *      for as *attached* — under Xvfb's virtualised File Explorer that click can
+ *      block indefinitely, which is exactly how this test ate the full 180 s test
+ *      timeout and reported nothing. An unknown verdict is only useful if it gets
+ *      REPORTED, so each step now fails fast with a `fileMap`/`<img>` dump.
  *   7. SVG via the full-binary path ....... PASS (svg is not in
  *      THUMBNAIL_EXTENSIONS → no `thumb=`, so it takes `serveFullBinary` and
  *      gets its MIME from `guessMimeType`).
@@ -109,6 +147,23 @@ const THUMB_MAX_DIM = 1024;
 const BRIDGE_TIMEOUT_MS = 60_000;
 /** Renderer-side: File Explorer paint + reading-view switch under Xvfb. */
 const RENDER_TIMEOUT_MS = 30_000;
+
+/**
+ * Hard ceilings on the two UI steps that can WEDGE rather than fail.
+ *
+ * `playwright.config.ts` sets no `actionTimeout`, so Playwright's default of
+ * `0` — wait forever — applies to every `click()`. `expandFolderInExplorer`
+ * waits for its `.nav-folder-title` to be *attached* and then clicks it; under
+ * Xvfb the File Explorer is virtualised, so an attached-but-never-actionable
+ * node makes that click hang until the TEST timeout kills the whole run with no
+ * diagnostic at all. These deadlines convert that into a fast, explained red.
+ * They are bounds on WAITING, not on any assertion.
+ */
+const EXPAND_DEADLINE_MS = 45_000;
+const READING_VIEW_DEADLINE_MS = 60_000;
+
+/** The 8 bytes every PNG starts with (`\x89PNG\r\n\x1a\n`). */
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
 let obsidian: ObsidianHandle;
 let scaffold: ScaffoldResult;
@@ -226,33 +281,38 @@ test.describe('remote images & binaries: getResourcePath → ResourceBridge → 
   });
 
   test('bridge serves a decodable PNG with the right Content-Type', async () => {
-    const probe = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
+    const probe = await bridgeFetch(obsidian.page, SMALL_PNG);
 
     expect(probe.error, `bridge fetch threw for ${SMALL_PNG}`).toBeNull();
     expect(probe.status, `bridge returned ${probe.status} for ${SMALL_PNG}`).toBe(200);
     expect(probe.contentType).toBe('image/png');
     expect(probe.byteLength, 'bridge served an empty body').toBeGreaterThan(0);
 
-    // The real assertion: the bytes are a PNG a browser can DECODE. A bridge
-    // that serves truncated / mis-sliced / mis-typed content still yields a
-    // 200 with a plausible byte count; only a decode proves the payload.
-    expect(probe.width, 'served PNG did not decode').toBeGreaterThan(0);
-    expect(probe.height, 'served PNG did not decode').toBeGreaterThan(0);
+    // The real assertion: the bytes ARE a PNG — signature, IHDR, and a size a
+    // decoder would honour. A bridge that serves truncated / mis-sliced /
+    // mis-typed content still yields a 200 with a plausible byte count and the
+    // right Content-Type; only reading the artefact itself proves the payload.
+    // `pngSize` throws (with the leading bytes in the message) if it is not one.
+    const { width, height } = pngSize(probe.body, SMALL_PNG);
+    expect(width, 'served PNG did not decode').toBeGreaterThan(0);
+    expect(height, 'served PNG did not decode').toBeGreaterThan(0);
   });
 
   test('a 2048px source is downscaled to the 1024px cap, not sent whole', async () => {
     const onRemote = await remote.stat(BIG_PNG);
     expect(onRemote, `${BIG_PNG} is missing from the remote`).not.toBeNull();
 
-    const probe = await bridgeFetch(obsidian.page, BIG_PNG, { decode: true });
+    const probe = await bridgeFetch(obsidian.page, BIG_PNG);
     expect(probe.error, `bridge fetch threw for ${BIG_PNG}`).toBeNull();
     expect(probe.status).toBe(200);
 
+    const { width, height } = pngSize(probe.body, BIG_PNG);
+
     // (a) The daemon actually resized: longer side lands exactly on the cap.
     expect(
-      Math.max(probe.width, probe.height),
+      Math.max(width, height),
       `${BIG_PNG} is 2048x1536 on the remote; the bridge served ` +
-      `${probe.width}x${probe.height}. getResourcePath asked for ` +
+      `${width}x${height}. getResourcePath asked for ` +
       `thumb=${THUMB_MAX_DIM}, so the longer side must come back at ` +
       `exactly ${THUMB_MAX_DIM}`,
     ).toBe(THUMB_MAX_DIM);
@@ -402,7 +462,20 @@ test.describe('remote images & binaries: getResourcePath → ResourceBridge → 
     // already parsed the note and does not re-resolve on a late insert, so the
     // fix must also invalidate metadata after a lazy load. Either way the run
     // reports something the code does not currently tell us.
-    await expandFolderInExplorer(obsidian.page, SUB_DIR, RENDER_TIMEOUT_MS);
+    //
+    // Budget: the steps below are each individually deadlined (45s + 30s + 60s
+    // + 60s + 30s worst case = 225s), and every deadline emits a diagnostic. The
+    // per-test timeout is raised above that sum on purpose: a step that blows its
+    // own bound must be the thing that fails, so the report survives. Under the
+    // inherited 180s the harness killed the test first and we learned nothing.
+    test.setTimeout(300_000);
+
+    await withDeadline(
+      obsidian.page,
+      `expandFolderInExplorer("${SUB_DIR}")`,
+      EXPAND_DEADLINE_MS,
+      () => expandFolderInExplorer(obsidian.page, SUB_DIR, RENDER_TIMEOUT_MS),
+    );
 
     await expect
       .poll(() => inVaultModel(obsidian.page, NESTED_PNG), {
@@ -447,15 +520,17 @@ test.describe('remote images & binaries: getResourcePath → ResourceBridge → 
   test('a remotely-REPLACED image is not served from a stale generation', async () => {
     // Warm every cache in the chain (adapter ReadCache, bridge mtime cache,
     // daemon thumbnail path) on the ORIGINAL 640x480 bytes.
-    const before = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
+    const before = await bridgeFetch(obsidian.page, SMALL_PNG);
     expect(before.error, `bridge fetch threw for ${SMALL_PNG}`).toBeNull();
     expect(before.status).toBe(200);
+
+    const first = pngSize(before.body, SMALL_PNG);
     expect(
-      before.width,
+      first.width,
       'the 640x480 fixture did not come back at its own size — it is under the ' +
       `${THUMB_MAX_DIM} cap, so the resize must be a no-op`,
     ).toBe(640);
-    expect(before.height).toBe(480);
+    expect(first.height).toBe(480);
 
     // Replace it out-of-band, at a DIFFERENT size. Different dimensions —
     // rather than different pixels at the same size — make staleness provable
@@ -466,8 +541,18 @@ test.describe('remote images & binaries: getResourcePath → ResourceBridge → 
     await expect
       .poll(
         async () => {
-          const p = await bridgeFetch(obsidian.page, SMALL_PNG, { decode: true });
-          return `${p.width}x${p.height}`;
+          const p = await bridgeFetch(obsidian.page, SMALL_PNG);
+          if (p.error) return `fetch failed: ${p.error}`;
+          // Not an `expect` — a poll callback that THROWS aborts the poll, and a
+          // transient non-PNG body (a half-written file mid-replace) must be
+          // retried, not treated as the verdict. A non-PNG that never resolves
+          // still fails the poll, and its bytes land in the failure message.
+          try {
+            const { width, height } = pngSize(p.body, SMALL_PNG);
+            return `${width}x${height}`;
+          } catch (e) {
+            return errorText(e);
+          }
         },
         {
           message:
@@ -492,10 +577,51 @@ interface BridgeProbe {
   contentType: string | null;
   contentRange: string | null;
   byteLength: number;
-  /** Decoded bitmap size; -1 when `decode` was not requested or the fetch failed. */
-  width: number;
-  height: number;
+  /** The served bytes. Empty when the fetch failed. */
+  body: Buffer;
   error: string | null;
+}
+
+/** `String(e)` for an `unknown`, with an Error's message preferred. */
+function errorText(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Width/height of a PNG, read out of its IHDR.
+ *
+ * This is the Node-side replacement for `createImageBitmap` (which does not
+ * exist outside a browser). It is NOT a weaker check: the PNG signature and the
+ * IHDR chunk type are both verified, so truncated, empty, JPEG-instead-of-PNG,
+ * or HTML-error-page bodies all throw here — with their leading bytes in the
+ * message — rather than silently reporting a dimension. The daemon's thumbnail
+ * of a PNG source is itself a PNG (`ResourceBridge.serveThumbnail` maps
+ * `format` to `image/png` / `image/jpeg`), so a JPEG body would mean the daemon
+ * changed format under us, and that must be loud.
+ */
+function pngSize(body: Buffer, what: string): { width: number; height: number } {
+  const head = body.subarray(0, 32).toString('hex');
+
+  if (body.length < 24) {
+    throw new Error(
+      `${what}: the bridge served ${body.length} B — too short to even be a PNG ` +
+      `header (need >= 24). Bytes: ${head || '<empty>'}`,
+    );
+  }
+  if (!body.subarray(0, 8).equals(PNG_SIGNATURE)) {
+    throw new Error(
+      `${what}: the bridge did not serve a PNG — the 8-byte signature is wrong. ` +
+      `${body.length} B, first 32 bytes: ${head}`,
+    );
+  }
+  if (body.subarray(12, 16).toString('ascii') !== 'IHDR') {
+    throw new Error(
+      `${what}: PNG signature is present but the first chunk is not IHDR — the ` +
+      `payload is malformed or truncated. ${body.length} B, first 32 bytes: ${head}`,
+    );
+  }
+
+  return { width: body.readUInt32BE(16), height: body.readUInt32BE(20) };
 }
 
 /** `app.vault.adapter.getResourcePath(p)` as the webview would call it. */
@@ -515,77 +641,183 @@ async function resourcePath(page: Page, vaultPath: string): Promise<string> {
 }
 
 /**
- * Fetch a vault asset THROUGH the bridge, from inside the Obsidian renderer —
- * i.e. exactly the request an `<img>` / `<iframe>` makes. Done in-page rather
- * than from Node on purpose: the port and the token are per-session secrets
- * that only `getResourcePath` knows, and a Node-side fetch would bypass the
- * webview's own origin handling and prove less.
+ * Fetch a vault asset THROUGH the bridge — the URL is minted in the renderer,
+ * the request is made from NODE.
  *
- * `decode: true` additionally runs the body through `createImageBitmap`, which
- * is the only way to assert on what the user actually SEES (dimensions) as
- * opposed to what the server claimed to send.
+ * The URL has to come from the page: the port and the token are per-session
+ * secrets that only the patched `getResourcePath` knows, so this is the exact
+ * URL Obsidian itself would put on an `<img>`.
+ *
+ * The REQUEST cannot come from the page. Obsidian's renderer CSP has no
+ * `connect-src` entry for `http://127.0.0.1:<port>`, so an in-page `fetch()` of
+ * that URL is refused by the browser with a contentless `TypeError: Failed to
+ * fetch` — no request is ever sent, and the probe measures Chromium's CSP rather
+ * than ResourceBridge. (`img-src` is permitted, which is why the `<img>` tests
+ * pass against the same URL.) The bridge binds `127.0.0.1` and CI runs Obsidian
+ * on the same host as the test process, so Node's global `fetch` reaches it with
+ * no CSP and hands back the real `Response`: status, `content-type`,
+ * `content-range` and the bytes, all first-hand.
  */
 async function bridgeFetch(
   page: Page,
   vaultPath: string,
-  opts: { range?: string; decode?: boolean } = {},
+  opts: { range?: string } = {},
 ): Promise<BridgeProbe> {
-  return page.evaluate(
-    async ({ p, range, decode }) => {
-      const fail = (failedUrl: string, error: string) => ({
-        url: failedUrl,
-        status: -1,
-        contentType: null as string | null,
-        contentRange: null as string | null,
-        byteLength: -1,
-        width: -1,
-        height: -1,
-        error,
-      });
+  const fail = (url: string, error: string): BridgeProbe => ({
+    url,
+    status: -1,
+    contentType: null,
+    contentRange: null,
+    byteLength: -1,
+    body: Buffer.alloc(0),
+    error,
+  });
 
-      const adapter = (window as unknown as {
-        app?: { vault?: { adapter?: { getResourcePath?: (path: string) => string } } };
-      }).app?.vault?.adapter;
-      if (!adapter?.getResourcePath) {
-        return fail('', 'app.vault.adapter.getResourcePath is missing');
-      }
+  let url: string;
+  try {
+    url = await resourcePath(page, vaultPath);
+  } catch (e) {
+    return fail('', errorText(e));
+  }
 
-      const url = adapter.getResourcePath(p);
-      if (url.startsWith('data:')) {
-        return fail(
-          url,
-          'getResourcePath returned a data: URL — the ResourceBridge is not running',
-        );
-      }
+  // `SftpDataAdapter.getResourcePath`'s "the bridge never bound" fallback. It
+  // is not fetchable, and reporting it as a fetch error would misattribute the
+  // failure to the transport.
+  if (url.startsWith('data:')) {
+    return fail(
+      url,
+      'getResourcePath returned a data: URL — the ResourceBridge is not running',
+    );
+  }
 
-      try {
-        const res = await fetch(url, range ? { headers: { Range: range } } : undefined);
-        const body = await res.arrayBuffer();
-        let width = -1;
-        let height = -1;
-        if (decode && res.ok) {
-          const type = res.headers.get('content-type') ?? '';
-          const bitmap = await createImageBitmap(new Blob([body], { type }));
-          width = bitmap.width;
-          height = bitmap.height;
-          bitmap.close();
-        }
-        return {
-          url,
-          status: res.status,
-          contentType: res.headers.get('content-type'),
-          contentRange: res.headers.get('content-range'),
-          byteLength: body.byteLength,
-          width,
-          height,
-          error: null as string | null,
-        };
-      } catch (e) {
-        return fail(url, String(e));
-      }
-    },
-    { p: vaultPath, range: opts.range ?? null, decode: opts.decode ?? false },
+  try {
+    const res = await fetch(url, {
+      headers: opts.range ? { Range: opts.range } : undefined,
+      // The bridge streams multi-MB bodies over SSH; without this a wedged
+      // daemon would hang the fetch until the TEST timeout, with no diagnostic.
+      signal: AbortSignal.timeout(BRIDGE_TIMEOUT_MS),
+    });
+    const body = Buffer.from(await res.arrayBuffer());
+    return {
+      url,
+      status: res.status,
+      contentType: res.headers.get('content-type'),
+      contentRange: res.headers.get('content-range'),
+      byteLength: body.byteLength,
+      body,
+      error: null,
+    };
+  } catch (e) {
+    return fail(url, errorText(e));
+  }
+}
+
+/**
+ * Run `work()` under a hard deadline, and on expiry raise an EXPLAINED failure
+ * instead of letting the test timeout swallow it.
+ *
+ * Needed because Playwright's `actionTimeout` defaults to 0 (wait forever) and
+ * this config does not override it: a `click()` on an attached-but-unactionable
+ * node — routine in Xvfb's virtualised File Explorer — never settles, so the
+ * whole test dies at the 180s harness timeout with no stack, no message and no
+ * state. Whatever the deadline catches, the maintainer gets the vault model and
+ * the DOM alongside it.
+ *
+ * `work()` is left running (with its rejection swallowed) rather than cancelled:
+ * there is nothing to cancel a pending Playwright action with, and an
+ * un-awaited rejection after the race would surface as an unhandled rejection.
+ */
+async function withDeadline<T>(
+  page: Page,
+  label: string,
+  ms: number,
+  work: () => Promise<T>,
+): Promise<T> {
+  const running = work();
+  running.catch(() => { /* the race below owns the outcome */ });
+
+  let timer: NodeJS.Timeout | undefined;
+  const expired = Symbol('deadline');
+  const deadline = new Promise<typeof expired>((resolve) => {
+    timer = setTimeout(() => resolve(expired), ms);
+  });
+
+  try {
+    const outcome = await Promise.race([running, deadline]);
+    if (outcome === expired) {
+      throw new Error(
+        `${label} did not settle within ${ms}ms and was still waiting — it would ` +
+        'otherwise have hung until the test timeout with no diagnostic. Playwright ' +
+        "has no actionTimeout in this config, so a click on a node that never " +
+        'becomes actionable waits forever.\n' +
+        (await explorerDiagnostic(page)),
+      );
+    }
+    return outcome as T;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * What the vault model and the DOM actually look like right now, for a deadline
+ * message. Answers the two questions a hang leaves open: is the file in
+ * `vault.fileMap` at all, and did an `<img>` ever make it into the preview?
+ *
+ * Bounded itself — a wedged renderer must not make the diagnostic hang too.
+ */
+async function explorerDiagnostic(page: Page): Promise<string> {
+  interface Snapshot {
+    underPrefix: string[];
+    fileMapSize: number;
+    folderTitles: (string | null)[];
+    previewImgs: string[];
+    anyImgOnPage: number;
+  }
+
+  const probe = page
+    .evaluate((prefix): Snapshot => {
+      const vault = (window as unknown as {
+        app?: { vault?: { fileMap?: Record<string, unknown> } };
+      }).app?.vault;
+      const keys = Object.keys(vault?.fileMap ?? {});
+      return {
+        underPrefix: keys.filter((k) => k === prefix || k.startsWith(`${prefix}/`)),
+        fileMapSize: keys.length,
+        folderTitles: Array.from(document.querySelectorAll('.nav-folder-title')).map(
+          (el) => el.getAttribute('data-path'),
+        ),
+        previewImgs: Array.from(
+          document.querySelectorAll('.markdown-preview-view img'),
+        ).map((el) => (el as HTMLImageElement).src),
+        anyImgOnPage: document.querySelectorAll('img').length,
+      };
+    }, SUB_DIR)
+    .catch((e: unknown) => errorText(e));
+
+  const timeout = new Promise<string>((resolve) =>
+    setTimeout(() => resolve('the renderer did not answer within 5000ms'), 5_000),
   );
+
+  const snapshot = await Promise.race([probe, timeout]);
+  if (typeof snapshot === 'string') {
+    return `DIAGNOSTIC — the vault-model probe itself failed: ${snapshot}`;
+  }
+
+  return [
+    'DIAGNOSTIC (vault model + DOM at the moment of the deadline):',
+    `  vault.fileMap keys under "${SUB_DIR}/": ` +
+    (snapshot.underPrefix.length > 0
+      ? JSON.stringify(snapshot.underPrefix)
+      : 'NONE — the lazy folder load never inserted the folder contents'),
+    `  vault.fileMap total keys: ${snapshot.fileMapSize}`,
+    `  .nav-folder-title[data-path] rendered: ${JSON.stringify(snapshot.folderTitles)}`,
+    `  <img> in .markdown-preview-view: ` +
+    (snapshot.previewImgs.length > 0
+      ? JSON.stringify(snapshot.previewImgs)
+      : 'NONE — the embed never resolved to an element'),
+    `  <img> anywhere in the document: ${snapshot.anyImgOnPage}`,
+  ].join('\n');
 }
 
 /** Is `vaultPath` a real entry in Obsidian's vault model? */
@@ -611,26 +843,37 @@ async function inVaultModel(page: Page, vaultPath: string): Promise<boolean> {
  * running it on every open would flip a note that is already in reading view
  * straight back to editing. So the command only fires when the preview pane is
  * not already up.
+ *
+ * The whole sequence sits under a `withDeadline`: each inner wait is bounded,
+ * but the `click()`s are not (no `actionTimeout` in the config), so this is the
+ * other place a test could wedge instead of failing.
  */
 async function openInReadingView(page: Page, notePath: string): Promise<void> {
-  const nav = page.locator(`.nav-file-title[data-path="${notePath}"]`);
-  await expect(
-    nav,
-    `${notePath} is not in the File Explorer — the connect walk never ` +
-    'materialised it, so there is nothing to open',
-  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
-  await nav.click();
+  await withDeadline(
+    page,
+    `openInReadingView("${notePath}")`,
+    READING_VIEW_DEADLINE_MS,
+    async () => {
+      const nav = page.locator(`.nav-file-title[data-path="${notePath}"]`);
+      await expect(
+        nav,
+        `${notePath} is not in the File Explorer — the connect walk never ` +
+        'materialised it, so there is nothing to open',
+      ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+      await nav.click();
 
-  const preview = page.locator('.markdown-preview-view').first();
-  const alreadyReading = await preview
-    .isVisible({ timeout: 2_000 })
-    .catch(() => false);
-  if (!alreadyReading) {
-    await runCommandViaPalette(page, 'Toggle reading view');
-  }
+      const preview = page.locator('.markdown-preview-view').first();
+      const alreadyReading = await preview
+        .isVisible({ timeout: 2_000 })
+        .catch(() => false);
+      if (!alreadyReading) {
+        await runCommandViaPalette(page, 'Toggle reading view');
+      }
 
-  await expect(
-    preview,
-    `${notePath} never entered reading view — no .markdown-preview-view appeared`,
-  ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+      await expect(
+        preview,
+        `${notePath} never entered reading view — no .markdown-preview-view appeared`,
+      ).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+    },
+  );
 }

--- a/plugin/e2e/links-metadata.spec.ts
+++ b/plugin/e2e/links-metadata.spec.ts
@@ -1,0 +1,506 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  runCommandViaPalette,
+  expandFolderInExplorer,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+
+/**
+ * Wiki links, backlinks, and the metadata cache over a remote vault.
+ *
+ * Nothing in the suite covers Obsidian's METADATA layer today. Every existing
+ * spec stops at "the bytes are on the remote" / "the row is in the File
+ * Explorer". But a vault whose files exist and whose links do not resolve is
+ * not a working Obsidian — links, backlinks, graph, and Quick Switcher are the
+ * product. This file asserts that layer end-to-end, against a real remote.
+ *
+ * ── THE DEFECT THESE TESTS ENCODE ────────────────────────────────────────────
+ *
+ * `src/main.ts:972-973` (`populateVaultFromRemote`):
+ *
+ *     const lazy = this.settings.lazyFolderLoad !== false;
+ *     const walk = await walker.walk('', !lazy);
+ *
+ * `lazyFolderLoad` DEFAULTS TO TRUE (`src/constants.ts:51`), so the connect-time
+ * walk is NON-RECURSIVE: only the ROOT's immediate children are walked, and
+ * `VaultModelBuilder.insertFile` is therefore never called for anything living
+ * in a subfolder. Those files are absent from `app.vault.fileMap` ENTIRELY —
+ * not "present but unloaded", simply not there.
+ *
+ * Obsidian's `metadataCache` resolves `[[wiki links]]` against `fileMap` and
+ * nothing else. A link whose target is missing from `fileMap` cannot resolve;
+ * it lands in `unresolvedLinks` instead, produces no backlink, no graph edge,
+ * and its target cannot be reached from the Quick Switcher. So on a stock
+ * (default-settings) connection, EVERY note in EVERY subfolder is invisible to
+ * Obsidian's whole knowledge layer until the user happens to CLICK that folder
+ * in the File Explorer — the only thing that deepens the tree is the delegated
+ * `.nav-folder-title` click hook at `src/main.ts:919-928`, which calls
+ * `LazyFolderLoader.loadFolder`.
+ *
+ * That is the trade the lazy walk made — a fast connect on a huge vault — and
+ * it silently bought it by starving the metadata cache.
+ *
+ * ── WHICH TESTS ARE EXPECTED RED, AND WHAT THE FIX IS ────────────────────────
+ *
+ * Tests 1-4 and 7 (root-level links) should PASS: the root IS walked.
+ * Tests 5, 6b and 8 (anything below the root) are PREDICTED RED. They are
+ * written at FULL STRENGTH on purpose. They are not flaky, not aspirational,
+ * and MUST NOT be weakened, quarantined, or `.fixme`d to get the suite green —
+ * a green suite here would mean the suite is lying about a user-facing data
+ * defect ("my links are broken", "my note is not findable").
+ *
+ * The fix belongs in the PRODUCT, and there are exactly two shapes of it:
+ *
+ *   (a) EAGER / BACKGROUND FULL INDEX — keep the fast lazy first paint, then
+ *       walk the rest of the tree in the background and feed it to
+ *       `VaultModelBuilder`, so `fileMap` eventually holds the whole vault; or
+ *   (b) METADATA INVALIDATION ON LAZY INSERT — if the tree stays lazy, a late
+ *       `LazyFolderLoader` insert must tell Obsidian to re-resolve links against
+ *       the enlarged `fileMap`.
+ *
+ * Test 6 is the discriminator between those two and is written as two strict
+ * halves: (a) expanding the folder DOES get the file into `fileMap` (the lazy
+ * loader itself works), and (b) after that late insert, the link in a note that
+ * was already indexed resolves. If 6a goes green and 6b stays red, nothing
+ * re-runs link resolution after a lazy insert, and fix (b) alone is not enough
+ * — the maintainer needs (a), or (a) + (b).
+ *
+ * HARD-FAILS, never skips.
+ */
+
+const STAMP = Date.now().toString(36);
+
+// ── remote fixtures (seeded BEFORE connect, so the connect walk sees them) ────
+const A = `${STAMP}-A.md`;           // root note that links to B (root)
+const B = `${STAMP}-B.md`;           // root link target
+const C = `${STAMP}-C.md`;           // root note that links INTO the subfolder
+const D = `${STAMP}-D.md`;           // created LIVE, after connect (test 7)
+const SUB = `${STAMP}-sub`;          // subfolder — never walked at connect
+const DEEP = `${SUB}/Deep.md`;       // the note the whole defect is about
+const DEEP_LINKTEXT = `${SUB}/Deep`; // exactly what the `[[...]]` in C contains
+
+// Indexing is asynchronous (Obsidian re-resolves links off its own queue), so
+// every metadata assertion polls. 20 s is far past the observed settle time on a
+// warm connection; it exists so a RED is a real defect, not a slow machine.
+const META_TIMEOUT_MS = 20_000;
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+
+test.beforeAll(async () => {
+  test.setTimeout(180_000);
+
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken connect
+  // is a broken plugin. Both must be red, not green-by-skipping.
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though the ' +
+      'port is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  // Seed BEFORE the connect. The whole point is what the connect-time walk does
+  // (and does not) put into `vault.fileMap`; a fixture written after connect
+  // would arrive via the live `fs.watch` → ChangeListener path instead and would
+  // not exercise the walk at all. (Test 7 deliberately uses that other path.)
+  await remote.writeFile(A, `# A\n\n[[${STAMP}-B]]\n`);
+  await remote.writeFile(B, '# B\n');
+  await remote.mkdirp(SUB);
+  await remote.writeFile(DEEP, '# Deep\n');
+  await remote.writeFile(C, `# C\n\n[[${DEEP_LINKTEXT}]]\n`);
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+
+  // Building blocks rather than `connectAndOpenShadow`, so we keep hold of the
+  // shadow vault PATH — `waitForShadowVaultLoaded` needs its log path.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+
+  // `launchObsidian` returns once the PLUGIN has loaded; the SSH connect, the
+  // adapter patch and `populateVaultFromRemote` all land later, at layout-ready.
+  // Every assertion below is about what that populate produced, so we must not
+  // race it.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  if (remote) {
+    await Promise.allSettled([
+      remote.removeFile(A),
+      remote.removeFile(B),
+      remote.removeFile(C),
+      remote.removeFile(D),
+    ]);
+    await remote.rmrf(SUB).catch(() => { /* best effort */ });
+    await remote.disconnect();
+  }
+  scaffold?.cleanup();
+});
+
+test.beforeEach(() => {
+  // A remote round-trip plus asynchronous re-indexing; the config's default
+  // 120 s gets tight once several polls stack up inside one test.
+  test.setTimeout(180_000);
+});
+
+test.describe('wiki links, backlinks + metadata cache over a remote vault', () => {
+  /**
+   * FIRST for a reason: if the metadata cache never indexes the virtual vault
+   * AT ALL, that is a much larger finding than the lazy-folder defect and it
+   * makes every other test in this file moot. This is the canary.
+   */
+  test('1 — a root-level wiki link to an existing remote note RESOLVES', async () => {
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, A, B)).resolved, {
+        message:
+          `metadataCache.resolvedLinks["${A}"] never contained "${B}". Both notes are ` +
+          'at the ROOT of the remote vault, which the connect walk DOES cover — so if ' +
+          'this is red, the metadata cache is not indexing the virtual vault at all ' +
+          '(a bigger defect than the lazy-folder one the rest of this file is about).',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toContain(B);
+  });
+
+  test('2 — unresolved-link count is 0 for a link whose target EXISTS on the remote', async () => {
+    // The mirror image of test 1, and not redundant with it: a link can be BOTH
+    // resolved and (stale-ly) listed as unresolved, and a note rendering a
+    // dangling-link style is broken to the user even if `resolvedLinks` is right.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, A, B)).unresolved, {
+        message:
+          `metadataCache.unresolvedLinks["${A}"] is not empty — Obsidian still thinks ` +
+          `the link to "${B}" is dangling even though that note exists on the remote.`,
+        timeout: META_TIMEOUT_MS,
+      })
+      .toEqual([]);
+  });
+
+  test('3 — the backlink appears on the target note', async () => {
+    // The MODEL assertion is the primary one: `getBacklinksForFile` is what the
+    // backlinks pane, the graph and the outgoing-links pane all read. Asserting
+    // the model (not the pane's DOM) keeps this immune to headless Obsidian's
+    // lazy/virtualised sidebar paint under Xvfb — the same reason
+    // `waitForShadowVaultLoaded` asserts on the model rather than on nav rows.
+    await expect
+      .poll(() => backlinkSourcesFor(obsidian.page, B), {
+        message:
+          `metadataCache.getBacklinksForFile("${B}") never listed "${A}" as a source. ` +
+          'The forward link resolves (test 1) but the reverse index is empty — the ' +
+          'backlinks pane and the graph would both be blank for this note.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toContain(A);
+  });
+
+  test('4 — clicking a wiki link opens the target note', async () => {
+    // The end-to-end user gesture, not just the index: open A, switch to Reading
+    // view (Obsidian's default is LIVE PREVIEW — a CodeMirror mode in which
+    // `.markdown-preview-view` does not exist; see reflect.spec.ts test 5), then
+    // click the rendered anchor and assert the workspace actually navigated.
+    await fileLocator(obsidian.page, A).click();
+    await runCommandViaPalette(obsidian.page, 'Toggle reading view');
+
+    const link = obsidian.page.locator('.markdown-preview-view a.internal-link').first();
+    await expect(
+      link,
+      `no rendered a.internal-link in the reading view of "${A}" — the wiki link was ` +
+      'not even turned into a clickable anchor',
+    ).toBeVisible({ timeout: META_TIMEOUT_MS });
+    await link.click();
+
+    await expect
+      .poll(() => activeFilePath(obsidian.page), {
+        message:
+          `clicking the [[${STAMP}-B]] anchor in "${A}" did not navigate to "${B}" — ` +
+          'the link renders but does not open its target.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toBe(B);
+  });
+
+  /**
+   * THE HEADLINE DEFECT. PREDICTED RED.
+   *
+   * `C` sits at the root (so it IS walked and IS indexed) and links into
+   * `<STAMP>-sub/`, which the lazy connect walk never descends into. `Deep.md` is
+   * therefore not in `fileMap`, so the link cannot resolve.
+   *
+   * The two assertions before the headline one are DIAGNOSTIC — they narrow the
+   * cause to a specific layer so one CI round is conclusive instead of
+   * speculative. Note their DIRECTION: they assert what a CORRECT build does
+   * (`Deep.md` IS in the vault model; the link is NOT dangling), not what the
+   * current build does. Asserting that `getAbstractFileByPath(...)` *is null*
+   * would pin today's bug as the expectation and would go red the day someone
+   * fixes it — a test that defends a defect. These fail today for the same root
+   * cause as the headline assertion, and each names the layer that broke:
+   *
+   *   5a red  → the file never reached `vault.fileMap`     (the walk starved it)
+   *   5b red  → Obsidian classified the link as dangling   (the consequence)
+   *   5c red  → the link does not resolve                  (the user-visible harm)
+   */
+  test('5 — a wiki link into a SUBFOLDER resolves', async () => {
+    const probe = await probeLinks(obsidian.page, C, DEEP);
+    const diag =
+      `\n  fileMap has "${DEEP}": ${probe.inFileMap}` +
+      `\n  resolvedLinks["${C}"]: ${JSON.stringify(probe.resolved)}` +
+      `\n  unresolvedLinks["${C}"]: ${JSON.stringify(probe.unresolved)}` +
+      `\n  fileMap sample: ${JSON.stringify(probe.fileMapSample)}`;
+
+    // 5a — the vault model must contain the note at all.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).inFileMap, {
+        message:
+          `app.vault.getAbstractFileByPath("${DEEP}") is null: the note is not in the ` +
+          'vault model AT ALL. The connect walk is non-recursive while `lazyFolderLoad` ' +
+          'is on (its default — src/main.ts:972-973, src/constants.ts:51), so ' +
+          'VaultModelBuilder.insertFile was never called for anything under a ' +
+          'subfolder. Nothing downstream — links, backlinks, graph, Quick Switcher — ' +
+          `can see this file.${diag}`,
+        timeout: META_TIMEOUT_MS,
+      })
+      .toBe(true);
+
+    // 5b — and therefore Obsidian must not be treating the link as dangling.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).unresolved, {
+        message:
+          `metadataCache.unresolvedLinks["${C}"] lists "${DEEP_LINKTEXT}" as dangling, ` +
+          `but "${DEEP}" exists on the remote. Obsidian resolves links against ` +
+          'vault.fileMap and the lazy walk never put the target there, so the user sees ' +
+          `a broken link to a note that is plainly there in their own vault.${diag}`,
+        timeout: META_TIMEOUT_MS,
+      })
+      .toEqual([]);
+
+    // 5c — the headline.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).resolved, {
+        message:
+          `metadataCache.resolvedLinks["${C}"] never contained "${DEEP}". Links into ` +
+          'subfolders do not resolve on a default connection. Fix this in the PRODUCT ' +
+          '— a background/eager full walk, or metadata invalidation on lazy insert — ' +
+          `NOT by weakening this assertion.${diag}`,
+        timeout: META_TIMEOUT_MS,
+      })
+      .toContain(DEEP);
+  });
+
+  /**
+   * The DISCRIMINATOR between the two candidate fixes. Both halves strict.
+   *
+   *   6a — expanding the folder in the File Explorer (the ONLY user gesture that
+   *        deepens the tree: `src/main.ts:919-928` → `LazyFolderLoader.loadFolder`)
+   *        gets `Deep.md` into `fileMap`. Expected GREEN — the lazy loader works.
+   *   6b — after that late insert, C's link resolves. UNKNOWN, leaning RED:
+   *        nothing in the product obviously re-runs link resolution for notes
+   *        already indexed when their target arrives late.
+   *
+   * 6a green + 6b red ⇒ "invalidate metadata on lazy insert" is REQUIRED, and even
+   * then every unexpanded folder stays invisible — i.e. the real fix is a
+   * background full index.
+   */
+  test('6 — expanding the folder in File Explorer makes the subfolder link resolve', async () => {
+    await expandFolderInExplorer(obsidian.page, SUB, META_TIMEOUT_MS);
+
+    // 6a — the lazy load itself landed.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).inFileMap, {
+        message:
+          `after clicking the "${SUB}" folder title, "${DEEP}" is STILL not in ` +
+          'vault.fileMap — LazyFolderLoader.loadFolder did not materialise the folder\'s ' +
+          'children, so the one escape hatch from the lazy walk is broken too.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toBe(true);
+
+    // 6b — and the metadata cache noticed.
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).resolved, {
+        message:
+          `"${DEEP}" is now in vault.fileMap (6a passed) but ` +
+          `metadataCache.resolvedLinks["${C}"] still does not contain it. The lazy ` +
+          'insert enlarged the vault WITHOUT making Obsidian re-resolve the links of ' +
+          'notes that were already indexed — so even a user who dutifully expands every ' +
+          'folder keeps broken links. This is the "invalidate metadata on lazy insert" ' +
+          'half of the fix.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toContain(DEEP);
+  });
+
+  /**
+   * Guards the LIVE-CHANGE → metadata chain, which nothing currently covers:
+   * `reflect.spec.ts` proves a remote write reaches the File Explorer, but not
+   * that it reaches the metadata cache. A note you can see but cannot link to is
+   * still broken. Root-level throughout, so the lazy walk is not implicated —
+   * this one is expected GREEN, and exists to stay that way.
+   */
+  test('7 — a note created remotely at root is linkable immediately', async () => {
+    await remote.writeFile(D, '# D\n');
+
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, A, D)).inFileMap, {
+        message:
+          `"${D}" was written on the remote but never reached vault.fileMap — the ` +
+          'fs.watch → RPC push → ChangeListener → vault-model chain did not deliver the ' +
+          'create.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toBe(true);
+
+    // Now make an ALREADY-INDEXED note point at the newly arrived one. This is the
+    // ordinary "I just made a note and linked to it" flow.
+    await remote.writeFile(A, `# A\n\n[[${STAMP}-B]]\n\n[[${STAMP}-D]]\n`);
+
+    await expect
+      .poll(async () => (await probeLinks(obsidian.page, A, D)).resolved, {
+        message:
+          `metadataCache.resolvedLinks["${A}"] never contained "${D}" after "${A}" was ` +
+          `rewritten on the remote to link to it. "${D}" IS in the vault model, so the ` +
+          'file itself landed — but the modify did not make Obsidian re-parse the source ' +
+          'note, so a live remote edit does not update the link index.',
+        timeout: META_TIMEOUT_MS,
+      })
+      .toContain(D);
+  });
+
+  /**
+   * PREDICTED RED — same root cause as test 5, different user-visible cost.
+   *
+   * Broken links are only half the damage. The Quick Switcher (and Search, and
+   * the graph) enumerate `fileMap`, so a note in an unexpanded subfolder is not
+   * merely unlinkable, it is UNREACHABLE: the user types its name and Obsidian
+   * tells them it does not exist. This is what the bug actually feels like.
+   */
+  test('8 — Quick Switcher can reach a note in an unexpanded subfolder', async () => {
+    await runCommandViaPalette(obsidian.page, 'Open quick switcher');
+
+    const input = obsidian.page
+      .locator('.prompt input, input.prompt-input, .suggestion-container input')
+      .first();
+    await expect(input, 'the Quick Switcher never opened').toBeVisible({ timeout: 10_000 });
+    await input.fill('');
+    await obsidian.page.keyboard.type('Deep', { delay: 20 });
+
+    await expect(
+      obsidian.page.locator('.prompt .suggestion-item', { hasText: 'Deep' }).first(),
+      `the Quick Switcher offers no suggestion for "Deep" — "${DEEP}" exists on the ` +
+      'remote but lives in a subfolder the lazy connect walk never descended into ' +
+      '(src/main.ts:972-973), so it is absent from vault.fileMap and the switcher ' +
+      'cannot enumerate it. To the user, the note simply does not exist.',
+    ).toBeVisible({ timeout: META_TIMEOUT_MS });
+  });
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Locate a File Explorer entry by filename. Obsidian sets `data-path` on every
+ * `.nav-file-title`, so the selector is stable across themes / language packs.
+ */
+function fileLocator(page: Page, fileName: string) {
+  return page.locator(`.nav-file-title[data-path$="${fileName}"]`);
+}
+
+interface LinkProbe {
+  /** Is `target` in `vault.fileMap` at all? The precondition for ANY resolution. */
+  inFileMap: boolean;
+  /** `Object.keys(metadataCache.resolvedLinks[src])` — target PATHS. */
+  resolved: string[];
+  /** `Object.keys(metadataCache.unresolvedLinks[src])` — dangling LINK TEXTS. */
+  unresolved: string[];
+  /** First 30 `fileMap` keys, so a failure message is conclusive on its own. */
+  fileMapSample: string[];
+}
+
+/**
+ * One round-trip snapshot of everything a link assertion needs. Read inside a
+ * single `evaluate` so the three facts are mutually consistent — a poll that
+ * fetched them separately could catch the cache mid-update and report a state
+ * that never actually existed.
+ */
+async function probeLinks(page: Page, src: string, target: string): Promise<LinkProbe> {
+  return page.evaluate(
+    ({ src, target }) => {
+      const app = (window as unknown as {
+        app?: {
+          vault?: {
+            fileMap?: Record<string, unknown>;
+            getAbstractFileByPath?: (p: string) => unknown;
+          };
+          metadataCache?: {
+            resolvedLinks?: Record<string, Record<string, number>>;
+            unresolvedLinks?: Record<string, Record<string, number>>;
+          };
+        };
+      }).app;
+      const mc = app?.metadataCache;
+      return {
+        inFileMap: app?.vault?.getAbstractFileByPath?.(target) != null,
+        resolved: Object.keys(mc?.resolvedLinks?.[src] ?? {}),
+        unresolved: Object.keys(mc?.unresolvedLinks?.[src] ?? {}),
+        fileMapSample: Object.keys(app?.vault?.fileMap ?? {}).slice(0, 30),
+      };
+    },
+    { src, target },
+  );
+}
+
+/**
+ * Source paths that link INTO `targetPath`, straight from
+ * `metadataCache.getBacklinksForFile(tfile).data` — the same structure the
+ * backlinks pane renders.
+ *
+ * `.data` is a `Map` on current Obsidian and a plain object on older builds;
+ * both shapes are handled rather than pinned, because which one we get is an
+ * Obsidian-version detail with no bearing on the behaviour under test. Returns
+ * `[]` when the target is not in the vault model at all — which the caller's
+ * assertion then correctly reports as "no backlinks".
+ */
+async function backlinkSourcesFor(page: Page, targetPath: string): Promise<string[]> {
+  return page.evaluate((p) => {
+    const app = (window as unknown as {
+      app?: {
+        vault?: { getAbstractFileByPath?: (path: string) => unknown };
+        metadataCache?: {
+          getBacklinksForFile?: (file: unknown) => { data?: unknown } | undefined;
+        };
+      };
+    }).app;
+    const tfile = app?.vault?.getAbstractFileByPath?.(p);
+    if (!tfile) return [];
+    const data = app?.metadataCache?.getBacklinksForFile?.(tfile)?.data;
+    if (!data) return [];
+    const asMap = data as { keys?: () => Iterable<string> };
+    if (typeof asMap.keys === 'function') return Array.from(asMap.keys());
+    return Object.keys(data as Record<string, unknown>);
+  }, targetPath);
+}
+
+/** `app.workspace.getActiveFile()?.path` — what the user is actually looking at. */
+async function activeFilePath(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const app = (window as unknown as {
+      app?: { workspace?: { getActiveFile?: () => { path?: string } | null } };
+    }).app;
+    return app?.workspace?.getActiveFile?.()?.path ?? null;
+  });
+}

--- a/plugin/e2e/links-metadata.spec.ts
+++ b/plugin/e2e/links-metadata.spec.ts
@@ -5,7 +5,6 @@ import {
   findShadowVaultPath,
   waitForShadowVaultLoaded,
   runCommandViaPalette,
-  expandFolderInExplorer,
   type ObsidianHandle,
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
@@ -73,6 +72,30 @@ import { logPathFor } from './helpers/log-oracle';
  * re-runs link resolution after a lazy insert, and fix (b) alone is not enough
  * — the maintainer needs (a), or (a) + (b).
  *
+ * ── TWO FIXTURE SUBFOLDERS, NOT ONE ──────────────────────────────────────────
+ *
+ * These tests share ONE Obsidian session and run in declaration order, so state
+ * LEAKS FORWARD: test 6 expands `<S>-sub`, which permanently inserts
+ * `<S>-sub/Deep.md` into `fileMap` for every test after it. Test 8 ("a note in
+ * an UNEXPANDED subfolder is reachable from the Quick Switcher") therefore
+ * cannot use `<S>-sub` — it would be asserting against a folder that test 6 has
+ * already expanded, and any green it reported would be an artefact of test
+ * ORDER rather than a fact about the product. So test 8 gets its own fixture,
+ * `<S>-sub2/Deep2.md`, seeded before connect and expanded by NOBODY.
+ *
+ * ── WHY EVERY GESTURE CARRIES AN EXPLICIT TIMEOUT ────────────────────────────
+ *
+ * `playwright.config.ts` sets no `actionTimeout`, so Playwright's default of `0`
+ * (= wait forever) applies: a bare `locator.click()` on an element that never
+ * becomes actionable does not FAIL, it BLOCKS until the 180 s test timeout, and
+ * the report then says only "Test timeout exceeded" — no locator, no DOM, no
+ * vault model. `page.evaluate` has the same property (a wedged renderer never
+ * answers, and an `expect.poll` cannot time out while its own probe is stuck).
+ * That is how tests 4 and 6 each burned three minutes and told the maintainer
+ * nothing. Every click, wait and `evaluate` below is bounded well under the test
+ * timeout and dumps the DOM + vault model on failure. The BOUNDS are what
+ * changed; not one assertion is weaker.
+ *
  * HARD-FAILS, never skips.
  */
 
@@ -87,10 +110,39 @@ const SUB = `${STAMP}-sub`;          // subfolder — never walked at connect
 const DEEP = `${SUB}/Deep.md`;       // the note the whole defect is about
 const DEEP_LINKTEXT = `${SUB}/Deep`; // exactly what the `[[...]]` in C contains
 
+// A SECOND subfolder, reserved for test 8 and expanded by nobody — see "TWO
+// FIXTURE SUBFOLDERS" above. Test 6 expands SUB, so SUB can no longer stand for
+// "a folder the user has never opened" once test 6 has run.
+const SUB2 = `${STAMP}-sub2`;
+const DEEP2 = `${SUB2}/Deep2.md`;
+
 // Indexing is asynchronous (Obsidian re-resolves links off its own queue), so
 // every metadata assertion polls. 20 s is far past the observed settle time on a
 // warm connection; it exists so a RED is a real defect, not a slow machine.
 const META_TIMEOUT_MS = 20_000;
+
+/**
+ * Budget for ONE UI gesture (a click; waiting for a row to paint). Explicit
+ * because the config leaves `actionTimeout` at Playwright's default of 0 —
+ * "wait forever" — which turns any un-actionable element into a silent
+ * three-minute hang instead of a failure with a locator in it.
+ */
+const ACTION_TIMEOUT_MS = 15_000;
+
+/**
+ * Budget for ONE `page.evaluate`. `page.evaluate` has no timeout of its own: if
+ * the renderer's main thread is wedged (say, a lazy folder load blocking on
+ * SSH), a probe inside an `expect.poll` never returns and the poll's own timeout
+ * can never fire — the hang wins. Bounding the evaluate makes "the renderer
+ * stopped answering" a fast, named failure.
+ */
+const EVAL_TIMEOUT_MS = 10_000;
+
+/** Test 6's expand + the post-insert settle of the vault model. */
+const EXPAND_TIMEOUT_MS = 30_000;
+
+/** Test 6's two polls. Short enough that BOTH verdicts fit inside the test. */
+const DISCRIMINATOR_TIMEOUT_MS = 25_000;
 
 let obsidian: ObsidianHandle;
 let scaffold: ScaffoldResult;
@@ -121,6 +173,8 @@ test.beforeAll(async () => {
   await remote.mkdirp(SUB);
   await remote.writeFile(DEEP, '# Deep\n');
   await remote.writeFile(C, `# C\n\n[[${DEEP_LINKTEXT}]]\n`);
+  await remote.mkdirp(SUB2);
+  await remote.writeFile(DEEP2, '# Deep2\n');
 
   scaffold = scaffoldTestVault();
   obsidian = await launchObsidian(scaffold.vaultPath);
@@ -149,6 +203,7 @@ test.afterAll(async () => {
       remote.removeFile(D),
     ]);
     await remote.rmrf(SUB).catch(() => { /* best effort */ });
+    await remote.rmrf(SUB2).catch(() => { /* best effort */ });
     await remote.disconnect();
   }
   scaffold?.cleanup();
@@ -210,30 +265,66 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
       .toContain(A);
   });
 
+  /**
+   * The end-to-end user GESTURE, not just the index: open A, switch to Reading
+   * view (Obsidian's default is LIVE PREVIEW — a CodeMirror mode in which
+   * `.markdown-preview-view` does not exist; see reflect.spec.ts test 5), then
+   * click the rendered anchor and assert the workspace actually navigated.
+   *
+   * Each step is bounded and each failure dumps the reading-view state: does a
+   * preview pane exist, how many `a.internal-link` are inside it and what do they
+   * point at, what mode is the leaf in, what is `getActiveFile()`. The previous
+   * version's bare `.click()` calls inherited `actionTimeout: 0` and simply hung
+   * for the full 180 s when the anchor never became clickable — a timeout with no
+   * evidence in it. The ASSERTION is untouched: clicking a link MUST open its
+   * target.
+   */
   test('4 — clicking a wiki link opens the target note', async () => {
-    // The end-to-end user gesture, not just the index: open A, switch to Reading
-    // view (Obsidian's default is LIVE PREVIEW — a CodeMirror mode in which
-    // `.markdown-preview-view` does not exist; see reflect.spec.ts test 5), then
-    // click the rendered anchor and assert the workspace actually navigated.
-    await fileLocator(obsidian.page, A).click();
-    await runCommandViaPalette(obsidian.page, 'Toggle reading view');
+    await openNote(obsidian.page, A);
+    await ensureReadingView(obsidian.page, A);
 
     const link = obsidian.page.locator('.markdown-preview-view a.internal-link').first();
-    await expect(
-      link,
-      `no rendered a.internal-link in the reading view of "${A}" — the wiki link was ` +
-      'not even turned into a clickable anchor',
-    ).toBeVisible({ timeout: META_TIMEOUT_MS });
-    await link.click();
+    const rendered = await link
+      .waitFor({ state: 'visible', timeout: META_TIMEOUT_MS })
+      .then(() => true)
+      .catch(() => false);
+    if (!rendered) {
+      throw new Error(
+        `no rendered a.internal-link in the reading view of "${A}" within ` +
+        `${META_TIMEOUT_MS}ms — the wiki link was not even turned into a clickable ` +
+        `anchor.\n${await dumpReadingView(obsidian.page)}`,
+      );
+    }
 
-    await expect
-      .poll(() => activeFilePath(obsidian.page), {
-        message:
-          `clicking the [[${STAMP}-B]] anchor in "${A}" did not navigate to "${B}" — ` +
-          'the link renders but does not open its target.',
-        timeout: META_TIMEOUT_MS,
-      })
-      .toBe(B);
+    // Bounded on purpose: an anchor that is present but never actionable (covered
+    // by Obsidian's hover page-preview popover, zero-sized under Xvfb, …) makes an
+    // unbounded click wait forever. 15 s of Playwright's actionability retries,
+    // then the truth.
+    const clickErr = await link
+      .click({ timeout: ACTION_TIMEOUT_MS })
+      .then(() => null)
+      .catch((e: unknown) => (e instanceof Error ? e.message : String(e)));
+    if (clickErr) {
+      throw new Error(
+        `the a.internal-link in "${A}" is rendered but could not be CLICKED within ` +
+        `${ACTION_TIMEOUT_MS}ms: ${clickErr}\n${await dumpReadingView(obsidian.page)}`,
+      );
+    }
+
+    try {
+      await expect
+        .poll(() => activeFilePath(obsidian.page), {
+          message:
+            `clicking the [[${STAMP}-B]] anchor in "${A}" did not navigate to "${B}" — ` +
+            'the link renders and accepts the click, but does not open its target.',
+          timeout: META_TIMEOUT_MS,
+        })
+        .toBe(B);
+    } catch (e) {
+      throw new Error(
+        `${e instanceof Error ? e.message : String(e)}\n${await dumpReadingView(obsidian.page)}`,
+      );
+    }
   });
 
   /**
@@ -315,35 +406,56 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
    *
    * 6a green + 6b red ⇒ "invalidate metadata on lazy insert" is REQUIRED, and even
    * then every unexpanded folder stays invisible — i.e. the real fix is a
-   * background full index.
+   * background full index. That verdict IS the deliverable of this test, and it
+   * only exists if the test FINISHES: the expand (30 s) and both polls (25 s each)
+   * are bounded, so 6b's message — "the file IS in fileMap and the link STILL did
+   * not resolve" — actually gets printed, instead of being swallowed by a
+   * three-minute test timeout that says nothing at all.
    */
   test('6 — expanding the folder in File Explorer makes the subfolder link resolve', async () => {
-    await expandFolderInExplorer(obsidian.page, SUB, META_TIMEOUT_MS);
+    await expandFolder(obsidian.page, SUB, EXPAND_TIMEOUT_MS);
 
     // 6a — the lazy load itself landed.
-    await expect
-      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).inFileMap, {
-        message:
-          `after clicking the "${SUB}" folder title, "${DEEP}" is STILL not in ` +
-          'vault.fileMap — LazyFolderLoader.loadFolder did not materialise the folder\'s ' +
-          'children, so the one escape hatch from the lazy walk is broken too.',
-        timeout: META_TIMEOUT_MS,
-      })
-      .toBe(true);
+    try {
+      await expect
+        .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).inFileMap, {
+          message:
+            `after clicking the "${SUB}" folder title, "${DEEP}" is STILL not in ` +
+            "vault.fileMap — LazyFolderLoader.loadFolder did not materialise the folder's " +
+            'children, so the one escape hatch from the lazy walk is broken too.',
+          timeout: DISCRIMINATOR_TIMEOUT_MS,
+        })
+        .toBe(true);
+    } catch (e) {
+      throw new Error(
+        `${e instanceof Error ? e.message : String(e)}\n${await dumpVaultModel(obsidian.page, SUB)}`,
+      );
+    }
 
-    // 6b — and the metadata cache noticed.
-    await expect
-      .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).resolved, {
-        message:
-          `"${DEEP}" is now in vault.fileMap (6a passed) but ` +
-          `metadataCache.resolvedLinks["${C}"] still does not contain it. The lazy ` +
-          'insert enlarged the vault WITHOUT making Obsidian re-resolve the links of ' +
-          'notes that were already indexed — so even a user who dutifully expands every ' +
-          'folder keeps broken links. This is the "invalidate metadata on lazy insert" ' +
-          'half of the fix.',
-        timeout: META_TIMEOUT_MS,
-      })
-      .toContain(DEEP);
+    // 6b — and the metadata cache noticed. 6a has just proven the file IS in
+    // fileMap, so a red here can only mean the lazy insert re-resolved nothing.
+    try {
+      await expect
+        .poll(async () => (await probeLinks(obsidian.page, C, DEEP)).resolved, {
+          message:
+            `"${DEEP}" IS now in vault.fileMap (6a passed) but ` +
+            `metadataCache.resolvedLinks["${C}"] still does not contain it. The lazy ` +
+            'insert enlarged the vault WITHOUT making Obsidian re-resolve the links of ' +
+            'notes that were already indexed — so even a user who dutifully expands every ' +
+            'folder keeps broken links. This is the "invalidate metadata on lazy insert" ' +
+            'half of the fix, and it is needed ON TOP OF a fuller walk.',
+          timeout: DISCRIMINATOR_TIMEOUT_MS,
+        })
+        .toContain(DEEP);
+    } catch (e) {
+      const probe = await probeLinks(obsidian.page, C, DEEP);
+      throw new Error(
+        `${e instanceof Error ? e.message : String(e)}\n` +
+        `  fileMap has "${DEEP}": ${probe.inFileMap}\n` +
+        `  resolvedLinks["${C}"]: ${JSON.stringify(probe.resolved)}\n` +
+        `  unresolvedLinks["${C}"]: ${JSON.stringify(probe.unresolved)}`,
+      );
+    }
   });
 
   /**
@@ -389,8 +501,24 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
    * the graph) enumerate `fileMap`, so a note in an unexpanded subfolder is not
    * merely unlinkable, it is UNREACHABLE: the user types its name and Obsidian
    * tells them it does not exist. This is what the bug actually feels like.
+   *
+   * ISOLATION — this test used to search for `Deep`, which lives in `<S>-sub`:
+   * the very folder test 6 EXPANDS, in the same Obsidian session, two tests
+   * earlier. A pass would then have been unfalsifiable — indistinguishable from
+   * "test 6 already loaded that folder into fileMap for me". It now targets
+   * `<S>-sub2/Deep2.md`, a fixture seeded before connect that NOTHING in this
+   * session expands, so the scenario in the title is the scenario under test.
+   *
+   * The "was it really unexpanded?" fact is captured as a DIAGNOSTIC and folded
+   * into the failure message rather than asserted. An `expect(inFileMap).toBe(false)`
+   * would encode today's bug as the requirement and would go red the day the
+   * product starts indexing the whole vault — the exact inversion this file
+   * exists to prevent. The real assertion is unchanged and unweakened: a note
+   * that exists on the remote MUST be reachable from the Quick Switcher.
    */
   test('8 — Quick Switcher can reach a note in an unexpanded subfolder', async () => {
+    const before = await probeLinks(obsidian.page, C, DEEP2);
+
     await runCommandViaPalette(obsidian.page, 'Open quick switcher');
 
     const input = obsidian.page
@@ -398,26 +526,62 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
       .first();
     await expect(input, 'the Quick Switcher never opened').toBeVisible({ timeout: 10_000 });
     await input.fill('');
-    await obsidian.page.keyboard.type('Deep', { delay: 20 });
+    await obsidian.page.keyboard.type('Deep2', { delay: 20 });
 
-    await expect(
-      obsidian.page.locator('.prompt .suggestion-item', { hasText: 'Deep' }).first(),
-      `the Quick Switcher offers no suggestion for "Deep" — "${DEEP}" exists on the ` +
-      'remote but lives in a subfolder the lazy connect walk never descended into ' +
-      '(src/main.ts:972-973), so it is absent from vault.fileMap and the switcher ' +
-      'cannot enumerate it. To the user, the note simply does not exist.',
-    ).toBeVisible({ timeout: META_TIMEOUT_MS });
+    try {
+      await expect(
+        obsidian.page.locator('.prompt .suggestion-item', { hasText: 'Deep2' }).first(),
+        `the Quick Switcher offers no suggestion for "Deep2" — "${DEEP2}" exists on the ` +
+        'remote, but it lives in a subfolder that NOTHING in this session has expanded, ' +
+        'so the lazy connect walk (src/main.ts:972-973) never descended into it. To the ' +
+        'user, the note simply does not exist.\n' +
+        `  DIAGNOSTIC — when the search was typed, app.vault.getAbstractFileByPath(` +
+        `"${DEEP2}") was ${before.inFileMap ? 'a TFile' : 'null'}. If it was null, the ` +
+        'switcher cannot enumerate what is not in vault.fileMap and the fix belongs in ' +
+        'the vault model (a background/eager walk); if it WAS a TFile, the model is fine ' +
+        'and the switcher/search index is the layer at fault.',
+      ).toBeVisible({ timeout: META_TIMEOUT_MS });
+    } catch (e) {
+      throw new Error(
+        `${e instanceof Error ? e.message : String(e)}\n` +
+        `  suggestions on screen: ${JSON.stringify(await switcherSuggestions(obsidian.page))}\n` +
+        `${await dumpVaultModel(obsidian.page, SUB2)}`,
+      );
+    }
   });
 });
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Locate a File Explorer entry by filename. Obsidian sets `data-path` on every
- * `.nav-file-title`, so the selector is stable across themes / language packs.
+ * Fail `work` at `ms` instead of letting it run to the test timeout.
+ *
+ * Needed because two things in this stack have NO timeout of their own:
+ * `page.evaluate` (a wedged renderer simply never answers — and an `expect.poll`
+ * cannot time out while its own probe is stuck inside one), and, since
+ * `playwright.config.ts` leaves `actionTimeout` at its default of `0`, anything
+ * that waits for actionability. Both previously produced a bare "Test timeout of
+ * 180000ms exceeded" with nothing in it. A late rejection from `work` is absorbed
+ * so it cannot resurface as an unhandled rejection after the race is over.
  */
-function fileLocator(page: Page, fileName: string) {
-  return page.locator(`.nav-file-title[data-path$="${fileName}"]`);
+async function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
+  void work.catch(() => { /* the race below already reports it */ });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(
+        `${what} did not settle within ${ms}ms — the Obsidian renderer stopped ` +
+        'answering. Bounded deliberately: an unbounded wait here would eat the whole ' +
+        'test timeout and report no evidence at all.',
+      )),
+      ms,
+    );
+  });
+  try {
+    return await Promise.race([work, guard]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 interface LinkProbe {
@@ -438,29 +602,33 @@ interface LinkProbe {
  * that never actually existed.
  */
 async function probeLinks(page: Page, src: string, target: string): Promise<LinkProbe> {
-  return page.evaluate(
-    ({ src, target }) => {
-      const app = (window as unknown as {
-        app?: {
-          vault?: {
-            fileMap?: Record<string, unknown>;
-            getAbstractFileByPath?: (p: string) => unknown;
+  return withDeadline(
+    page.evaluate(
+      ({ src, target }) => {
+        const app = (window as unknown as {
+          app?: {
+            vault?: {
+              fileMap?: Record<string, unknown>;
+              getAbstractFileByPath?: (p: string) => unknown;
+            };
+            metadataCache?: {
+              resolvedLinks?: Record<string, Record<string, number>>;
+              unresolvedLinks?: Record<string, Record<string, number>>;
+            };
           };
-          metadataCache?: {
-            resolvedLinks?: Record<string, Record<string, number>>;
-            unresolvedLinks?: Record<string, Record<string, number>>;
-          };
+        }).app;
+        const mc = app?.metadataCache;
+        return {
+          inFileMap: app?.vault?.getAbstractFileByPath?.(target) != null,
+          resolved: Object.keys(mc?.resolvedLinks?.[src] ?? {}),
+          unresolved: Object.keys(mc?.unresolvedLinks?.[src] ?? {}),
+          fileMapSample: Object.keys(app?.vault?.fileMap ?? {}).slice(0, 30),
         };
-      }).app;
-      const mc = app?.metadataCache;
-      return {
-        inFileMap: app?.vault?.getAbstractFileByPath?.(target) != null,
-        resolved: Object.keys(mc?.resolvedLinks?.[src] ?? {}),
-        unresolved: Object.keys(mc?.unresolvedLinks?.[src] ?? {}),
-        fileMapSample: Object.keys(app?.vault?.fileMap ?? {}).slice(0, 30),
-      };
-    },
-    { src, target },
+      },
+      { src, target },
+    ),
+    EVAL_TIMEOUT_MS,
+    `probeLinks("${src}" → "${target}")`,
   );
 }
 
@@ -476,31 +644,274 @@ async function probeLinks(page: Page, src: string, target: string): Promise<Link
  * assertion then correctly reports as "no backlinks".
  */
 async function backlinkSourcesFor(page: Page, targetPath: string): Promise<string[]> {
-  return page.evaluate((p) => {
-    const app = (window as unknown as {
-      app?: {
-        vault?: { getAbstractFileByPath?: (path: string) => unknown };
-        metadataCache?: {
-          getBacklinksForFile?: (file: unknown) => { data?: unknown } | undefined;
+  return withDeadline(
+    page.evaluate((p) => {
+      const app = (window as unknown as {
+        app?: {
+          vault?: { getAbstractFileByPath?: (path: string) => unknown };
+          metadataCache?: {
+            getBacklinksForFile?: (file: unknown) => { data?: unknown } | undefined;
+          };
         };
-      };
-    }).app;
-    const tfile = app?.vault?.getAbstractFileByPath?.(p);
-    if (!tfile) return [];
-    const data = app?.metadataCache?.getBacklinksForFile?.(tfile)?.data;
-    if (!data) return [];
-    const asMap = data as { keys?: () => Iterable<string> };
-    if (typeof asMap.keys === 'function') return Array.from(asMap.keys());
-    return Object.keys(data as Record<string, unknown>);
-  }, targetPath);
+      }).app;
+      const tfile = app?.vault?.getAbstractFileByPath?.(p);
+      if (!tfile) return [];
+      const data = app?.metadataCache?.getBacklinksForFile?.(tfile)?.data;
+      if (!data) return [];
+      const asMap = data as { keys?: () => Iterable<string> };
+      if (typeof asMap.keys === 'function') return Array.from(asMap.keys());
+      return Object.keys(data as Record<string, unknown>);
+    }, targetPath),
+    EVAL_TIMEOUT_MS,
+    `backlinkSourcesFor("${targetPath}")`,
+  );
 }
 
 /** `app.workspace.getActiveFile()?.path` — what the user is actually looking at. */
 async function activeFilePath(page: Page): Promise<string | null> {
-  return page.evaluate(() => {
-    const app = (window as unknown as {
-      app?: { workspace?: { getActiveFile?: () => { path?: string } | null } };
-    }).app;
-    return app?.workspace?.getActiveFile?.()?.path ?? null;
-  });
+  return withDeadline(
+    page.evaluate(() => {
+      const app = (window as unknown as {
+        app?: { workspace?: { getActiveFile?: () => { path?: string } | null } };
+      }).app;
+      return app?.workspace?.getActiveFile?.()?.path ?? null;
+    }),
+    EVAL_TIMEOUT_MS,
+    'activeFilePath()',
+  );
+}
+
+/**
+ * Open a note by clicking its File Explorer row — the user's own gesture — and
+ * wait until the workspace agrees that note is active.
+ *
+ * The wait and the click both carry explicit timeouts: under `actionTimeout: 0`,
+ * a row that is attached but never becomes actionable (headless Obsidian's File
+ * Explorer paint is lazy/virtualised under Xvfb) makes `click()` block forever.
+ */
+async function openNote(page: Page, notePath: string): Promise<void> {
+  const nav = page.locator(`.nav-file-title[data-path$="${notePath}"]`).first();
+  const visible = await nav
+    .waitFor({ state: 'visible', timeout: ACTION_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!visible) {
+    throw new Error(
+      `openNote: no visible .nav-file-title for "${notePath}" within ` +
+      `${ACTION_TIMEOUT_MS}ms — the connect walk never materialised it (or the File ` +
+      `Explorer never painted it), so there is nothing to click.\n` +
+      `${await dumpVaultModel(page, notePath)}`,
+    );
+  }
+
+  const clickErr = await nav
+    .click({ timeout: ACTION_TIMEOUT_MS })
+    .then(() => null)
+    .catch((e: unknown) => (e instanceof Error ? e.message : String(e)));
+  if (clickErr) {
+    throw new Error(
+      `openNote: the File Explorer row for "${notePath}" could not be clicked within ` +
+      `${ACTION_TIMEOUT_MS}ms: ${clickErr}\n${await dumpVaultModel(page, notePath)}`,
+    );
+  }
+
+  await expect
+    .poll(() => activeFilePath(page), {
+      message:
+        `openNote: clicking the File Explorer row for "${notePath}" did not make it the ` +
+        'active file — the note could not even be opened, so nothing downstream of this ' +
+        'would mean anything.',
+      timeout: ACTION_TIMEOUT_MS,
+    })
+    .toBe(notePath);
+}
+
+/**
+ * Make sure the READING view is what is on screen for the note that is open.
+ *
+ * Obsidian's default is Live Preview, a CodeMirror mode in which
+ * `.markdown-preview-view` does not exist at all. `Toggle reading view` is a
+ * TOGGLE and the mode sticks to the leaf, so firing it unconditionally would
+ * flip a note that is ALREADY in reading view straight back into editing — hence
+ * the guard. (Same idiom as `images.spec.ts`'s `openInReadingView`, whose
+ * root-embed test passes in CI, so reading view itself is known to work here.)
+ */
+async function ensureReadingView(page: Page, notePath: string): Promise<void> {
+  const preview = page.locator('.markdown-preview-view').first();
+  const already = await preview.isVisible({ timeout: 2_000 }).catch(() => false);
+  if (!already) {
+    await runCommandViaPalette(page, 'Toggle reading view');
+  }
+
+  const showing = await preview
+    .waitFor({ state: 'visible', timeout: META_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!showing) {
+    throw new Error(
+      `"${notePath}" never entered reading view — no .markdown-preview-view appeared ` +
+      `within ${META_TIMEOUT_MS}ms of "Toggle reading view".\n${await dumpReadingView(page)}`,
+    );
+  }
+}
+
+/**
+ * Expand a folder in the File Explorer, then wait until its children are
+ * actually IN the vault model.
+ *
+ * Deliberately NOT `helpers/obsidian.ts:expandFolderInExplorer`: that helper
+ * waits for the folder title to be merely `attached` and then issues a bare
+ * `title.click()`, which — under the config's default `actionTimeout: 0` — waits
+ * forever on a row that is attached but not actionable. That is precisely the
+ * three-minute hang this test used to die of, and a hang reports nothing. Same
+ * PRODUCT gesture (a real click on `.nav-folder-title[data-path=…]`, which is what
+ * the delegated listener at `src/main.ts:919-928` hooks), bounded, and loud on
+ * failure. The shared helper is used by other specs and is not this spec's to
+ * change.
+ *
+ * Waits on `vault.fileMap` rather than on rendered `.nav-file-title` nodes: the
+ * model is what the load actually produces, and the File Explorer's paint races
+ * under Xvfb.
+ */
+async function expandFolder(page: Page, folderPath: string, timeoutMs: number): Promise<void> {
+  const title = page.locator(`.nav-folder-title[data-path="${folderPath}"]`).first();
+  const visible = await title
+    .waitFor({ state: 'visible', timeout: ACTION_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!visible) {
+    throw new Error(
+      `expandFolder: no visible .nav-folder-title[data-path="${folderPath}"] within ` +
+      `${ACTION_TIMEOUT_MS}ms — the folder was never materialised by the connect ` +
+      `populate, so there is nothing to expand.\n${await dumpVaultModel(page, folderPath)}`,
+    );
+  }
+
+  const clickErr = await title
+    .click({ timeout: ACTION_TIMEOUT_MS })
+    .then(() => null)
+    .catch((e: unknown) => (e instanceof Error ? e.message : String(e)));
+  if (clickErr) {
+    throw new Error(
+      `expandFolder: the "${folderPath}" folder title is rendered but could not be ` +
+      `CLICKED within ${ACTION_TIMEOUT_MS}ms: ${clickErr}\n` +
+      `${await dumpVaultModel(page, folderPath)}`,
+    );
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await childrenInFileMap(page, folderPath)) >= 1) return;
+    await new Promise((r) => setTimeout(r, 300));
+  }
+
+  throw new Error(
+    `expandFolder: "${folderPath}" still had no children in vault.fileMap within ` +
+    `${timeoutMs}ms of clicking its .nav-folder-title — LazyFolderLoader.loadFolder ` +
+    'never landed, so the one escape hatch from the lazy walk is broken too.\n' +
+    `${await dumpVaultModel(page, folderPath)}`,
+  );
+}
+
+/** How many `fileMap` keys sit under `folderPath/`. */
+async function childrenInFileMap(page: Page, folderPath: string): Promise<number> {
+  return withDeadline(
+    page.evaluate((prefix) => {
+      const app = (window as unknown as {
+        app?: { vault?: { fileMap?: Record<string, unknown> } };
+      }).app;
+      return Object.keys(app?.vault?.fileMap ?? {})
+        .filter((k) => k.startsWith(`${prefix}/`)).length;
+    }, folderPath),
+    EVAL_TIMEOUT_MS,
+    `childrenInFileMap("${folderPath}")`,
+  ).catch(() => 0);
+}
+
+/**
+ * What the vault model and the File Explorer actually contain around
+ * `aroundPath`. A bare "element not found" cannot separate "the populate never
+ * inserted it" from "it IS in the model but the explorer has not painted it";
+ * this can, in one CI round.
+ */
+async function dumpVaultModel(page: Page, aroundPath: string): Promise<string> {
+  const state = await withDeadline(
+    page.evaluate((needle) => {
+      const app = (window as unknown as {
+        app?: { vault?: { fileMap?: Record<string, unknown> } };
+      }).app;
+      const keys = Object.keys(app?.vault?.fileMap ?? {});
+      return {
+        fileMapKeys: keys.length,
+        hasExactPath: keys.includes(needle),
+        under: keys.filter((k) => k.startsWith(`${needle}/`)).slice(0, 20),
+        sample: keys.slice(0, 30),
+        navFileTitles: Array.from(document.querySelectorAll('.nav-file-title'))
+          .map((el) => el.getAttribute('data-path'))
+          .slice(0, 30),
+        navFolderTitles: Array.from(document.querySelectorAll('.nav-folder-title'))
+          .map((el) => el.getAttribute('data-path'))
+          .slice(0, 20),
+      };
+    }, aroundPath),
+    EVAL_TIMEOUT_MS,
+    `dumpVaultModel("${aroundPath}")`,
+  ).catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
+
+  return `vault model around "${aroundPath}": ${JSON.stringify(state)}`;
+}
+
+/**
+ * Everything test 4 needs in order to explain itself: is there a preview pane at
+ * all, how many `a.internal-link` are inside it and what do they point at, are
+ * there any anywhere else (i.e. did the leaf stay in Live Preview), what mode is
+ * the active leaf in, and which file is actually open.
+ */
+async function dumpReadingView(page: Page): Promise<string> {
+  const state = await withDeadline(
+    page.evaluate(() => {
+      const app = (window as unknown as {
+        app?: {
+          workspace?: {
+            getActiveFile?: () => { path?: string } | null;
+            activeLeaf?: { getViewState?: () => { state?: { mode?: string } } } | null;
+          };
+        };
+      }).app;
+      const anchors = Array.from(
+        document.querySelectorAll('.markdown-preview-view a.internal-link'),
+      ).map((el) => ({
+        href: el.getAttribute('href'),
+        dataHref: el.getAttribute('data-href'),
+        text: (el.textContent ?? '').trim(),
+        className: el.className,
+        painted: (el as HTMLElement).offsetParent !== null,
+      }));
+      return {
+        previewPanes: document.querySelectorAll('.markdown-preview-view').length,
+        internalLinksInPreview: anchors.length,
+        anchors: anchors.slice(0, 10),
+        internalLinksAnywhere: document.querySelectorAll('a.internal-link').length,
+        editorPanes: document.querySelectorAll('.markdown-source-view').length,
+        leafMode: app?.workspace?.activeLeaf?.getViewState?.()?.state?.mode ?? null,
+        activeFile: app?.workspace?.getActiveFile?.()?.path ?? null,
+      };
+    }),
+    EVAL_TIMEOUT_MS,
+    'dumpReadingView()',
+  ).catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
+
+  return `reading-view state: ${JSON.stringify(state)}`;
+}
+
+/** The suggestion rows the Quick Switcher is currently showing. */
+async function switcherSuggestions(page: Page): Promise<string[]> {
+  return withDeadline(
+    page.evaluate(() =>
+      Array.from(document.querySelectorAll('.prompt .suggestion-item'))
+        .map((el) => (el.textContent ?? '').trim())
+        .slice(0, 20)),
+    EVAL_TIMEOUT_MS,
+    'switcherSuggestions()',
+  ).catch(() => []);
 }

--- a/plugin/e2e/links-metadata.spec.ts
+++ b/plugin/e2e/links-metadata.spec.ts
@@ -5,6 +5,7 @@ import {
   findShadowVaultPath,
   waitForShadowVaultLoaded,
   runCommandViaPalette,
+  dismissBlockingModals,
   type ObsidianHandle,
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
@@ -85,16 +86,30 @@ import { logPathFor } from './helpers/log-oracle';
  *
  * ── WHY EVERY GESTURE CARRIES AN EXPLICIT TIMEOUT ────────────────────────────
  *
- * `playwright.config.ts` sets no `actionTimeout`, so Playwright's default of `0`
- * (= wait forever) applies: a bare `locator.click()` on an element that never
- * becomes actionable does not FAIL, it BLOCKS until the 180 s test timeout, and
- * the report then says only "Test timeout exceeded" — no locator, no DOM, no
- * vault model. `page.evaluate` has the same property (a wedged renderer never
- * answers, and an `expect.poll` cannot time out while its own probe is stuck).
- * That is how tests 4 and 6 each burned three minutes and told the maintainer
- * nothing. Every click, wait and `evaluate` below is bounded well under the test
- * timeout and dumps the DOM + vault model on failure. The BOUNDS are what
- * changed; not one assertion is weaker.
+ * `playwright.config.ts` now sets `actionTimeout: 30_000`, so a click on an
+ * element that never becomes actionable FAILS with Playwright's own locator
+ * diagnostic (which resolved element, what covered it) instead of blocking until
+ * the test timeout. That diagnostic is the single most useful artefact a red run
+ * here can produce, so the gestures below keep their own, TIGHTER bounds only
+ * where a faster verdict is worth more than the extra retry window — and they
+ * always let Playwright's message propagate rather than replacing it.
+ *
+ * `page.evaluate` still has NO timeout of its own: a wedged renderer never
+ * answers, and an `expect.poll` cannot time out while its own probe is stuck
+ * inside one. That is what `withDeadline` below is for, and it is used ONLY on
+ * evaluates, never to wrap a click.
+ *
+ * ── AN OPEN MODAL SWALLOWS EVERY CLICK ───────────────────────────────────────
+ *
+ * Dismissing the trust dialog makes Obsidian auto-open its Settings dialog on
+ * the Community-plugins tab (see `dismissBlockingModals`). That `.modal-container`
+ * covers the whole window and intercepts pointer events, so the File Explorer
+ * and the rendered link are un-clickable while it is up — the model-level tests
+ * (1, 2, 3) pass and only the gesture tests (4, 6, 8) fail, which is a very
+ * misleading signature. `dismissBlockingModals` is therefore called after the
+ * shadow vault is up and again before every click sequence. It is a HARNESS fix
+ * (Playwright cannot click a covered element); it weakens no assertion, and it
+ * logs whatever it closed.
  *
  * HARD-FAILS, never skips.
  */
@@ -122,10 +137,12 @@ const DEEP2 = `${SUB2}/Deep2.md`;
 const META_TIMEOUT_MS = 20_000;
 
 /**
- * Budget for ONE UI gesture (a click; waiting for a row to paint). Explicit
- * because the config leaves `actionTimeout` at Playwright's default of 0 —
- * "wait forever" — which turns any un-actionable element into a silent
- * three-minute hang instead of a failure with a locator in it.
+ * Budget for ONE UI gesture (a click; waiting for a row to paint). Tighter than
+ * the config's `actionTimeout: 30_000` on purpose: several gestures stack up
+ * inside one test, and 15 s is already far past the observed settle time for a
+ * row that is going to become actionable at all. Playwright's own failure text
+ * (including "…subtree intercepts pointer events" and the offending element) is
+ * always propagated into the thrown error, never replaced by it.
  */
 const ACTION_TIMEOUT_MS = 15_000;
 
@@ -191,6 +208,13 @@ test.beforeAll(async () => {
   // Every assertion below is about what that populate produced, so we must not
   // race it.
   await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+  // `launchObsidian` dismissed the trust dialog, and Obsidian answered that by
+  // auto-opening its Settings dialog on the Community-plugins tab. It is a
+  // full-window `.modal-container.mod-dim` and it intercepts pointer events, so
+  // nothing in the File Explorer can be clicked until it is gone. Anything it
+  // closes gets logged.
+  await dismissBlockingModals(obsidian.page);
 });
 
 test.afterAll(async () => {
@@ -273,13 +297,16 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
    *
    * Each step is bounded and each failure dumps the reading-view state: does a
    * preview pane exist, how many `a.internal-link` are inside it and what do they
-   * point at, what mode is the leaf in, what is `getActiveFile()`. The previous
-   * version's bare `.click()` calls inherited `actionTimeout: 0` and simply hung
-   * for the full 180 s when the anchor never became clickable — a timeout with no
-   * evidence in it. The ASSERTION is untouched: clicking a link MUST open its
+   * point at, what mode is the leaf in, what is `getActiveFile()`. Playwright's
+   * own click diagnostic is folded into that message rather than discarded — it
+   * is what identified the real cause of this test's last red: the anchor was
+   * "visible, enabled and stable" and the click still could not land, because
+   * Obsidian's auto-opened Settings dialog was covering the window. Hence the
+   * modal sweep first. The ASSERTION is untouched: clicking a link MUST open its
    * target.
    */
   test('4 — clicking a wiki link opens the target note', async () => {
+    await dismissBlockingModals(obsidian.page);
     await openNote(obsidian.page, A);
     await ensureReadingView(obsidian.page, A);
 
@@ -296,10 +323,12 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
       );
     }
 
-    // Bounded on purpose: an anchor that is present but never actionable (covered
-    // by Obsidian's hover page-preview popover, zero-sized under Xvfb, …) makes an
-    // unbounded click wait forever. 15 s of Playwright's actionability retries,
-    // then the truth.
+    // 15 s of Playwright's actionability retries — tighter than the config's 30 s
+    // `actionTimeout` because several gestures stack inside this test. An anchor
+    // that is present but never actionable (covered by an Obsidian modal, by the
+    // hover page-preview popover, zero-sized under Xvfb, …) fails here, and
+    // Playwright's message — which names the element doing the covering — is
+    // quoted verbatim into the error below rather than replaced by it.
     const clickErr = await link
       .click({ timeout: ACTION_TIMEOUT_MS })
       .then(() => null)
@@ -413,6 +442,9 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
    * three-minute test timeout that says nothing at all.
    */
   test('6 — expanding the folder in File Explorer makes the subfolder link resolve', async () => {
+    // A modal left up by an earlier test would make the folder title
+    // un-clickable and turn 6a into a false red about LazyFolderLoader.
+    await dismissBlockingModals(obsidian.page);
     await expandFolder(obsidian.page, SUB, EXPAND_TIMEOUT_MS);
 
     // 6a — the lazy load itself landed.
@@ -519,6 +551,9 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
   test('8 — Quick Switcher can reach a note in an unexpanded subfolder', async () => {
     const before = await probeLinks(obsidian.page, C, DEEP2);
 
+    // BEFORE the palette is opened, never after: the palette is itself a
+    // `.modal-container` and this would close it.
+    await dismissBlockingModals(obsidian.page);
     await runCommandViaPalette(obsidian.page, 'Open quick switcher');
 
     const input = obsidian.page
@@ -556,13 +591,20 @@ test.describe('wiki links, backlinks + metadata cache over a remote vault', () =
 /**
  * Fail `work` at `ms` instead of letting it run to the test timeout.
  *
- * Needed because two things in this stack have NO timeout of their own:
- * `page.evaluate` (a wedged renderer simply never answers — and an `expect.poll`
- * cannot time out while its own probe is stuck inside one), and, since
- * `playwright.config.ts` leaves `actionTimeout` at its default of `0`, anything
- * that waits for actionability. Both previously produced a bare "Test timeout of
- * 180000ms exceeded" with nothing in it. A late rejection from `work` is absorbed
- * so it cannot resurface as an unhandled rejection after the race is over.
+ * Scoped deliberately to `page.evaluate`, which has NO timeout of its own: a
+ * wedged renderer simply never answers, and an `expect.poll` cannot time out
+ * while its own probe is stuck inside one — the hang wins and the report says
+ * only "Test timeout of 180000ms exceeded".
+ *
+ * It is NOT used around clicks. `playwright.config.ts` now sets
+ * `actionTimeout: 30_000`, so an un-actionable element already fails on its own,
+ * and Playwright's message ("locator resolved to <div …>; <div class=
+ * "modal-container mod-dim"> subtree intercepts pointer events") is strictly
+ * better evidence than anything a deadline wrapper could synthesise. Racing a
+ * click against a deadline can only throw that away.
+ *
+ * A late rejection from `work` is absorbed so it cannot resurface as an
+ * unhandled rejection after the race is over.
  */
 async function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
   void work.catch(() => { /* the race below already reports it */ });
@@ -685,11 +727,18 @@ async function activeFilePath(page: Page): Promise<string | null> {
  * Open a note by clicking its File Explorer row — the user's own gesture — and
  * wait until the workspace agrees that note is active.
  *
- * The wait and the click both carry explicit timeouts: under `actionTimeout: 0`,
- * a row that is attached but never becomes actionable (headless Obsidian's File
- * Explorer paint is lazy/virtualised under Xvfb) makes `click()` block forever.
+ * Sweeps modals first: an open `.modal-container` (Obsidian auto-opens Settings
+ * after the trust dialog is dismissed) covers the File Explorer and makes the
+ * row un-clickable no matter how healthy the vault model is.
+ *
+ * The wait and the click carry explicit 15 s bounds — tighter than the config's
+ * 30 s `actionTimeout` because several gestures stack inside one test — and
+ * Playwright's own failure text is quoted verbatim into the error, since that is
+ * where "…intercepts pointer events" and the covering element show up.
  */
 async function openNote(page: Page, notePath: string): Promise<void> {
+  await dismissBlockingModals(page);
+
   const nav = page.locator(`.nav-file-title[data-path$="${notePath}"]`).first();
   const visible = await nav
     .waitFor({ state: 'visible', timeout: ACTION_TIMEOUT_MS })
@@ -740,6 +789,8 @@ async function ensureReadingView(page: Page, notePath: string): Promise<void> {
   const preview = page.locator('.markdown-preview-view').first();
   const already = await preview.isVisible({ timeout: 2_000 }).catch(() => false);
   if (!already) {
+    // Before the palette, not after — the palette is a `.modal-container` too.
+    await dismissBlockingModals(page);
     await runCommandViaPalette(page, 'Toggle reading view');
   }
 
@@ -760,20 +811,24 @@ async function ensureReadingView(page: Page, notePath: string): Promise<void> {
  * actually IN the vault model.
  *
  * Deliberately NOT `helpers/obsidian.ts:expandFolderInExplorer`: that helper
- * waits for the folder title to be merely `attached` and then issues a bare
- * `title.click()`, which — under the config's default `actionTimeout: 0` — waits
- * forever on a row that is attached but not actionable. That is precisely the
- * three-minute hang this test used to die of, and a hang reports nothing. Same
- * PRODUCT gesture (a real click on `.nav-folder-title[data-path=…]`, which is what
- * the delegated listener at `src/main.ts:919-928` hooks), bounded, and loud on
- * failure. The shared helper is used by other specs and is not this spec's to
- * change.
+ * waits for the folder title to be merely `attached`, which under Xvfb's
+ * virtualised File Explorer is satisfied by a row that never becomes actionable
+ * — a 30 s `actionTimeout` burn with a weaker message than the one below. Same
+ * PRODUCT gesture (a real click on `.nav-folder-title[data-path=…]`, which is
+ * what the delegated listener at `src/main.ts:919-928` hooks), tighter bound,
+ * and loud on failure. The shared helper is used by other specs and is not this
+ * spec's to change.
+ *
+ * Sweeps modals first, for the same reason `openNote` does: a covered folder
+ * title cannot be clicked, and the resulting red would libel LazyFolderLoader.
  *
  * Waits on `vault.fileMap` rather than on rendered `.nav-file-title` nodes: the
  * model is what the load actually produces, and the File Explorer's paint races
  * under Xvfb.
  */
 async function expandFolder(page: Page, folderPath: string, timeoutMs: number): Promise<void> {
+  await dismissBlockingModals(page);
+
   const title = page.locator(`.nav-folder-title[data-path="${folderPath}"]`).first();
   const visible = await title
     .waitFor({ state: 'visible', timeout: ACTION_TIMEOUT_MS })

--- a/plugin/e2e/playwright.config.ts
+++ b/plugin/e2e/playwright.config.ts
@@ -27,6 +27,14 @@ export default defineConfig({
   // workflow sets E2E_DEMO=1 to opt it back in.
   testIgnore: process.env.E2E_DEMO ? [] : ['**/demo.spec.ts'],
   timeout: 120_000,
+  // Playwright's DEFAULT actionTimeout is 0 — wait FOREVER. With Obsidian's
+  // virtualised File Explorer under Xvfb a node can be *attached but never
+  // actionable* (hover popovers swallow pointer events, rows paint lazily), so
+  // a bare `.click()` blocked until the whole test timed out: three minutes
+  // burned with NO message, which reads as "the product hung" when in fact the
+  // harness was waiting. Bound it — an unactionable element now fails with
+  // Playwright's own locator diagnostic, well inside the 120 s test budget.
+  actionTimeout: 30_000,
   retries: 1,
   workers: 1, // Obsidian is a single-instance app
   use: {

--- a/plugin/e2e/plugin-code-roundtrip.spec.ts
+++ b/plugin/e2e/plugin-code-roundtrip.spec.ts
@@ -9,6 +9,14 @@ import {
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
 import { makeFakePlugin, seedPluginOnRemote } from './helpers/remote-fixtures';
+import {
+  COMMUNITY_PLUGINS_REL,
+  captureCommunityPlugins,
+  preCleanRemoteFixtures,
+  resetRemoteFixtures,
+  type CommunityPluginsSnapshot,
+  type FixtureFootprint,
+} from './helpers/remote-reset';
 import { assertSshdReachable } from './helpers/sshd';
 import { logPathFor } from './helpers/log-oracle';
 import * as fs from 'node:fs';
@@ -71,6 +79,25 @@ import * as path from 'node:path';
  * had it" from "this device deleted it"), NOT in weakening this test. Test 6
  * asserts the user-facing behaviour — an uninstall sticks — and is left red.
  *
+ * …which is exactly WHY the fixtures must be force-purged in `afterAll`
+ * ---------------------------------------------------------------------
+ * The defect test 6 pins is the reason this spec cannot rely on the product to
+ * tidy up after it. The remote enabled list is MONOTONIC: once `e2e-probe` /
+ * `e2e-probe2` are in it, nothing this spec does — including deleting them
+ * locally, which is literally what test 6 does — will take them out again. And
+ * the docker test vault is SHARED and PERSISTS across specs within a run, so a
+ * fixture left enabled there is pulled into the shadow vault of every LATER
+ * spec at connect (`src/main.ts:632-670`), staged, and loaded. That is not
+ * hypothetical: it is what turned the previously-passing
+ * `sync.spec.ts › create — new note appears on remote` red.
+ *
+ * So `afterAll` restores the remote's `community-plugins.json` to its captured
+ * bytes and rmrf's every fixture plugin dir (shared AND per-device),
+ * unconditionally, wrapped step-by-step so a red test still cleans up. That
+ * cleanup is the HARNESS's job, not the product's — it must not, and does not,
+ * touch test 6's assertions. If anything, having to hand-revert the remote is
+ * itself evidence of the defect's blast radius: a real user has no `afterAll`.
+ *
  * State is CHAINED across the tests in this file (each builds on the shadow
  * vault the previous one left behind), hence `mode: 'serial'` and the generous
  * per-test timeout: several of them quit and relaunch Obsidian.
@@ -89,9 +116,11 @@ const PROBE2_V = '2.0.0';
 const PROBE2_V_BUMPED = '2.0.1';
 
 const SELF_ID = 'remote-ssh';
-const COMMUNITY_PLUGINS_REL = '.obsidian/community-plugins.json';
 
 const BINARY_FILES = ['manifest.json', 'main.js', 'styles.css'] as const;
+
+/** Everything this spec puts on the SHARED remote — and therefore owes back. */
+const FOOTPRINT: FixtureFootprint = { pluginIds: [PROBE_ID, PROBE2_ID] };
 
 /**
  * A probe whose `onload()` records its VERSION as well as the fact that it ran.
@@ -126,6 +155,12 @@ let remote: RemoteVerifier;
  * reuses this exact path.
  */
 let shadowVaultPath: string;
+/**
+ * The remote's `community-plugins.json` as it was BEFORE this spec seeded
+ * anything (null = it did not exist). Captured after the pre-clean, so it is a
+ * clean baseline, and put back byte-for-byte in `afterAll`.
+ */
+let communityPluginsSnapshot: CommunityPluginsSnapshot = { raw: null };
 
 /** A path inside the shadow vault's `.obsidian` config dir. */
 function localPath(...segments: string[]): string {
@@ -178,13 +213,22 @@ test.beforeAll(async () => {
     );
   }
 
-  // Start from a known remote: leftovers from an earlier run (or an earlier
-  // retry of this one) would make the version-ordering assertions meaningless.
-  await remote.rmrf(`.obsidian/plugins/${PROBE_ID}`);
-  await remote.rmrf(`.obsidian/plugins/${PROBE2_ID}`);
-  await remote.removeFile(COMMUNITY_PLUGINS_REL);
+  // DEFENSIVE PRE-CLEAN. A previous run that crashed (or was killed) leaves its
+  // fixture plugins on the shared docker vault — in `.obsidian/plugins/`, in the
+  // per-device `.obsidian/user/<clientId>/plugins/`, and named in the remote
+  // enabled list, which the monotonic union can never have removed. Inheriting
+  // any of that would make the version-ordering assertions below meaningless.
+  await preCleanRemoteFixtures(remote, FOOTPRINT);
+
+  // The clean baseline `afterAll` restores byte-for-byte. Captured AFTER the
+  // pre-clean, so a leftover fixture id can never be baked into the "original".
+  communityPluginsSnapshot = await captureCommunityPlugins(remote);
 
   // ── DEVICE B: the plugin exists ONLY on the remote, before we ever connect ──
+  // The list is written to EXACTLY `[PROBE_ID]` (not merged): test 1 asserts the
+  // connect MERGES rather than copies it — that `remote-ssh` survives a remote
+  // list that omits it — and a merged seed would not exercise that at all.
+  await remote.removeFile(COMMUNITY_PLUGINS_REL);
   await seedPluginOnRemote(remote, PROBE_ID, probeFiles(PROBE_ID, PROBE_V1));
   await remote.writeFile(COMMUNITY_PLUGINS_REL, `${JSON.stringify([PROBE_ID])}\n`);
 
@@ -205,11 +249,14 @@ test.beforeAll(async () => {
 });
 
 test.afterAll(async () => {
-  await obsidian?.cleanup();
+  // Runs even when a test FAILED — and one of them (test 6) is expected to. The
+  // product cannot revert this itself: the enabled list only ever grows, so a
+  // fixture left there is loaded by every later spec's shadow vault at connect.
+  // Each step is guarded inside `resetRemoteFixtures`, so a failure in one
+  // cannot skip the others.
+  await obsidian?.cleanup().catch(() => {});
   if (remote) {
-    await remote.rmrf(`.obsidian/plugins/${PROBE_ID}`).catch(() => {});
-    await remote.rmrf(`.obsidian/plugins/${PROBE2_ID}`).catch(() => {});
-    await remote.removeFile(COMMUNITY_PLUGINS_REL).catch(() => {});
+    await resetRemoteFixtures(remote, FOOTPRINT, communityPluginsSnapshot);
     await remote.disconnect();
   }
   scaffold?.cleanup();

--- a/plugin/e2e/plugin-code-roundtrip.spec.ts
+++ b/plugin/e2e/plugin-code-roundtrip.spec.ts
@@ -1,0 +1,460 @@
+import { test, expect } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { makeFakePlugin, seedPluginOnRemote } from './helpers/remote-fixtures';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * #429b — third-party plugin CODE crossing the device boundary.
+ *
+ * `restart-settings.spec.ts` covers a plugin's *settings* (`data.json`, which
+ * is deliberately PER-DEVICE, under `.obsidian/user/<clientId>/`). This spec
+ * covers the other half, and the one that decides whether a plugin exists at
+ * all on a second machine: its CODE.
+ *
+ * The contract (product side)
+ * ---------------------------
+ * `ShadowVaultBootstrap.PLUGIN_BINARY_FILES = ['manifest.json','main.js','styles.css']`
+ * (`src/shadow/ShadowVaultBootstrap.ts:733`). `data.json` is NOT in that list,
+ * on purpose: plugin code is IDENTITY-shared (every device runs the same
+ * plugin), plugin settings are DEVICE-scoped. Leaking `data.json` into the
+ * code round-trip would recreate exactly the cross-device settings collision
+ * that `.obsidian/user/<clientId>/` exists to prevent.
+ *
+ * The connect-time sequence (`src/main.ts:632-670`) is:
+ *
+ *   1. `pullCommunityPlugins` / `pushCommunityPlugins` — round-trip the
+ *      *enabled list* (`.obsidian/community-plugins.json`), with `remote-ssh`
+ *      force-unioned in so a remote list that omits it can never disable the
+ *      very plugin doing the sync.
+ *   2. `installMissingShadowPlugins` — marketplace fetch for ids the list now
+ *      names but whose binaries aren't staged.
+ *   3. `pullPluginBinaries` / `pushPluginBinaries` — the CODE round-trip, for
+ *      the plugins the marketplace cannot serve (BRAT / sideloaded), and as a
+ *      fallback when a marketplace fetch failed.
+ *
+ * Convergence is VERSION-ORDERED, not last-writer-wins
+ * ----------------------------------------------------
+ * `pullPluginBinaries` pulls only when the plugin is absent locally or the
+ * remote manifest `version` is STRICTLY NEWER (`ShadowVaultBootstrap.ts:762`);
+ * `pushPluginBinaries` pushes only when the remote lacks it or the local
+ * version is strictly newer (`:806`). This is load-bearing: a "content
+ * differs" gate would let a laggard machine downgrade a plugin the rest of the
+ * fleet already upgraded, and the two sides would ping-pong on every connect,
+ * forever. It also means a test that seeds files without thinking about
+ * `version` silently exercises nothing — both sides skip. Every fixture here
+ * therefore pins its version explicitly, and the probe's `onload()` body is
+ * overridden to STAMP THE VERSION into `window.__E2E_PROBE__` (the default body
+ * from `makeFakePlugin` records only `{ id, loaded }`).
+ *
+ * Test 6 is EXPECTED TO FAIL — it encodes a real defect
+ * -----------------------------------------------------
+ * `pushCommunityPlugins` (`src/shadow/ShadowVaultBootstrap.ts:698-702`)
+ * computes a monotonic UNION of remote+local and then "No-ops when the remote
+ * already equals the union". The list can therefore only ever GROW. A user who
+ * uninstalls a plugin on one machine can never propagate that removal: the push
+ * will not shrink the remote list, and on the very next connect
+ * `pullCommunityPlugins` (`:652`) merges the remote list back in and RESURRECTS
+ * the plugin locally. The union is the right anti-clobber default for a stale
+ * local list, but it is not removal semantics; the fix belongs in the PRODUCT
+ * (a tombstone / explicit-removal channel that distinguishes "this device never
+ * had it" from "this device deleted it"), NOT in weakening this test. Test 6
+ * asserts the user-facing behaviour — an uninstall sticks — and is left red.
+ *
+ * State is CHAINED across the tests in this file (each builds on the shadow
+ * vault the previous one left behind), hence `mode: 'serial'` and the generous
+ * per-test timeout: several of them quit and relaunch Obsidian.
+ *
+ * HARD-FAILS, never skips.
+ */
+
+/** Pulled from the remote (device-B direction). Seeded BEFORE the first connect. */
+const PROBE_ID = 'e2e-probe';
+/** Pushed from the shadow disk (device-A direction). Written AFTER the first connect. */
+const PROBE2_ID = 'e2e-probe2';
+
+const PROBE_V1 = '1.0.0';
+const PROBE_V2 = '2.0.0';
+const PROBE2_V = '2.0.0';
+const PROBE2_V_BUMPED = '2.0.1';
+
+const SELF_ID = 'remote-ssh';
+const COMMUNITY_PLUGINS_REL = '.obsidian/community-plugins.json';
+
+const BINARY_FILES = ['manifest.json', 'main.js', 'styles.css'] as const;
+
+/**
+ * A probe whose `onload()` records its VERSION as well as the fact that it ran.
+ * The version matters: it is the only way to prove which *copy* of the code
+ * Obsidian actually executed after a version-ordered convergence.
+ *
+ * NOTE the constraint on WHERE these fixtures may be seeded: never into the
+ * SOURCE scaffold vault. `ShadowVaultBootstrap` snapshots the source vault's
+ * community plugins into `settings.pendingPluginSuggestions`, and the shadow
+ * window then opens a `PendingPluginsModal` that swallows Ctrl+P, hanging every
+ * later palette interaction. Fixtures go on the REMOTE, or onto the shadow disk
+ * AFTER the connect — never into the scaffold.
+ */
+function probeFiles(id: string, version: string): Record<string, string> {
+  const files = makeFakePlugin({
+    id,
+    version,
+    onloadBody:
+      `window.__E2E_PROBE__ = { id: ${JSON.stringify(id)}, ` +
+      `version: ${JSON.stringify(version)}, loaded: true };`,
+  });
+  return { ...files };
+}
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+/**
+ * Captured ONCE. `findShadowVaultPath` picks the most recently registered vault
+ * out of the user-global `obsidian.json`, so re-resolving it after a later
+ * connect could drift onto a different vault — every relaunch in this file
+ * reuses this exact path.
+ */
+let shadowVaultPath: string;
+
+/** A path inside the shadow vault's `.obsidian` config dir. */
+function localPath(...segments: string[]): string {
+  return path.join(shadowVaultPath, '.obsidian', ...segments);
+}
+
+function readLocalList(): string[] {
+  return JSON.parse(fs.readFileSync(localPath('community-plugins.json'), 'utf8')) as string[];
+}
+
+function writeLocalList(ids: string[]): void {
+  fs.writeFileSync(localPath('community-plugins.json'), `${JSON.stringify(ids)}\n`, 'utf8');
+}
+
+async function readRemoteList(): Promise<string[]> {
+  const body = await remote.readFile(COMMUNITY_PLUGINS_REL);
+  if (body === null) throw new Error('remote community-plugins.json is missing');
+  return JSON.parse(body) as string[];
+}
+
+/** Write a plugin's files onto the LOCAL shadow disk (the device-A direction). */
+function writeLocalPlugin(id: string, files: Record<string, string>): void {
+  const dir = localPath('plugins', id);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    fs.writeFileSync(path.join(dir, name), content, 'utf8');
+  }
+}
+
+/** Quit Obsidian and relaunch it on the SAME shadow vault, fully reconnected. */
+async function relaunchShadow(): Promise<void> {
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+}
+
+// The tests below CHAIN: each one leaves the shadow vault in the state the next
+// one starts from. Serial keeps them in one worker, in order.
+test.describe.configure({ mode: 'serial' });
+
+test.beforeAll(async () => {
+  test.setTimeout(240_000);
+  await assertSshdReachable();
+
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) {
+    throw new Error(
+      'RemoteVerifier could not connect to the docker test sshd even though the port ' +
+      'is open. This spec hard-fails rather than skipping.',
+    );
+  }
+
+  // Start from a known remote: leftovers from an earlier run (or an earlier
+  // retry of this one) would make the version-ordering assertions meaningless.
+  await remote.rmrf(`.obsidian/plugins/${PROBE_ID}`);
+  await remote.rmrf(`.obsidian/plugins/${PROBE2_ID}`);
+  await remote.removeFile(COMMUNITY_PLUGINS_REL);
+
+  // ── DEVICE B: the plugin exists ONLY on the remote, before we ever connect ──
+  await seedPluginOnRemote(remote, PROBE_ID, probeFiles(PROBE_ID, PROBE_V1));
+  await remote.writeFile(COMMUNITY_PLUGINS_REL, `${JSON.stringify([PROBE_ID])}\n`);
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+
+  // Building blocks rather than `connectAndOpenShadow`, to KEEP the shadow vault
+  // path: every relaunch below reuses it, and the on-disk assertions read
+  // straight out of it.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+
+  // `launchObsidian` only waits for the plugin to LOAD; the SSH connect (and
+  // with it the whole plugin round-trip) lands later, at layout-ready.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  if (remote) {
+    await remote.rmrf(`.obsidian/plugins/${PROBE_ID}`).catch(() => {});
+    await remote.rmrf(`.obsidian/plugins/${PROBE2_ID}`).catch(() => {});
+    await remote.removeFile(COMMUNITY_PLUGINS_REL).catch(() => {});
+    await remote.disconnect();
+  }
+  scaffold?.cleanup();
+});
+
+test.beforeEach(() => {
+  // Several of these tests quit and relaunch Obsidian more than once; the 120 s
+  // file default has no headroom for that.
+  test.setTimeout(240_000);
+});
+
+test.describe('third-party plugin CODE round-trips across the device boundary (#429b)', () => {
+  test('pull: a plugin that exists only on the remote is staged onto this device', async () => {
+    const seeded = probeFiles(PROBE_ID, PROBE_V1);
+
+    // The connect in `beforeAll` ran pullCommunityPlugins → installer →
+    // pullPluginBinaries. `e2e-probe` is not on the marketplace, so ONLY the
+    // binary pull can have put it here.
+    for (const file of BINARY_FILES) {
+      const localFile = localPath('plugins', PROBE_ID, file);
+      await expect
+        .poll(() => fs.existsSync(localFile), {
+          message:
+            `${file} was never staged onto the shadow disk for '${PROBE_ID}'. A plugin ` +
+            'installed on another machine (BRAT / sideloaded) therefore does not exist on ' +
+            'this one: the enabled list names it, but there is no code to load.',
+          timeout: 20_000,
+        })
+        .toBe(true);
+
+      expect(
+        fs.readFileSync(localFile, 'utf8'),
+        `${file} was staged but its bytes differ from what the remote holds`,
+      ).toBe(seeded[file]);
+    }
+
+    // The enabled list must be the MERGE, not a verbatim copy: the remote list is
+    // `["e2e-probe"]`, and writing that verbatim would drop `remote-ssh` — the
+    // sync plugin would switch ITSELF off on connect.
+    const localList = readLocalList();
+    expect(localList, `the pulled plugin '${PROBE_ID}' is missing from the local enabled list`)
+      .toContain(PROBE_ID);
+    expect(
+      localList,
+      'the merge dropped remote-ssh from the enabled list — the next vault open would start ' +
+      'with the sync plugin disabled, and nothing would ever reconnect',
+    ).toContain(SELF_ID);
+  });
+
+  test('a pulled plugin actually LOADS on the next start of the shadow vault', async () => {
+    // Obsidian scans `.obsidian/plugins/` at STARTUP, so code staged during the
+    // previous connect can only load on the next open. Without this, test 1
+    // proves nothing a user can feel: bytes on disk that never execute are a
+    // silent non-fix.
+    await relaunchShadow();
+
+    const probe = await obsidian.page.evaluate((id: string) => {
+      const app = (window as unknown as {
+        app?: { plugins?: { plugins?: Record<string, unknown> } };
+      }).app;
+      const sentinel = (window as unknown as {
+        __E2E_PROBE__?: { id?: string; version?: string; loaded?: boolean };
+      }).__E2E_PROBE__;
+      return {
+        registered: Boolean(app?.plugins?.plugins?.[id]),
+        sentinel: sentinel ?? null,
+        ids: Object.keys(app?.plugins?.plugins ?? {}),
+      };
+    }, PROBE_ID);
+
+    expect(
+      probe.registered,
+      `Obsidian did not register '${PROBE_ID}' at startup (loaded: ` +
+      `${probe.ids.join(', ') || 'none'}). The code was staged but never ran — from the ` +
+      'user\'s point of view the plugin is still not installed on this device.',
+    ).toBe(true);
+
+    expect(
+      probe.sentinel?.loaded,
+      `'${PROBE_ID}' is registered but its onload() sentinel never fired`,
+    ).toBe(true);
+    expect(probe.sentinel?.version, 'the copy Obsidian ran is not the version we staged')
+      .toBe(PROBE_V1);
+  });
+
+  test('push: a plugin present only on THIS device reaches the remote', async () => {
+    const files = probeFiles(PROBE2_ID, PROBE2_V);
+
+    // Install it the way a sideload does: drop the code into the shadow vault's
+    // plugins dir and enable it in the list, with Obsidian NOT running.
+    await obsidian.cleanup();
+    writeLocalPlugin(PROBE2_ID, files);
+    writeLocalList([...readLocalList(), PROBE2_ID]);
+
+    obsidian = await launchObsidian(shadowVaultPath);
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+    for (const file of BINARY_FILES) {
+      const rel = `.obsidian/plugins/${PROBE2_ID}/${file}`;
+      await expect
+        .poll(() => remote.exists(rel), {
+          message:
+            `${rel} never reached the remote. The remote vault is the canonical store every ` +
+            'other machine pulls from — a plugin that only ever lives on the device it was ' +
+            'installed on has not been synced at all.',
+          timeout: 20_000,
+        })
+        .toBe(true);
+
+      const bytes = await remote.readBinaryFile(rel);
+      expect(bytes, `${rel} exists on the remote but could not be read back`).not.toBeNull();
+      expect(
+        bytes!.equals(Buffer.from(files[file], 'utf8')),
+        `${rel} reached the remote with different bytes — the code channel corrupted it`,
+      ).toBe(true);
+    }
+
+    expect(
+      await readRemoteList(),
+      `'${PROBE2_ID}' was pushed but never enabled on the remote — another machine would pull ` +
+      'nothing, because the binary pull is driven by the enabled list',
+    ).toContain(PROBE2_ID);
+  });
+
+  test('plugin data.json is NOT pushed with the code', async () => {
+    // `data.json` is the plugin's SETTINGS. It is device-scoped by contract
+    // (`.obsidian/user/<clientId>/…`, proven by restart-settings.spec.ts) and is
+    // deliberately absent from PLUGIN_BINARY_FILES. If the code round-trip
+    // carried it to the shared identity path, every device would fight over one
+    // settings file — the exact collision the per-device layout exists to stop.
+    fs.writeFileSync(
+      localPath('plugins', PROBE2_ID, 'data.json'),
+      JSON.stringify({ secret: 'device-A-only', n: 1 }),
+      'utf8',
+    );
+
+    // Bump the version so the push path is genuinely EXERCISED on this connect.
+    // Version-ordered convergence would otherwise skip `e2e-probe2` entirely
+    // (remote == local) and the assertion below would pass without the code ever
+    // having had the chance to leak `data.json`.
+    await obsidian.cleanup();
+    writeLocalPlugin(PROBE2_ID, probeFiles(PROBE2_ID, PROBE2_V_BUMPED));
+    obsidian = await launchObsidian(shadowVaultPath);
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+    await expect
+      .poll(async () => remote.readFile(`.obsidian/plugins/${PROBE2_ID}/manifest.json`), {
+        message: 'the version bump never reached the remote, so the push path did not run',
+        timeout: 20_000,
+      })
+      .toContain(`"version": "${PROBE2_V_BUMPED}"`);
+
+    expect(
+      await remote.exists(`.obsidian/plugins/${PROBE2_ID}/data.json`),
+      'the plugin CODE round-trip carried data.json to the SHARED remote path. Plugin ' +
+      'settings are device-scoped by design; a shared copy means every machine overwrites ' +
+      'every other machine\'s settings on every save (#342 / #429).',
+    ).toBe(false);
+  });
+
+  test('an OLDER local copy does not DOWNGRADE a NEWER remote plugin', async () => {
+    // Another machine upgraded the plugin to 2.0.0 while this device still runs
+    // 1.0.0. Convergence must be VERSION-ORDERED: pull up, never push down. A
+    // last-writer-wins gate would push 1.0.0 back over 2.0.0, the other machine
+    // would push 2.0.0 again, and the fleet would ping-pong forever.
+    await obsidian.cleanup();
+
+    await seedPluginOnRemote(remote, PROBE_ID, probeFiles(PROBE_ID, PROBE_V2));
+    writeLocalPlugin(PROBE_ID, probeFiles(PROBE_ID, PROBE_V1));
+
+    const seededRemote = await remote.readFile(`.obsidian/plugins/${PROBE_ID}/manifest.json`);
+    expect(
+      (JSON.parse(seededRemote ?? '{}') as { version?: string }).version,
+      'fixture setup: the remote was not seeded at the newer version',
+    ).toBe(PROBE_V2);
+
+    obsidian = await launchObsidian(shadowVaultPath);
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+    await expect
+      .poll(
+        () =>
+          (JSON.parse(
+            fs.readFileSync(localPath('plugins', PROBE_ID, 'manifest.json'), 'utf8'),
+          ) as { version?: string }).version,
+        {
+          message:
+            `the newer remote copy of '${PROBE_ID}' was never pulled — this device is stuck ` +
+            'on an old version of a plugin the rest of the fleet has already upgraded',
+          timeout: 20_000,
+        },
+      )
+      .toBe(PROBE_V2);
+
+    const remoteManifest = await remote.readFile(`.obsidian/plugins/${PROBE_ID}/manifest.json`);
+    expect(remoteManifest, `'${PROBE_ID}' vanished from the remote`).not.toBeNull();
+    expect(
+      (JSON.parse(remoteManifest!) as { version?: string }).version,
+      'this device DOWNGRADED the remote plugin to its own older copy. Convergence is ' +
+      'version-ordered on purpose (ShadowVaultBootstrap.ts:762,806): a last-writer-wins push ' +
+      'makes every machine in the fleet overwrite the others on every connect, forever.',
+    ).toBe(PROBE_V2);
+
+    // …and the local `main.js` is the NEW code, not merely a new manifest.
+    expect(
+      fs.readFileSync(localPath('plugins', PROBE_ID, 'main.js'), 'utf8'),
+      'the manifest was upgraded but the code was not — the device would report v2 and run v1',
+    ).toBe(probeFiles(PROBE_ID, PROBE_V2)['main.js']);
+  });
+
+  test('uninstall: removing a plugin locally drops it from the remote enabled list', async () => {
+    // ── EXPECTED TO FAIL: this encodes a real, unfixed defect ─────────────────
+    // `pushCommunityPlugins` unions remote+local and then no-ops when the remote
+    // already equals that union (ShadowVaultBootstrap.ts:698-702), so the remote
+    // list is MONOTONIC — it can only grow. A removal made here can never reach
+    // the remote; worse, the next `pullCommunityPlugins` (:652) merges the remote
+    // list back in and RESURRECTS the plugin on this device.
+    //
+    // The assertions below are the correct user-facing behaviour and must NOT be
+    // weakened. The fix belongs in the PRODUCT: the enabled list needs real
+    // removal semantics (a tombstone, or a per-device "last known" set, so an id
+    // that disappeared from a device that previously HAD it is treated as a
+    // delete rather than as a device that simply never knew about it).
+    await obsidian.cleanup();
+
+    writeLocalList(readLocalList().filter((id) => id !== PROBE2_ID));
+    fs.rmSync(localPath('plugins', PROBE2_ID), { recursive: true, force: true });
+
+    obsidian = await launchObsidian(shadowVaultPath);
+    await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+    await expect
+      .poll(async () => (await readRemoteList()).includes(PROBE2_ID), {
+        message:
+          `uninstalling '${PROBE2_ID}' on this device never propagated: the remote enabled ` +
+          'list still names it, so every other machine keeps it — and this device pulls it ' +
+          'back on the next connect. A fleet-wide uninstall is impossible.',
+        timeout: 20_000,
+      })
+      .toBe(false);
+
+    expect(
+      readLocalList(),
+      `the connect RESURRECTED '${PROBE2_ID}' in this device's enabled list — the monotonic ` +
+      'union in pushCommunityPlugins/pullCommunityPlugins makes an uninstall un-doable',
+    ).not.toContain(PROBE2_ID);
+  });
+});

--- a/plugin/e2e/sync.spec.ts
+++ b/plugin/e2e/sync.spec.ts
@@ -1,48 +1,108 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import {
   launchObsidian,
-  connectAndOpenShadow,
-  runCommandViaPalette,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  dismissBlockingModals,
   type ObsidianHandle,
 } from './helpers/obsidian';
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { RemoteVerifier } from './helpers/remote-verifier';
 import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
 
 /**
- * E2E sync tests — verify that local Obsidian operations (create,
- * edit, delete) propagate to the remote filesystem.
+ * E2E sync tests — Obsidian → REMOTE. A create / edit / delete performed in the
+ * connected Obsidian window must land on the remote filesystem, and every
+ * verdict is taken over an INDEPENDENT SFTP connection (`RemoteVerifier`), never
+ * through the plugin. `reflect.spec.ts` covers the opposite direction.
  *
- * These tests require:
- *   - Docker test sshd running (`npm run sshd:start`)
- *   - Plugin + server built
- *   - Obsidian installed
+ * Requires: docker test sshd (`npm run sshd:start`), plugin+server built,
+ * Obsidian installed. HARD-FAILS — it never skips.
  *
- * The test connects to the remote vault, performs file operations
- * via the Obsidian UI, then checks the remote filesystem directly
- * via a separate SFTP connection (RemoteVerifier) to confirm the
- * changes landed.
+ * ── WHICH DRIVE PATH THIS SPEC USES, AND WHY ─────────────────────────────────
  *
- * This suite HARD-FAILS — it never skips. It used to `test.skip` both
- * when sshd was down and when `connectAndOpenShadow` THREW, so a
- * genuinely broken connect reported CI green: exactly the failure mode
- * `helpers/sshd.ts` exists to stop ("that is how 1.0.49 shipped
- * broken"). The connect-* specs were migrated to `assertSshdReachable`;
- * this spec and `reflect.spec.ts` were left behind. Not any more.
+ * The operations are driven through Obsidian's OWN vault API from inside the
+ * renderer (`app.vault.create` / `.modify` / `.delete` via `page.evaluate`), NOT
+ * by typing into CodeMirror and steering the command palette.
+ *
+ * That is not a shortcut and it removes no product coverage, because the chain
+ * under test starts BELOW that line. In the shadow window `app.vault.adapter` is
+ * the plugin's PATCHED adapter, and `vault.create/modify/delete` are exactly the
+ * calls Obsidian's editor makes on the user's behalf — they go
+ *
+ *     vault.<op>  →  patched adapter.write/remove  →  RPC/SFTP  →  remote file
+ *
+ * i.e. every line of OUR code that a keystroke would have reached. What the old
+ * UI path added on top was Obsidian's internal "contenteditable → save debounce
+ * → vault.modify" step: Obsidian's code, not the plugin's, and not something
+ * this suite is here to certify. What it also added was NON-DETERMINISM, which
+ * is what actually broke it:
+ *
+ *   - `Create new note` makes `Untitled.md`, and the rename to TEST_NOTE was
+ *     done by `if (await inlineTitle.isVisible()) { … }` — a SILENT SKIP. When
+ *     the title field wasn't there the note simply stayed `Untitled.md` and the
+ *     spec went on to assert `remote.exists('e2e-test-<stamp>.md')`, failing with
+ *     "Expected true, Received false" — a message that names nothing.
+ *   - `isVisible()` does NOT hit-test; `click()` DOES. An element under
+ *     Obsidian's auto-opened Settings overlay (`.modal-container.mod-dim`) still
+ *     reports visible while every click on it is intercepted. So the overlay
+ *     being up or down silently flipped WHICH of those steps worked: the spec
+ *     was green by luck, and closing the overlay (which fixed `images` and
+ *     `links-metadata`) flipped the luck the other way.
+ *   - `waitForTimeout(5_000)` "waited" for the remote. It didn't; it slept, and
+ *     any slower-than-5 s propagation was a red with no evidence.
+ *
+ * So: the SETUP is deterministic and typed, and the VERDICT is unchanged and
+ * unweakened. Every silent-skip branch is gone — each stage (the vault accepted
+ * the op; the file is in the vault model; the remote has it) asserts, so a red
+ * names the stage that broke. Every fixed sleep is gone — the remote is POLLED
+ * with `expect.poll` and a message, so a red says what the remote actually held.
+ *
+ * The three remote assertions (`remote.exists`, `remote.readFile` content) are
+ * the product contract and are at full strength. Do not weaken them.
+ *
+ * ── ORDERING ─────────────────────────────────────────────────────────────────
+ *
+ * The tests share one Obsidian session and run in declaration order: `create`
+ * makes TEST_NOTE, `edit` rewrites it, `delete` removes it. Each re-derives the
+ * TFile by path rather than relying on "the note is still open" (which the old
+ * `edit` did — another way for focus drift to make it edit the wrong file).
  */
-
-let obsidian: ObsidianHandle;
-let scaffold: ScaffoldResult;
-let remote: RemoteVerifier;
 
 const STAMP = Date.now().toString(36);
 const TEST_NOTE = `e2e-test-${STAMP}.md`;
 const TEST_CONTENT_INITIAL = `# E2E Test Note\n\nCreated by sync.spec.ts at ${STAMP}\n`;
 const TEST_CONTENT_EDITED = `# E2E Test Note (edited)\n\nEdited by sync.spec.ts at ${STAMP}\n`;
 
+/**
+ * Budget for a local op to reach the remote: vault → patched adapter → RPC →
+ * daemon → disk. Sub-second on a warm connection; 20 s is far past the observed
+ * settle time, so a RED here is a real propagation defect and not a slow box.
+ * (It replaces a fixed 5 s sleep, which could only ever be wrong in one of two
+ * directions.)
+ */
+const SYNC_TIMEOUT_MS = 20_000;
+
+/**
+ * Budget for ONE `page.evaluate`. `page.evaluate` has no timeout of its own: a
+ * wedged renderer (say, an adapter write blocked on SSH) simply never answers,
+ * and the test would burn its whole timeout reporting nothing. Bounding it makes
+ * "the renderer stopped answering" a fast, named failure.
+ */
+const EVAL_TIMEOUT_MS = 15_000;
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+
 test.beforeAll(async () => {
-  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken
-  // connect is a broken plugin. Both must be red, not green-by-skipping.
+  test.setTimeout(180_000);
+
+  // HARD-FAIL, never skip: a down sshd is a broken harness and a broken connect
+  // is a broken plugin. Both must be red, not green-by-skipping.
   await assertSshdReachable();
 
   remote = new RemoteVerifier();
@@ -58,65 +118,98 @@ test.beforeAll(async () => {
   scaffold = scaffoldTestVault();
   obsidian = await launchObsidian(scaffold.vaultPath);
 
-  // connectAndOpenShadow drives palette → "Remote SSH: Connect" →
-  // passphrase modal Connect button → reads obsidian.json for the
-  // new shadow vault entry → relaunches our managed Obsidian on
-  // the shadow vault path. The returned handle's `page` is now
-  // attached to the shadow window (the only one with remote files
-  // visible). The previous heuristic — `connected = items > 0` —
-  // returned true on the scaffold's seeded local_demo*.md even
-  // when the connect command was a silent no-op.
-  //
-  // Deliberately NOT wrapped in try/catch: if the connect flow throws,
-  // the plugin is broken and this suite must go RED. Swallowing it into
-  // a `test.skip` is what let a broken connect ship green.
-  obsidian = await connectAndOpenShadow(obsidian, scaffold.vaultPath);
+  // The connect building blocks rather than `connectAndOpenShadow`, so we keep
+  // hold of the shadow vault PATH — `waitForShadowVaultLoaded` needs its log
+  // path. Deliberately NOT wrapped in try/catch: if the connect flow throws, the
+  // plugin is broken and this suite must go RED. Swallowing it into a
+  // `test.skip` is what let a broken connect ship green in 1.0.49.
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+
+  // THE RACE THE OLD SPEC NEVER CLOSED. `launchObsidian` returns once the PLUGIN
+  // has loaded; the SSH connect, the ADAPTER PATCH and `populateVaultFromRemote`
+  // all land later, at layout-ready. A `vault.create` fired before the patch
+  // writes to the shadow vault's LOCAL directory and never reaches the remote —
+  // a "Received false" that has nothing to do with sync. Block until the remote
+  // tree is actually in the vault model before any test runs.
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+
+  // Harness, not product: dismissing the trust dialog makes Obsidian auto-open
+  // its Settings dialog, a full-window `.modal-container.mod-dim` that
+  // intercepts pointer events. Nothing below clicks, but a modal left up also
+  // steals keyboard focus and makes every failure screenshot unreadable. It logs
+  // whatever it closes, so a modal that IS meaningful (a host-key prompt, a
+  // write conflict) surfaces in CI instead of being silently swallowed.
+  await dismissBlockingModals(obsidian.page);
 });
 
 test.afterAll(async () => {
-  // Clean up test files on remote
   if (remote) {
-    await remote.removeFile(TEST_NOTE).catch(() => {});
+    await remote.removeFile(TEST_NOTE).catch(() => { /* best effort */ });
     await remote.disconnect();
   }
   await obsidian?.cleanup();
   scaffold?.cleanup();
 });
 
+test.beforeEach(() => {
+  // A remote round-trip plus a bounded poll; the config's default 120 s gets
+  // tight once the create's two polls stack up inside one test.
+  test.setTimeout(180_000);
+});
+
 test.describe('Remote sync verification', () => {
-  // No `beforeEach` skip gate: reaching here means `beforeAll` completed,
-  // which means the connect succeeded. If it didn't, beforeAll threw and
-  // the whole suite is already red — which is the point.
+  // No `beforeEach` skip gate: reaching here means `beforeAll` completed, which
+  // means the connect AND the populate succeeded. If they didn't, `beforeAll`
+  // threw and the whole suite is already red — which is the point.
 
   test('create — new note appears on remote', async () => {
     const { page } = obsidian;
 
-    // Create a new note via command palette (hardened against CI's
-    // racy palette wiring — the fixed-sleep version timed the whole
-    // test out at 120s in run 26015295742).
-    await runCommandViaPalette(page, 'Create new note');
-    await page.waitForTimeout(1_000);
+    // Stage 1 — Obsidian accepts the create, at a KNOWN path. `vault.create`
+    // either returns the TFile or throws; there is no branch in which this
+    // quietly leaves an `Untitled.md` behind and lets the remote assertion take
+    // the blame (which is exactly what the old palette + conditional-rename path
+    // did).
+    await createNote(page, TEST_NOTE, TEST_CONTENT_INITIAL);
 
-    // Type the filename in the title area
-    // Obsidian focuses the inline title after creating a new note
-    const inlineTitle = page.locator('.inline-title');
-    if (await inlineTitle.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await inlineTitle.fill(TEST_NOTE.replace('.md', ''));
-      await page.keyboard.press('Enter');
-    }
+    // Stage 2 — and it is in the vault model under that exact path. If this is
+    // red, the create never happened locally and nothing about the remote is
+    // implicated; if it is GREEN and stage 3 is red, the write did not
+    // propagate. That split is the whole diagnostic value.
+    expect(
+      await inFileMap(page, TEST_NOTE),
+      `app.vault.create("${TEST_NOTE}") returned but the note is not in ` +
+      `vault.fileMap — the local create did not take.\n${await dumpVaultState(page)}`,
+    ).toBe(true);
 
-    // Type content in the editor
-    const editor = page.locator('.cm-editor .cm-content');
-    await expect(editor).toBeVisible({ timeout: 5_000 });
-    await editor.click();
-    await page.keyboard.type(TEST_CONTENT_INITIAL);
+    // Stage 3 — THE CONTRACT. Ground truth over an independent SFTP connection.
+    // Polled, not slept: the old fixed 5 s sleep turned any slower propagation
+    // into a bare "Expected true, Received false".
+    await expect
+      .poll(() => remote.exists(TEST_NOTE), {
+        message:
+          `"${TEST_NOTE}" was created in Obsidian (it IS in vault.fileMap) but never ` +
+          `appeared on the remote within ${SYNC_TIMEOUT_MS}ms. The vault → patched ` +
+          'adapter → RPC/SFTP → disk chain did not deliver the write.',
+        timeout: SYNC_TIMEOUT_MS,
+      })
+      .toBe(true);
 
-    // Wait for the write to propagate to remote
-    await page.waitForTimeout(5_000);
-
-    // Verify on remote
-    const exists = await remote.exists(TEST_NOTE);
-    expect(exists).toBe(true);
+    // …and with the right BYTES, not merely the right name. Polled separately:
+    // a zero-byte file can exist for a beat before its content lands, and
+    // asserting content off the back of `exists` alone would be racy in the
+    // other direction.
+    await expect
+      .poll(() => remote.readFile(TEST_NOTE), {
+        message:
+          `"${TEST_NOTE}" exists on the remote but its content never contained the ` +
+          'text Obsidian created it with — the file landed, its bytes did not.',
+        timeout: SYNC_TIMEOUT_MS,
+      })
+      .toContain('E2E Test Note');
 
     const content = await remote.readFile(TEST_NOTE);
     expect(content).toContain('E2E Test Note');
@@ -126,40 +219,294 @@ test.describe('Remote sync verification', () => {
   test('edit — modified content reflects on remote', async () => {
     const { page } = obsidian;
 
-    // The note from the create test should still be open.
-    // Select all and replace content.
-    const editor = page.locator('.cm-editor .cm-content');
-    await expect(editor).toBeVisible({ timeout: 5_000 });
-    await editor.click();
-    await page.keyboard.press('Control+A');
-    await page.keyboard.type(TEST_CONTENT_EDITED);
+    // Re-derive the TFile by PATH. The old test assumed "the note from the
+    // create test should still be open" and typed into whatever had focus — so a
+    // stray modal, a focus drift or a different active leaf silently edited
+    // something else (or nothing) and the remote assertion took the blame.
+    await modifyNote(page, TEST_NOTE, TEST_CONTENT_EDITED);
 
-    // Wait for the write to propagate
-    await page.waitForTimeout(5_000);
+    await expect
+      .poll(() => remote.readFile(TEST_NOTE), {
+        message:
+          `"${TEST_NOTE}" was rewritten through app.vault.modify() but the remote copy ` +
+          `never picked the new content up within ${SYNC_TIMEOUT_MS}ms — an EDIT in ` +
+          'Obsidian does not reach the remote (the create did, so the connection and ' +
+          'the adapter patch are both fine).',
+        timeout: SYNC_TIMEOUT_MS,
+      })
+      .toContain('edited');
 
-    // Verify on remote
+    // Full strength, unchanged: the edited body — not just the marker word — is
+    // what has to be on the remote, and the old body must be GONE (an append
+    // would satisfy `toContain('edited')` while leaving the file wrong).
     const content = await remote.readFile(TEST_NOTE);
     expect(content).toContain('edited');
+    expect(content).toContain(STAMP);
+    expect(content).not.toContain('Created by sync.spec.ts');
   });
 
   test('delete — removed note disappears from remote', async () => {
     const { page } = obsidian;
 
-    // Delete the current note via command palette (hardened — see
-    // the create test).
-    await runCommandViaPalette(page, 'Delete current file');
+    // Precondition, asserted rather than assumed: the previous tests really did
+    // leave TEST_NOTE on the remote. Without this a delete test can pass simply
+    // because the file was never there — the classic vacuous green.
+    expect(
+      await remote.exists(TEST_NOTE),
+      `"${TEST_NOTE}" is not on the remote BEFORE the delete, so this test could ` +
+      'only ever pass vacuously. The create/edit tests above must have failed.',
+    ).toBe(true);
 
-    // Obsidian shows a confirmation dialog — click Delete
-    const confirmBtn = page.locator('.modal-button-container button:has-text("Delete")');
-    if (await confirmBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await confirmBtn.click();
-    }
+    // `vault.delete` is Obsidian's own hard delete — the same `adapter.remove()`
+    // the UI's "Delete current file" ends up calling once its confirmation is
+    // through. The old test drove the palette and then clicked that confirm
+    // button behind `if (await confirmBtn.isVisible(…))`: another silent skip, in
+    // which a missing (or overlay-covered) dialog left the file undeleted and the
+    // failure landed on `expect(exists).toBe(false)` instead of on the gesture
+    // that never happened.
+    await deleteNote(page, TEST_NOTE);
 
-    // Wait for delete to propagate
-    await page.waitForTimeout(5_000);
+    expect(
+      await inFileMap(page, TEST_NOTE),
+      `app.vault.delete("${TEST_NOTE}") returned but the note is STILL in ` +
+      `vault.fileMap — the local delete did not take.\n${await dumpVaultState(page)}`,
+    ).toBe(false);
 
-    // Verify on remote
-    const exists = await remote.exists(TEST_NOTE);
-    expect(exists).toBe(false);
+    // THE CONTRACT.
+    await expect
+      .poll(() => remote.exists(TEST_NOTE), {
+        message:
+          `"${TEST_NOTE}" was deleted in Obsidian (it is gone from vault.fileMap) but ` +
+          `is STILL on the remote after ${SYNC_TIMEOUT_MS}ms. A delete does not ` +
+          'propagate: the user removes a note and it silently comes back on the next ' +
+          'connect.',
+        timeout: SYNC_TIMEOUT_MS,
+      })
+      .toBe(false);
   });
 });
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Fail `work` at `ms` instead of letting it run to the test timeout. Scoped
+ * deliberately to `page.evaluate`, which has NO timeout of its own — a renderer
+ * wedged inside a blocked adapter write never answers, and the report would say
+ * only "Test timeout of 120000ms exceeded". A late rejection is absorbed so it
+ * cannot resurface as an unhandled rejection after the race is over.
+ */
+async function withDeadline<T>(work: Promise<T>, ms: number, what: string): Promise<T> {
+  void work.catch(() => { /* the race below already reports it */ });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(
+        `${what} did not settle within ${ms}ms — the Obsidian renderer stopped ` +
+        'answering (an adapter write blocked on SSH looks exactly like this). Bounded ' +
+        'deliberately: an unbounded wait here would eat the whole test timeout and ' +
+        'report no evidence at all.',
+      )),
+      ms,
+    );
+  });
+  try {
+    return await Promise.race([work, guard]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * The outcome of one in-renderer vault op. The renderer-side reason is carried
+ * back VERBATIM rather than collapsed into a boolean — "the note already exists"
+ * and "the adapter threw EACCES" are different findings and must not both
+ * surface as `false`.
+ */
+interface VaultOpResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * `app.vault.create(path, content)`. Throws — loudly, with the renderer's own
+ * message and the vault state — if Obsidian did not accept the create. There is
+ * no branch in which a failed create is carried past.
+ */
+async function createNote(page: Page, notePath: string, content: string): Promise<void> {
+  const result = await withDeadline(
+    page.evaluate(
+      async ({ p, c }): Promise<VaultOpResult> => {
+        const app = (window as unknown as {
+          app?: { vault?: { create?: (path: string, data: string) => Promise<unknown> } };
+        }).app;
+        if (!app?.vault?.create) {
+          return { ok: false, error: 'app.vault.create is not available' };
+        }
+        try {
+          await app.vault.create(p, c);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      { p: notePath, c: content },
+    ),
+    EVAL_TIMEOUT_MS,
+    `app.vault.create("${notePath}")`,
+  );
+
+  if (!result.ok) {
+    throw new Error(
+      `app.vault.create("${notePath}") FAILED in the renderer: ${result.error}. ` +
+      'Obsidian would not create the note at all, so nothing about remote ' +
+      `propagation is under test yet.\n${await dumpVaultState(page)}`,
+    );
+  }
+}
+
+/**
+ * `app.vault.modify(getAbstractFileByPath(path), content)` — the same call
+ * Obsidian's editor makes when it saves. Resolving the TFile BY PATH is the
+ * point: it cannot edit "whatever happened to be focused".
+ */
+async function modifyNote(page: Page, notePath: string, content: string): Promise<void> {
+  const result = await withDeadline(
+    page.evaluate(
+      async ({ p, c }): Promise<VaultOpResult> => {
+        const app = (window as unknown as {
+          app?: {
+            vault?: {
+              getAbstractFileByPath?: (path: string) => unknown;
+              modify?: (file: unknown, data: string) => Promise<void>;
+            };
+          };
+        }).app;
+        const file = app?.vault?.getAbstractFileByPath?.(p);
+        if (!file) {
+          return { ok: false, error: `getAbstractFileByPath("${p}") returned null` };
+        }
+        if (!app?.vault?.modify) {
+          return { ok: false, error: 'app.vault.modify is not available' };
+        }
+        try {
+          await app.vault.modify(file, c);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      { p: notePath, c: content },
+    ),
+    EVAL_TIMEOUT_MS,
+    `app.vault.modify("${notePath}")`,
+  );
+
+  if (!result.ok) {
+    throw new Error(
+      `app.vault.modify("${notePath}") FAILED in the renderer: ${result.error}. The ` +
+      'EDIT never happened locally, so the remote assertion below would have been ' +
+      `reporting the wrong defect.\n${await dumpVaultState(page)}`,
+    );
+  }
+}
+
+/**
+ * `app.vault.delete(getAbstractFileByPath(path))` — Obsidian's hard delete,
+ * which is what "Delete current file" resolves to once its confirmation dialog
+ * is through, and which lands on the patched `adapter.remove()`.
+ */
+async function deleteNote(page: Page, notePath: string): Promise<void> {
+  const result = await withDeadline(
+    page.evaluate(
+      async (p): Promise<VaultOpResult> => {
+        const app = (window as unknown as {
+          app?: {
+            vault?: {
+              getAbstractFileByPath?: (path: string) => unknown;
+              delete?: (file: unknown, force?: boolean) => Promise<void>;
+            };
+          };
+        }).app;
+        const file = app?.vault?.getAbstractFileByPath?.(p);
+        if (!file) {
+          return { ok: false, error: `getAbstractFileByPath("${p}") returned null` };
+        }
+        if (!app?.vault?.delete) {
+          return { ok: false, error: 'app.vault.delete is not available' };
+        }
+        try {
+          await app.vault.delete(file);
+          return { ok: true };
+        } catch (e) {
+          return { ok: false, error: e instanceof Error ? e.message : String(e) };
+        }
+      },
+      notePath,
+    ),
+    EVAL_TIMEOUT_MS,
+    `app.vault.delete("${notePath}")`,
+  );
+
+  if (!result.ok) {
+    throw new Error(
+      `app.vault.delete("${notePath}") FAILED in the renderer: ${result.error}. The ` +
+      'DELETE never happened locally, so "still on the remote" would be the wrong ' +
+      `finding.\n${await dumpVaultState(page)}`,
+    );
+  }
+}
+
+/** Is `notePath` in `vault.fileMap` at all? The local half of every verdict. */
+async function inFileMap(page: Page, notePath: string): Promise<boolean> {
+  return withDeadline(
+    page.evaluate((p) => {
+      const app = (window as unknown as {
+        app?: { vault?: { getAbstractFileByPath?: (path: string) => unknown } };
+      }).app;
+      return app?.vault?.getAbstractFileByPath?.(p) != null;
+    }, notePath),
+    EVAL_TIMEOUT_MS,
+    `inFileMap("${notePath}")`,
+  );
+}
+
+/**
+ * What was on screen and what the vault held, for the failure messages above.
+ * A bare "Received false" cannot separate "Obsidian never made the file",
+ * "Obsidian made it under a different name" (the old `Untitled.md` failure) and
+ * "it propagated nowhere"; the active file, the vault's markdown paths and any
+ * open modal (the overlay that silently broke the old click-driven path)
+ * separate all three in one CI round.
+ */
+async function dumpVaultState(page: Page): Promise<string> {
+  const state = await withDeadline(
+    page.evaluate(() => {
+      const app = (window as unknown as {
+        app?: {
+          vault?: {
+            fileMap?: Record<string, unknown>;
+            getMarkdownFiles?: () => Array<{ path?: string }>;
+          };
+          workspace?: { getActiveFile?: () => { path?: string } | null };
+        };
+      }).app;
+      const keys = Object.keys(app?.vault?.fileMap ?? {});
+      return {
+        activeFile: app?.workspace?.getActiveFile?.()?.path ?? null,
+        fileMapKeys: keys.length,
+        markdownFiles: (app?.vault?.getMarkdownFiles?.() ?? [])
+          .map((f) => f.path)
+          .slice(0, 30),
+        fileMapSample: keys.slice(0, 30),
+        openModals: Array.from(document.querySelectorAll('.modal-container')).map((c) => ({
+          title: c.querySelector('.modal-title')?.textContent?.trim() ?? '(untitled)',
+          containerClass: c.className,
+        })),
+      };
+    }),
+    EVAL_TIMEOUT_MS,
+    'dumpVaultState()',
+  ).catch((e: unknown) => ({ error: e instanceof Error ? e.message : String(e) }));
+
+  return `vault + screen state: ${JSON.stringify(state)}`;
+}

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.0",
+      "version": "1.1.8-beta.1",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.0",
+  "version": "1.1.8-beta.1",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
**This PR is EXPECTED TO GO RED.** That is the deliverable.

Tests encode **correct behaviour**. No assertion was weakened to make it pass, and there is no `test.skip` / `test.fixme`. Every red is a real defect to fix in a follow-up — not a test to soften.

E2E goes from **17 → 60 tests**.

## New helpers
- `remote-verifier`: `mkdirp` / `rmrf` / `readBinaryFile` / `setMtime`
- `remote-fixtures`: `makePng` — a **real decodable RGBA PNG** with random pixels (2048×1536 → 10.3 MB; CRC + zlib round-trip verified). The existing `makeOnePngOf` was a 1×1 zero-padded blob that could never support a dimension/resize assertion. Also `makeSvg`, `makePdf`, `makeFakePlugin` (a genuinely loadable plugin — `version` is a parameter because code convergence is version-ordered), `seedPluginOnRemote`.
- `obsidian`: `expandFolderInExplorer` — clicks the product's **own** lazy-load hook (`.nav-folder-title[data-path]`), so a deferred folder load can finally be driven from a test.

## The five specs

| spec | tests | expected red |
|---|---|---|
| `images.spec.ts` | 9 | 1 |
| `fs-visibility.spec.ts` | 10 | **7** |
| `links-metadata.spec.ts` | 8 | 3 |
| `cache-pressure.spec.ts` | 10 | 2 |
| `plugin-code-roundtrip.spec.ts` | 6 | 1 |

## Defects these encode

### 🔴 `fs-visibility` — the open half of #429
A plugin doing `fs.writeFileSync(path.join(adapter.basePath, 'note.md'))` must reach the **remote** vault; a remote note must be readable via raw `fs`; `getFullPath`/`getFilePath` must resolve. Today none of that holds — `basePath` hands out the local shadow root, `getFullPath`/`getFilePath` aren't patched at all, and the note tree is never mirrored.

Two vehicles, so no excuse survives: in-page `window.require('fs')`, **and a real fake plugin whose `onload()` does the write** — a byte-for-byte reproduction of the field report ("Claudian creates the .md in the local folder").

These **cannot** be fixed by weakening the assertions. The only correct fixes are (i) mirror the note tree with a local→remote watcher, or (ii) patch `getFullPath`/`getFilePath` over a real FS-backed view.

### 🔴 `links-metadata` + `images` — lazy folder loading starves the metadata cache
Lazy loading walks the **root only** (`main.ts`: `walk('', !lazy)`), so files in unexpanded folders are absent from `vault.fileMap` **entirely**, and `metadataCache` resolves only against `fileMap`. Consequences, now pinned: a `[[link]]` into a subfolder **does not resolve**; Quick Switcher **cannot find** the note; an image embedded from a subfolder **does not render**.

`links-metadata` test 6 is the **discriminator**: it tells us whether the fix is an eager/background full index, or metadata invalidation on lazy insert.

### 🔴 `cache-pressure` — NEW DEFECT: mtime-only revalidation
`SftpDataAdapter` revalidates a cached read on **mtime equality alone** and never compares the remote **size**, even though `stat()` already returns it. SFTP mtime is **1-second resolution** — so **two edits inside the same wall-clock second serve a stale copy**. (This is why `reflect.spec.ts` has to sleep 1.1 s to make its own test pass.)

Deliberately placed in an **SFTP** suite: on RPC the daemon's `fs.changed` push invalidates the entry and **masks** the defect, so asserting it there would be flaky-red instead of honest-red.

Eviction is **proven**, never inferred — via `readCache.stats()`, with the probe itself a precondition test that hard-fails rather than continue unproven. Confirmed budgets: ReadCache **64 MiB**, DirCache TTL **3000 ms**.

### 🔴 `plugin-code-roundtrip` — NEW DEFECT: uninstall doesn't propagate
`pushCommunityPlugins` computes a **monotonic union**, so removing a plugin can never reach the remote — and the next connect's **pull resurrects it**. Needs tombstone / real removal semantics.

## Green side (the "prove it's safe" half)
Thumbnail downscaling to the 1024 cap *and* a byte-count check (catches `ResourceBridge` silently falling back to the full binary when the thumbnail RPC fails — it swallows that today), Range requests, SVG/PDF paths, LRU eviction returning byte-identical data, writes under cache pressure not corrupting, plugin pull → load-on-next-start → push, `data.json` staying out of the code set, and no-downgrade version-ordered convergence.

## Next
Read the CI results, then fix the product defects in a follow-up and take it to `main`.