### PR TITLE
probe(e2e): can Node fs be routed to the remote daemon? (#429 design decision)

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/fs-sync-bridge-probe.spec.ts
+++ b/plugin/e2e/fs-sync-bridge-probe.spec.ts
@@ -1,0 +1,202 @@
+import { test, expect } from '@playwright/test';
+import {
+  launchObsidian,
+  driveConnectFlow,
+  findShadowVaultPath,
+  waitForShadowVaultLoaded,
+  type ObsidianHandle,
+} from './helpers/obsidian';
+import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
+import { RemoteVerifier } from './helpers/remote-verifier';
+import { assertSshdReachable } from './helpers/sshd';
+import { logPathFor } from './helpers/log-oracle';
+
+/**
+ * CAPABILITY PROBE — not a product test.
+ *
+ * We want to close the open half of #429 by taking Node's `fs` over in the
+ * renderer and routing it to the remote daemon — instead of mirroring the note
+ * tree to local disk (which abandons the virtual-vault design) or shipping a
+ * FUSE dependency (which kills adoption).
+ *
+ * Patching `fs` is the easy part. The ENTIRE difficulty is one thing:
+ *
+ *     fs.readFileSync(p)  is SYNCHRONOUS, and the remote is 10-100 ms away.
+ *
+ * The WRITE side has an out: write locally, push in the background — the plugin
+ * cannot tell. The READ side has none: a synchronous call must produce bytes
+ * before it returns. That needs a real sync-over-async bridge, and whether one
+ * EXISTS in Obsidian's renderer is an empirical question we have only been
+ * guessing at.
+ *
+ * So stop guessing. This runs inside the real Obsidian and reports the facts.
+ * It asserts only the things the approach would DEPEND on, so a red here means
+ * "this design is not available", not "the product is broken".
+ *
+ * Probes:
+ *   1. renderer Node surface        — require / child_process / worker_threads
+ *   2. SharedArrayBuffer            — present? crossOriginIsolated?
+ *   3. Atomics.wait on the MAIN thread — the ideal bridge. Chromium normally
+ *      FORBIDS this on the main thread; Electron might not. THIS is the question.
+ *   4. is require('fs') patchable   — shared module cache, writable properties
+ *   5. spawnSync round-trip latency — the fallback bridge's real cost
+ *   6. adapter read latency         — what a sync remote read would freeze the
+ *                                     UI for, in milliseconds
+ *
+ * Read the JSON it prints in CI, then pick the design.
+ */
+
+let obsidian: ObsidianHandle;
+let scaffold: ScaffoldResult;
+let remote: RemoteVerifier;
+let shadowVaultPath: string;
+
+test.beforeAll(async () => {
+  await assertSshdReachable();
+  remote = new RemoteVerifier();
+  if (!(await remote.connect())) throw new Error('RemoteVerifier could not connect to the test sshd');
+
+  scaffold = scaffoldTestVault();
+  obsidian = await launchObsidian(scaffold.vaultPath);
+  await driveConnectFlow(obsidian.page);
+  shadowVaultPath = await findShadowVaultPath(scaffold.vaultPath, 15_000);
+  await obsidian.cleanup();
+  obsidian = await launchObsidian(shadowVaultPath);
+  await waitForShadowVaultLoaded(obsidian.page, logPathFor(shadowVaultPath), 30_000);
+});
+
+test.afterAll(async () => {
+  await obsidian?.cleanup();
+  await remote?.disconnect();
+  scaffold?.cleanup();
+});
+
+test.describe('capability probe: can Node fs be routed to the remote daemon? (#429)', () => {
+  test('PROBE — report the renderer capabilities that decide the design', async () => {
+    const report = await obsidian.page.evaluate(async () => {
+      const out: Record<string, unknown> = {};
+      const req = (window as unknown as { require?: (m: string) => unknown }).require;
+
+      // ── 1. renderer Node surface ──────────────────────────────────────────
+      out.hasRequire = typeof req === 'function';
+      if (typeof req !== 'function') return out;
+
+      const tryReq = (m: string): unknown => { try { return req(m); } catch { return null; } };
+      const procG = (globalThis as { process?: { versions?: Record<string, string>; execPath?: string } }).process;
+      out.hasChildProcess = tryReq('child_process') !== null;
+      out.hasWorkerThreads = tryReq('worker_threads') !== null;
+      out.nodeVersion = procG?.versions?.node ?? null;
+      out.electronVersion = procG?.versions?.electron ?? null;
+
+      // ── 2. SharedArrayBuffer ──────────────────────────────────────────────
+      out.hasSharedArrayBuffer = typeof SharedArrayBuffer !== 'undefined';
+      out.crossOriginIsolated =
+        (globalThis as { crossOriginIsolated?: boolean }).crossOriginIsolated ?? null;
+
+      // ── 3. THE question: Atomics.wait on the renderer MAIN thread ─────────
+      // Chromium forbids this on the main thread ("Atomics.wait cannot be
+      // called in this context"). If Electron permits it, we get a real
+      // sync-over-async bridge: no process spawn, no polling, microsecond
+      // wake-up. If it throws, the ideal design is off the table.
+      if (typeof SharedArrayBuffer !== 'undefined') {
+        try {
+          const sab = new SharedArrayBuffer(8);
+          const ta = new Int32Array(sab);
+          const t0 = performance.now();
+          const r = Atomics.wait(ta, 0, 0, 5); // 'timed-out' means PERMITTED
+          out.atomicsWaitMainThread = { allowed: true, result: r, ms: Math.round(performance.now() - t0) };
+        } catch (e) {
+          out.atomicsWaitMainThread = { allowed: false, error: String(e) };
+        }
+      } else {
+        out.atomicsWaitMainThread = { allowed: false, error: 'no SharedArrayBuffer' };
+      }
+
+      // ── 4. is require('fs') patchable? ────────────────────────────────────
+      // A plugin does `require('fs')`. If the module cache is shared and the
+      // exported functions are writable, we can take them over.
+      // Caveat we cannot fix and should record: a plugin that DESTRUCTURES —
+      // `const { writeFileSync } = require('fs')` — captures the value and
+      // bypasses any later patch.
+      const fsA = tryReq('fs') as Record<string, unknown> | null;
+      const fsB = tryReq('fs') as Record<string, unknown> | null;
+      out.fsModuleCacheShared = fsA !== null && fsA === fsB;
+      if (fsA) {
+        const d = Object.getOwnPropertyDescriptor(fsA, 'writeFileSync');
+        out.fsWriteFileSyncDescriptor = d
+          ? { writable: d.writable ?? null, configurable: d.configurable ?? null }
+          : null;
+        try {
+          const orig = fsA.writeFileSync;
+          let sawPatched = false;
+          fsA.writeFileSync = () => { sawPatched = true; };
+          // Call it through a FRESH require, the way a plugin would.
+          (tryReq('fs') as Record<string, () => void>).writeFileSync();
+          fsA.writeFileSync = orig; // restore immediately — no disk I/O happened
+          out.fsPatchTakesEffect = sawPatched;
+        } catch (e) {
+          out.fsPatchTakesEffect = `threw: ${String(e)}`;
+        }
+      }
+
+      // ── 5. spawnSync round-trip cost (the fallback bridge) ────────────────
+      const cp = tryReq('child_process') as {
+        spawnSync?: (c: string, a: string[], o?: unknown) => unknown;
+      } | null;
+      if (cp?.spawnSync && procG?.execPath) {
+        const samples: number[] = [];
+        for (let i = 0; i < 5; i++) {
+          const t0 = performance.now();
+          try { cp.spawnSync(procG.execPath, ['-e', '0'], { timeout: 10_000 }); } catch { /* still timed */ }
+          samples.push(performance.now() - t0);
+        }
+        samples.sort((a, b) => a - b);
+        out.spawnSyncMs = { samples: samples.map((s) => Math.round(s)), medianMs: Math.round(samples[2]) };
+      } else {
+        out.spawnSyncMs = null;
+      }
+
+      // ── 6. what a sync remote read would cost the UI ──────────────────────
+      const app = (window as unknown as {
+        app?: { vault?: { adapter?: { read?: (p: string) => Promise<string> } } };
+      }).app;
+      const adapter = app?.vault?.adapter;
+      if (adapter?.read) {
+        const samples: number[] = [];
+        for (let i = 0; i < 5; i++) {
+          const t0 = performance.now();
+          try { await adapter.read('remote_demo1.md'); } catch { /* still timed */ }
+          samples.push(performance.now() - t0);
+        }
+        samples.sort((a, b) => a - b);
+        out.adapterReadMs = {
+          samples: samples.map((s) => Math.round(s)),
+          medianMs: Math.round(samples[2]),
+          note: 'sample 1 is a cold remote fetch; later ones are likely cache hits',
+        };
+      }
+
+      return out;
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(
+      '\n===== FS SYNC-BRIDGE CAPABILITY REPORT =====\n' +
+      JSON.stringify(report, null, 2) +
+      '\n===========================================\n',
+    );
+
+    // The preconditions the whole approach rests on. A red here is a FINDING
+    // ("this design is not available in Obsidian's renderer"), not a bug.
+    expect(report.hasRequire, 'the renderer must expose require() to patch fs at all').toBe(true);
+    expect(
+      report.fsModuleCacheShared,
+      "require('fs') must return the SAME module object a plugin sees, or a patch is invisible to it",
+    ).toBe(true);
+    expect(
+      report.fsPatchTakesEffect,
+      'patching the fs module object must be observable through a fresh require()',
+    ).toBe(true);
+    expect(report.hasChildProcess, 'child_process is the fallback sync bridge').toBe(true);
+  });
+});

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.4",
+      "version": "1.1.8-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
**Not a product change. A measurement.**

Before committing to a design for the open half of #429 (a plugin's `fs.writeFileSync` never reaches the remote), measure the renderer instead of arguing about it.

## The plan we like

Take over Node's `fs` in the renderer and route it to the remote daemon.

It's the only option that **keeps the virtual vault** — no local mirror of the note tree, which would abandon the whole shadow-vault design — and ships **no FUSE dependency**, which would kill adoption.

## The one hard problem

Patching `fs` is easy. Everything hinges on this:

```js
fs.readFileSync(p)   // SYNCHRONOUS. The remote is 10–100 ms away.
```

- **Writes have an out:** write locally, push in the background. The plugin can't tell. Claudian's case is solved by this alone.
- **Reads have none:** a synchronous call must produce bytes *before it returns*. That needs a genuine sync-over-async bridge — and whether one **exists** in Obsidian's renderer is an empirical question we've only been guessing at.

## What this probe measures, in a real Obsidian

1. **`Atomics.wait` on the renderer MAIN thread** — the ideal bridge (worker does the async I/O, main thread blocks on a `SharedArrayBuffer`, microsecond wake-up, no process spawn). **Chromium normally forbids this on the main thread.** Whether Electron permits it is *the* question, and it decides the design.
2. `SharedArrayBuffer` / `crossOriginIsolated` / `worker_threads` / `child_process` availability.
3. **Is `require('fs')` patchable** — shared module cache + writable properties. It patches, then calls through a *fresh* `require('fs')` to prove a plugin would actually see it. (Known limit it also documents: a plugin that *destructures* — `const { writeFileSync } = require('fs')` — captures the value and bypasses any patch. Nothing can fix that.)
4. **`spawnSync` round-trip latency** — the fallback bridge's real cost.
5. **Adapter read latency** — how long a sync remote read would actually freeze the UI.

It asserts only the preconditions the approach depends on, so a **red here is a finding** ("this design isn't available in the renderer"), not a product defect.

## Then what

Read the JSON it prints in CI and pick the design. If `Atomics.wait` is allowed, we get a clean sync bridge and #429 closes without touching the architecture. If it isn't, we know the real cost of `spawnSync` and can decide whether a UI freeze of *N* ms is an acceptable price for "the plugin's write actually reaches your vault" — versus today, where it silently writes to a folder nobody looks at.

This PR is a scaffold for that decision. I'd merge it only if we keep the probe as a standing environment check; otherwise it gets deleted once we've read the number.