### PR TITLE
fix(server): correct replay-then-bind ordering in resumeInvoke

### DIFF
--- a/server/internal/handlers/extension.go
+++ b/server/internal/handlers/extension.go
@@ -173,19 +173,23 @@ func (r *extensionRunner) resumeInvoke(ctx context.Context, p proto.ExtensionInv
 		return nil, rpc.ErrInvalidParams("extension.invoke: unknown invocationId for resume")
 	}
 
-	// Fix #2: Replay-then-bind ordering.
-	// Replay persisted output BEFORE binding session to prevent live
-	// stream batches from interleaving with historical replay.
-	inv, isRunning := r.rebindInvocation(invocationID, session)
+	// Determine output mode from active invocation (if still running).
+	inv, isRunning := r.lookupInvocation(invocationID)
 	outputMode := "batch"
 	if isRunning {
 		outputMode = inv.outputMode
 	}
 
+	// Fix #2: Replay-then-bind ordering.
+	// Read persisted output BEFORE binding session to prevent live
+	// stream batches from interleaving with historical replay.
 	items, done, err := r.logs.ReplayFrom(invocationID, p.ResumeFrom)
 	if err != nil {
 		return nil, rpc.ErrInternal("extension.invoke: replay: " + err.Error())
 	}
+
+	// Bind session for live output AFTER replay is captured.
+	r.rebindInvocation(invocationID, session)
 	if len(items) > 0 {
 		if err := sendReplay(session, outputMode, invocationID, items); err != nil {
 			return nil, rpc.ErrInternal("extension.invoke: replay notify: " + err.Error())


### PR DESCRIPTION
## Summary

Fix for the inverted replay-then-bind ordering flagged in [#466](https://github.com/sotashimozono/obsidian-remote-ssh/pull/466#issuecomment-4977714004) (post-merge).

## Problem

`resumeInvoke` called `rebindInvocation` before `ReplayFrom`, so for a still-running invocation, `streamProcess` could push a live batch to the newly-bound session before the replay was sent — the exact interleave the ordering was meant to prevent.

## Fix

Use `lookupInvocation` (read-only) to get `outputMode`, then `ReplayFrom` to capture the log, then `rebindInvocation` to bind the session. No window for live batches to slip in between.

```
// Before: bind → replay (gap)
// After:  lookup → replay → bind (no gap)
```

## Verification

`make build` ✅ · `make test` ✅