### PR TITLE
feat(server): add extension.kill with cli.kill compatibility alias (beta.0)

### DIFF
--- a/next/proto/types.ts
+++ b/next/proto/types.ts
@@ -62,6 +62,8 @@ export type MethodName =
   | 'server.info'
   | 'extension.schema'
   | 'extension.invoke'
+  | 'extension.kill'
+  | 'cli.kill'
   | 'fs.stat'
   | 'fs.exists'
   | 'fs.list'
@@ -108,6 +110,7 @@ export interface ExtensionSchemaResult {
 }
 
 export interface ExtensionInvokeParams {
+  invocationId?: string;
   tool: string;
   args?: Record<string, string>;
   workingDir?: string;
@@ -118,6 +121,15 @@ export interface ExtensionInvokeParams {
 export interface ExtensionInvokeResult {
   invocationId: string;
   accepted: boolean;
+}
+
+export interface ExtensionKillParams {
+  invocationId: string;
+}
+
+export interface ExtensionKillResult {
+  invocationId: string;
+  killed: boolean;
 }
 
 export interface CliOutputParams {

--- a/next/proto/types.ts
+++ b/next/proto/types.ts
@@ -110,12 +110,10 @@ export interface ExtensionSchemaResult {
 }
 
 export interface ExtensionInvokeParams {
-  invocationId?: string;
   tool: string;
   args?: Record<string, string>;
   workingDir?: string;
   persist?: boolean;
-  resumeFrom?: number;
 }
 
 export interface ExtensionInvokeResult {

--- a/server/cmd/obsidian-remote-server/main.go
+++ b/server/cmd/obsidian-remote-server/main.go
@@ -152,6 +152,8 @@ func run(args []string) (int, error) {
 	extRunner := handlers.NewExtensionRunner(capManager, logStore, absRoot)
 	disp.Handle("extension.schema", handlers.RequireAuth(extRunner.Schema()))
 	disp.Handle("extension.invoke", handlers.RequireAuth(extRunner.Invoke()))
+	disp.Handle("extension.kill", handlers.RequireAuth(extRunner.Kill()))
+	disp.Handle("cli.kill", handlers.RequireAuth(extRunner.KillCompat()))
 	// fs.* handlers are gated behind session auth.
 	// Read side.
 	disp.Handle("fs.stat", handlers.RequireAuth(handlers.FsStat(absRoot)))

--- a/server/config/capabilities.json
+++ b/server/config/capabilities.json
@@ -14,7 +14,7 @@
           "name": "prompt",
           "required": true,
           "maxLength": 65535,
-          "pattern": "^(?!\\s*-)[\\s\\S]+$"
+          "pattern": "^\\s*[^\\s-][\\s\\S]*$"
         }
       ]
     }

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -25,6 +27,22 @@ type extensionRunner struct {
 	vaultDir string
 	seq      atomic.Int64
 	slots    chan struct{}
+
+	mu     sync.Mutex
+	active map[string]activeInvocation
+}
+
+// activeInvocation tracks a running extension process.
+//
+// The daemon uses a single-principal model — one token minted at startup
+// that every session authenticates with. *Session is a transport handle,
+// not an identity, so there is no per-session authorization boundary.
+// session is the (rebindable) stream target for live output; when nil,
+// output is persisted to the log for replay by a future reattach.
+type activeInvocation struct {
+	session    *server.Session
+	stop       func() error
+	outputMode string
 }
 
 const maxConcurrentExtensionInvocations = 4
@@ -35,6 +53,7 @@ func NewExtensionRunner(mgr *extensions.Manager, logs *extensions.LogStore, vaul
 		logs:     logs,
 		vaultDir: vaultDir,
 		slots:    make(chan struct{}, maxConcurrentExtensionInvocations),
+		active:   map[string]activeInvocation{},
 	}
 }
 
@@ -117,10 +136,77 @@ func (r *extensionRunner) Invoke() rpc.Handler {
 		if p.Persist != nil {
 			persist = *p.Persist
 		}
-		go r.streamProcess(session, invocationID, cmd, stdout, stderr, persist, cap.OutputMode, releaseSlot)
+		r.registerInvocation(invocationID, session, cap.OutputMode, func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			return cmd.Process.Kill()
+		})
+		go r.streamProcess(invocationID, cmd, stdout, stderr, persist, cap.OutputMode, releaseSlot)
 
 		return proto.ExtensionInvokeResult{InvocationID: invocationID, Accepted: true}, nil
 	}
+}
+
+func (r *extensionRunner) Kill() rpc.Handler {
+	return r.killForMethod("extension.kill")
+}
+
+func (r *extensionRunner) KillCompat() rpc.Handler {
+	return r.killForMethod("cli.kill")
+}
+
+func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
+	return func(ctx context.Context, raw json.RawMessage) (interface{}, *rpc.Error) {
+		var p proto.ExtensionKillParams
+		if e := decodeParams(methodName, raw, &p); e != nil {
+			return nil, e
+		}
+		if strings.TrimSpace(p.InvocationID) == "" {
+			return nil, rpc.ErrInvalidParams(methodName + ": invocationId is required")
+		}
+
+		inv, ok := r.lookupInvocation(p.InvocationID)
+		if !ok {
+			return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: false}, nil
+		}
+
+		err := inv.stop()
+		if err != nil && !errors.Is(err, os.ErrProcessDone) {
+			return nil, rpc.ErrInternal(methodName + ": " + err.Error())
+		}
+		r.unregisterInvocation(p.InvocationID)
+		return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: true}, nil
+	}
+}
+
+func (r *extensionRunner) registerInvocation(invocationID string, session *server.Session, outputMode string, stop func() error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.active[invocationID] = activeInvocation{session: session, outputMode: outputMode, stop: stop}
+}
+
+func (r *extensionRunner) lookupInvocation(invocationID string) (activeInvocation, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inv, ok := r.active[invocationID]
+	return inv, ok
+}
+
+func (r *extensionRunner) unregisterInvocation(invocationID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.active, invocationID)
+}
+
+func (r *extensionRunner) currentInvocationSession(invocationID string) *server.Session {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inv, ok := r.active[invocationID]
+	if !ok {
+		return nil
+	}
+	return inv.session
 }
 
 func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]string) ([]string, error) {
@@ -164,8 +250,9 @@ func validateAndBuildArgs(cap proto.ExtensionCapability, provided map[string]str
 	return out, nil
 }
 
-func (r *extensionRunner) streamProcess(session *server.Session, invocationID string, cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, persist bool, outputMode string, releaseSlot func()) {
+func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, persist bool, outputMode string, releaseSlot func()) {
 	defer releaseSlot()
+	defer r.unregisterInvocation(invocationID)
 	itemsCh := make(chan proto.CliOutputBatchItem, 256)
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -185,32 +272,40 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 		if len(batch) == 0 {
 			return true
 		}
+		session := r.currentInvocationSession(invocationID)
 		payload := append([]proto.CliOutputBatchItem(nil), batch...)
-		if outputMode == "single" {
-			for _, it := range payload {
-				if err := session.SendNotification("cli.output", proto.CliOutputParams{
-					InvocationID: invocationID,
-					Stream:       it.Stream,
-					Data:         it.Data,
-					Seq:          it.Seq,
-				}); err != nil {
-					_ = cmd.Process.Kill()
-					return false
-				}
-			}
-		} else {
-			if err := session.SendNotification("cli.output.batch", proto.CliOutputBatchParams{
-				InvocationID: invocationID,
-				Items:        payload,
-			}); err != nil {
-				_ = cmd.Process.Kill()
-				return false
-			}
-		}
+
+		// Persist to log first so a reattaching session can replay.
 		if persistEnabled {
 			ok, err := r.logs.AppendBatch(invocationID, payload)
 			if err != nil || !ok {
 				persistEnabled = false
+			}
+		}
+
+		// Stream to the active session if one exists.
+		// When session is nil (dropped with no reattach) or send fails,
+		// the process keeps running — output is already persisted above
+		// and can be replayed via resumeInvoke + ReplayFrom.
+		if session != nil {
+			if outputMode == "single" {
+				for _, it := range payload {
+					if err := session.SendNotification("cli.output", proto.CliOutputParams{
+						InvocationID: invocationID,
+						Stream:       it.Stream,
+						Data:         it.Data,
+						Seq:          it.Seq,
+					}); err != nil {
+						session = nil
+					}
+				}
+			} else {
+				if err := session.SendNotification("cli.output.batch", proto.CliOutputBatchParams{
+					InvocationID: invocationID,
+					Items:        payload,
+				}); err != nil {
+					session = nil
+				}
 			}
 		}
 		batch = batch[:0]
@@ -235,11 +330,14 @@ func (r *extensionRunner) streamProcess(session *server.Session, invocationID st
 						sig = err.Error()
 					}
 				}
-				_ = session.SendNotification("cli.done", proto.CliDoneParams{
-					InvocationID: invocationID,
-					ExitCode:     exitCode,
-					Signal:       sig,
-				})
+				session := r.currentInvocationSession(invocationID)
+				if session != nil {
+					_ = session.SendNotification("cli.done", proto.CliDoneParams{
+						InvocationID: invocationID,
+						ExitCode:     exitCode,
+						Signal:       sig,
+					})
+				}
 				return
 			}
 			batch = append(batch, it)

--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -175,7 +175,8 @@ func (r *extensionRunner) killForMethod(methodName string) rpc.Handler {
 		if err != nil && !errors.Is(err, os.ErrProcessDone) {
 			return nil, rpc.ErrInternal(methodName + ": " + err.Error())
 		}
-		r.unregisterInvocation(p.InvocationID)
+		// Don't unregister here — streamProcess's deferred unregisterInvocation
+		// handles cleanup after sending cli.done.
 		return proto.ExtensionKillResult{InvocationID: p.InvocationID, Killed: true}, nil
 	}
 }
@@ -284,9 +285,8 @@ func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdo
 		}
 
 		// Stream to the active session if one exists.
-		// When session is nil (dropped with no reattach) or send fails,
-		// the process keeps running — output is already persisted above
-		// and can be replayed via resumeInvoke + ReplayFrom.
+		// On send failure the client is gone; kill the process so the
+		// slot is released via the deferred releaseSlot.
 		if session != nil {
 			if outputMode == "single" {
 				for _, it := range payload {
@@ -296,7 +296,9 @@ func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdo
 						Data:         it.Data,
 						Seq:          it.Seq,
 					}); err != nil {
-						session = nil
+						_ = cmd.Process.Kill()
+						batch = batch[:0]
+						return false
 					}
 				}
 			} else {
@@ -304,7 +306,9 @@ func (r *extensionRunner) streamProcess(invocationID string, cmd *exec.Cmd, stdo
 					InvocationID: invocationID,
 					Items:        payload,
 				}); err != nil {
-					session = nil
+					_ = cmd.Process.Kill()
+					batch = batch[:0]
+					return false
 				}
 			}
 		}

--- a/server/internal/handlers/extension_test.go
+++ b/server/internal/handlers/extension_test.go
@@ -1,10 +1,13 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/proto"
+	"github.com/sotashimozono/obsidian-remote-ssh/server/internal/server"
 )
 
 func TestValidateAndBuildArgs_RejectsLeadingDash(t *testing.T) {
@@ -40,5 +43,71 @@ func TestValidateAndBuildArgs_AllowsLeadingDashWhenConfigured(t *testing.T) {
 	}
 	if len(args) != 1 || args[0] != "--help" {
 		t.Fatalf("args = %v, want [--help]", args)
+	}
+}
+
+func TestExtensionKill_NotFound_ReturnsKilledFalse(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	h := r.Kill()
+
+	ctx := server.WithSession(context.Background(), server.NewSession())
+	res, rpcErr := h(ctx, json.RawMessage(`{"invocationId":"inv-missing"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if out.Killed {
+		t.Fatalf("Killed = true, want false")
+	}
+}
+
+func TestExtensionKill_ExistingInvocationCanBeKilled(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	owner := server.NewSession()
+	called := false
+	r.registerInvocation("inv-2", owner, "batch", func() error {
+		called = true
+		return nil
+	})
+
+	h := r.Kill()
+	ownerCtx := server.WithSession(context.Background(), owner)
+	res, rpcErr := h(ownerCtx, json.RawMessage(`{"invocationId":"inv-2"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if !out.Killed {
+		t.Fatalf("Killed = false, want true")
+	}
+	if !called {
+		t.Fatalf("stop should be called for owner session")
+	}
+}
+
+func TestExtensionKill_CompatAlias(t *testing.T) {
+	r := NewExtensionRunner(nil, nil, "")
+	r.registerInvocation("inv-3", server.NewSession(), "batch", func() error {
+		return nil
+	})
+
+	h := r.KillCompat()
+	ctx := server.WithSession(context.Background(), server.NewSession())
+	res, rpcErr := h(ctx, json.RawMessage(`{"invocationId":"inv-3"}`))
+	if rpcErr != nil {
+		t.Fatalf("unexpected rpc error: %v", rpcErr)
+	}
+	out, ok := res.(proto.ExtensionKillResult)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", res)
+	}
+	if !out.Killed {
+		t.Fatalf("Killed = false, want true")
 	}
 }

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -269,12 +269,10 @@ type ExtensionSchemaResult struct {
 
 // ExtensionInvokeParams is the generic command invocation contract.
 type ExtensionInvokeParams struct {
-	InvocationID string            `json:"invocationId,omitempty"`
-	Tool         string            `json:"tool"`
-	Args         map[string]string `json:"args,omitempty"`
-	WorkingDir   string            `json:"workingDir,omitempty"`
-	Persist      *bool             `json:"persist,omitempty"`
-	ResumeFrom   int64             `json:"resumeFrom,omitempty"`
+	Tool       string            `json:"tool"`
+	Args       map[string]string `json:"args,omitempty"`
+	WorkingDir string            `json:"workingDir,omitempty"`
+	Persist    *bool             `json:"persist,omitempty"`
 }
 
 // ExtensionInvokeResult identifies the accepted execution stream.

--- a/server/internal/proto/types.go
+++ b/server/internal/proto/types.go
@@ -269,17 +269,29 @@ type ExtensionSchemaResult struct {
 
 // ExtensionInvokeParams is the generic command invocation contract.
 type ExtensionInvokeParams struct {
-	Tool       string            `json:"tool"`
-	Args       map[string]string `json:"args,omitempty"`
-	WorkingDir string            `json:"workingDir,omitempty"`
-	Persist    *bool             `json:"persist,omitempty"`
-	ResumeFrom int64             `json:"resumeFrom,omitempty"`
+	InvocationID string            `json:"invocationId,omitempty"`
+	Tool         string            `json:"tool"`
+	Args         map[string]string `json:"args,omitempty"`
+	WorkingDir   string            `json:"workingDir,omitempty"`
+	Persist      *bool             `json:"persist,omitempty"`
+	ResumeFrom   int64             `json:"resumeFrom,omitempty"`
 }
 
 // ExtensionInvokeResult identifies the accepted execution stream.
 type ExtensionInvokeResult struct {
 	InvocationID string `json:"invocationId"`
 	Accepted     bool   `json:"accepted"`
+}
+
+// ExtensionKillParams requests termination of an active invocation.
+type ExtensionKillParams struct {
+	InvocationID string `json:"invocationId"`
+}
+
+// ExtensionKillResult reports whether the target invocation was terminated.
+type ExtensionKillResult struct {
+	InvocationID string `json:"invocationId"`
+	Killed       bool   `json:"killed"`
 }
 
 // ─── server-push notifications ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Introduces  as the canonical lifecycle method for , with  kept as a deprecated compatibility alias.

This is **beta.0** of the incremental merge strategy proposed in [#425](https://github.com/sotashimozono/obsidian-remote-ssh/pull/425).

## Changes

- Add  struct with session-based tracking (single-principal model)
- Add  and  handlers with existence-only checks
- Register invocations in  for lifecycle tracking
- Update  to use session lookup instead of parameter passing
- Add  field to 
- Add  and  protocol types
- Fix  regex for RE2 compatibility
- Add tests for kill behavior

## Motivation

Following the incremental merge strategy from #425 review:
- **beta.0** (this PR):  +  — ready to merge
- **beta.1** (follow-up):  /  — iterate on blocking issues
- **beta.2**: next slice

Each PR stays reviewable in isolation and the git history tells a clear story of what each increment decided.

## Verification

- ✅  passes
- ✅  passes (all tests green)