### PR TITLE
feat(adapter): a plugin's raw fs writes now reach the remote vault (#429)

### DIFF
--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -131,14 +131,31 @@ Things that aren't a specific plugin but trip plugins in general:
 - **`app.vault.adapter.basePath` and `getBasePath()`** resolve to the
   **shadow vault's** local root (e.g. `~/.obsidian-remote/vaults/<P-id>/`),
   not the remote SSH path; #170 patches both so readers don't crash on
-  `undefined`. But the vault tree is **virtual** — served from the
-  remote, not mirrored to disk (only `.obsidian/` lives there). So
-  `basePath` + Node `fs` only touches the local shadow copy: `fs` reads
-  miss remote notes, `fs` writes don't reach the remote. Only the vault
-  API round-trips (`.obsidian/` config via a dedicated watcher,
-  #342/#434). See *Direct-disk / agentic plugins* (#429) and the
+  `undefined`. The vault tree there is **virtual** — served from the
+  remote, not mirrored to disk (only `.obsidian/` lives there) — so the
+  two directions are **not** symmetric:
+  - **Writes propagate.** A file written under `basePath` with Node
+    `fs` — by a plugin, or by a subprocess it spawned — is picked up by
+    a filesystem watcher and pushed to the remote vault through the
+    same adapter the vault API uses, then registered in `vault.fileMap`
+    (#429). It goes through the normal mtime precondition, so a
+    simultaneous remote edit raises the usual conflict prompt. The
+    config tree (`.obsidian/**`), `.trash`, VCS/dependency dirs and
+    editor temp files are excluded; a file over the write-back size
+    limit (Settings → Advanced, 32 MB default) is reported rather than
+    pushed. The whole behaviour is switchable: *Push out-of-band file
+    writes to the remote*.
+  - **Reads do not.** `fs.readFileSync` / `fs.readdirSync` under
+    `basePath` see only what is physically there — the config tree and
+    whatever an out-of-band writer left behind — never the remote
+    notes. Mirroring the note tree to disk would mean keeping a local
+    clone of the remote vault, which is the thing this design exists to
+    avoid. So a plugin that *reads* notes through Node `fs` (importers,
+    exporters, "open in external editor", anything that shells out to a
+    local binary) sees an empty vault. Read through the vault API.
+  See *Direct-disk / agentic plugins* (#429) and the
   **basePath survey** (#133) — its "syncs up to the remote" mitigations
-  assumed a vault-tree watcher that was never built. **Exception:** plugins that shell out to a local
+  now hold for writes, and only for writes. **Exception:** plugins that shell out to a local
   binary (notably obsidian-Git's `SimpleGit` desktop path) operate on
   the shadow git repo rather than the remote one — patching can't fix
   this from our side. obsidian-Git's bundled `IsomorphicGit` mode
@@ -149,11 +166,12 @@ Things that aren't a specific plugin but trip plugins in general:
   they don't see our patched `app.vault.adapter`. Plugins that pass file
   paths to a worker for parsing (some search-heavy plugins do this)
   will break against the remote. Same diagnosis: no general fix.
-- **`fs.watch` from Node** doesn't reach the remote. Our patched
+- **`fs.watch` from Node** doesn't see remote activity. Our patched
   adapter feeds `app.vault.adapter.on('modify', …)`-style listeners
   through the daemon's `fs.watch` notifications, but a plugin that
-  installs its own `fs.watch` against `basePath` only watches the local
-  empty directory.
+  installs its own `fs.watch` against `basePath` only sees local disk
+  events — its own writes and other out-of-band writers, never a change
+  another device made on the remote.
 - **Static asset URLs (`app://local/<path>`)** — a few plugins build
   these manually instead of going through `getResourcePath`. The
   manually-built URL points at the local FS and won't render. The
@@ -165,11 +183,15 @@ Things that aren't a specific plugin but trip plugins in general:
   needed at this time.
 - **Direct-disk / agentic plugins** (e.g. Claude Code wrappers like
   "Claudian") write via Node `fs` / child processes, bypassing the
-  adapter — so their files stay in the local shadow copy and never
-  reach the remote ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
-  No local→remote reconciler exists for the vault tree (adding one =
-  the sync model this single-source-of-truth design avoids). Use
-  plugins that go through the vault API.
+  adapter ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
+  The files they *create or edit* now reach the remote vault and the
+  file explorer, via the write-back watcher described above — a
+  one-way, event-driven push, not a reconciler. What they still cannot
+  do is **read**: an agent that greps the vault directory, or opens a
+  note by absolute path, finds nothing there, because the note tree is
+  never materialised on disk. Feed such a plugin content through the
+  vault API (or paste it in); don't expect it to discover the vault by
+  walking `basePath`.
 
 ## Why we can't auto-test all of this
 

--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -145,14 +145,23 @@ Things that aren't a specific plugin but trip plugins in general:
     limit (Settings → Advanced, 32 MB default) is reported rather than
     pushed. The whole behaviour is switchable: *Push out-of-band file
     writes to the remote*.
-  - **Reads do not.** `fs.readFileSync` / `fs.readdirSync` under
-    `basePath` see only what is physically there — the config tree and
-    whatever an out-of-band writer left behind — never the remote
-    notes. Mirroring the note tree to disk would mean keeping a local
-    clone of the remote vault, which is the thing this design exists to
-    avoid. So a plugin that *reads* notes through Node `fs` (importers,
-    exporters, "open in external editor", anything that shells out to a
-    local binary) sees an empty vault. Read through the vault API.
+  - **Reads work only for a file you asked for by path.**
+    `getFullPath(path)` and `getFilePath(path)` materialise that one
+    file onto the shadow disk before returning, so the path they hand
+    back resolves and `shell.openPath` / an `<img>` / an external editor
+    opens the real note. Files read through the vault API are cached the
+    same way. Everything else is still absent: the note tree is **not**
+    mirrored, because that would mean keeping a local clone of the
+    remote vault — the thing this design exists to avoid. So
+    `fs.readFileSync(path.join(basePath, 'note.md'))` on a note nobody
+    asked for fails, and `fs.readdirSync(basePath)` lists only the
+    config tree plus whatever happens to be materialised — never the
+    vault. A plugin that discovers notes by walking the filesystem sees
+    an empty vault; read through the vault API instead.
+    The cache is bounded (Settings → Advanced, *On-demand file cache*,
+    128 MB default, 8 MB per file), evicts least-recently-used copies,
+    refuses anything over the limit rather than fetching and discarding
+    it, and is deleted on disconnect.
   See *Direct-disk / agentic plugins* (#429) and the
   **basePath survey** (#133) — its "syncs up to the remote" mitigations
   now hold for writes, and only for writes. **Exception:** plugins that shell out to a local
@@ -186,12 +195,13 @@ Things that aren't a specific plugin but trip plugins in general:
   adapter ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
   The files they *create or edit* now reach the remote vault and the
   file explorer, via the write-back watcher described above — a
-  one-way, event-driven push, not a reconciler. What they still cannot
-  do is **read**: an agent that greps the vault directory, or opens a
-  note by absolute path, finds nothing there, because the note tree is
-  never materialised on disk. Feed such a plugin content through the
-  vault API (or paste it in); don't expect it to discover the vault by
-  walking `basePath`.
+  one-way, event-driven push, not a reconciler. Reading is the half
+  that stays limited: an agent that greps the vault directory finds
+  only what has been materialised (a note it was pointed at by
+  `getFullPath`, or one that was opened), never the vault as a whole,
+  because the tree is not mirrored. Point such a plugin at specific
+  notes rather than expecting it to discover the vault by walking
+  `basePath`.
 
 ## Why we can't auto-test all of this
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.5",
+      "version": "1.1.8-beta.6",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.4",
+      "version": "1.1.8-beta.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.4",
+  "version": "1.1.8-beta.5",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/AdapterManager.ts
+++ b/plugin/src/adapter/AdapterManager.ts
@@ -6,6 +6,7 @@ import type { PluginSettings } from '../types';
 import { ReadCache } from '../cache/ReadCache';
 import { DirCache } from '../cache/DirCache';
 import { SftpDataAdapter } from './SftpDataAdapter';
+import { MaterializedCache } from './MaterializedCache';
 import { AdapterPatcher } from './AdapterPatcher';
 import { ResourceBridge } from './ResourceBridge';
 import { WriteConflictModal } from '../ui/WriteConflictModal';
@@ -24,6 +25,7 @@ import { PathMapper } from '../path/PathMapper';
 import { logger } from '../util/logger';
 import { errorMessage } from '../util/errorMessage';
 import * as path from 'path';
+import * as fs from 'fs';
 
 /**
  * The set of FileSystemAdapter methods that get monkey-patched onto
@@ -49,6 +51,11 @@ export const PATCHED_METHODS = [
   // through the replacement makes the contract explicit and gives
   // tests a single hook to assert on. #170, follow-up to #133.
   'basePath', 'getBasePath',
+  // Path surface — the stock FileSystemAdapter versions join onto the
+  // local base and so hand out a path to nothing, because the note tree
+  // is virtual (#429). The replacements materialise the file first,
+  // within the cache budget, so what they return actually resolves.
+  'getFullPath', 'getFilePath',
 ] as const;
 
 /**
@@ -68,6 +75,7 @@ export class AdapterManager {
   private ancestorTracker: AncestorTracker | null = null;
   private offlineQueue: OfflineQueue | null = null;
   private resourceBridge: ResourceBridge | null = null;
+  private materializedCache: MaterializedCache | null = null;
 
   constructor(
     private readonly app: App,
@@ -81,6 +89,15 @@ export class AdapterManager {
 
   get dataAdapter(): SftpDataAdapter | null {
     return this._dataAdapter;
+  }
+
+  /**
+   * The session's materialisation ledger. `LocalWriteWatcher` consults
+   * it so a copy we put on disk is never pushed back to the remote as
+   * if the user had written it.
+   */
+  get materialized(): MaterializedCache | null {
+    return this.materializedCache;
   }
 
   isPatched(): boolean {
@@ -245,6 +262,29 @@ export class AdapterManager {
     // stateless (only mutates the live Vault) and the adapter object
     // outlives a reconnect's swapClient, so wiring once here holds for
     // the whole patched lifetime — no per-swap re-policy needed.
+    // Bounded on-demand disk cache behind getFullPath / getFilePath and
+    // the read-through in read/readBinary. Zero budget switches the
+    // whole thing off; nothing is ever pre-fetched either way.
+    this.materializedCache = new MaterializedCache({
+      absOf: (rel) => path.join(shadowBasePath, rel),
+      writeFile: (abs, data) => {
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, data);
+        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        return s ? { size: s.size, mtimeMs: s.mtimeMs } : null;
+      },
+      statFile: (abs) => {
+        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        return s?.isFile() ? { size: s.size, mtimeMs: s.mtimeMs } : null;
+      },
+      deleteFile: (abs) => fs.rmSync(abs, { force: true }),
+      budgetBytes: shadowBasePath
+        ? Math.max(0, this.getSettings().fsCacheMB ?? 128) * 1024 * 1024
+        : 0,
+      maxFileBytes: Math.max(0, this.getSettings().fsCacheMaxFileMB ?? 8) * 1024 * 1024,
+    });
+    this._dataAdapter.setMaterializedCache(this.materializedCache);
+
     const localOpRegistry = new LocalOpRegistry();
     this._dataAdapter.setWriterReflector(
       new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
@@ -291,6 +331,12 @@ export class AdapterManager {
     this._dataAdapter = null;
     this.readCache = null;
     this.dirCache = null;
+    // The disk cache is per-session: drop every untouched copy we put
+    // on the shadow disk so a disconnect leaves behind only what the
+    // user (or a plugin) actually created there. A copy somebody edited
+    // is left alone — the watcher owns it now.
+    this.materializedCache?.clear();
+    this.materializedCache = null;
     this.ancestorTracker?.clear();
     this.ancestorTracker = null;
     this.transferTracker?.clear();

--- a/plugin/src/adapter/LocalWriteWatcher.ts
+++ b/plugin/src/adapter/LocalWriteWatcher.ts
@@ -31,6 +31,13 @@ export interface LocalWriteWatcherDeps {
   removeRemote(rel: string): Promise<void>;
   /** True for paths the write-back must never touch (config tree, VCS, temp files). */
   ignore(rel: string): boolean;
+  /**
+   * True when the bytes on disk are a copy the plugin itself
+   * materialised from the remote (`MaterializedCache`), so pushing them
+   * back would be an echo of the remote's own content. Defaults to
+   * never — a deployment without the disk cache is unaffected.
+   */
+  isMirroredCopy?(rel: string, stat: LocalFileStat): boolean;
   /** Largest single file to push. Bigger files are skipped, loudly. */
   maxBytes: number;
   /** Coalesces a burst of writes; also the interval between stability samples. */
@@ -222,6 +229,13 @@ export class LocalWriteWatcher {
     if (this.pushed.get(rel) === sig) {
       this.sample.set(rel, sig);
       return;                          // already on the remote, byte-identical
+    }
+    if (this.deps.isMirroredCopy?.(rel, st)) {
+      // We put these bytes there ourselves, materialising the remote's
+      // own content. Pushing them back would be an echo — and on a
+      // stale copy it would be an echo that overwrites a newer remote.
+      this.sample.set(rel, sig);
+      return;
     }
     if (this.sample.get(rel) !== sig) {
       // First sighting of this generation. Wait one more debounce and

--- a/plugin/src/adapter/LocalWriteWatcher.ts
+++ b/plugin/src/adapter/LocalWriteWatcher.ts
@@ -1,0 +1,266 @@
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/** The bits of a local `stat` this watcher reasons about. */
+export interface LocalFileStat {
+  size: number;
+  mtimeMs: number;
+}
+
+/**
+ * Injectable surface so the debounce / stability / ledger logic is
+ * unit-testable without a real filesystem, timers or an SSH session.
+ * All paths are vault-relative with `/` separators.
+ */
+export interface LocalWriteWatcherDeps {
+  /**
+   * Start watching the shadow vault's local root. `onChange` gets the
+   * changed path, or `null` when the platform reported an event with
+   * no filename (the watcher then re-scans).
+   */
+  watch(onChange: (rel: string | null) => void): { close(): void };
+  /** Every regular file currently under the watched root. Used for the `null` event. */
+  scan(): string[];
+  /** `null` when the path is absent, unreadable, or not a regular file. */
+  stat(rel: string): LocalFileStat | null;
+  /** Bytes of the local file; `null` if it vanished or cannot be read. */
+  read(rel: string): Buffer | null;
+  /** Push local bytes to the remote vault (through the patched adapter). */
+  push(rel: string, data: Buffer): Promise<void>;
+  /** Delete the remote counterpart of a path we previously pushed. */
+  removeRemote(rel: string): Promise<void>;
+  /** True for paths the write-back must never touch (config tree, VCS, temp files). */
+  ignore(rel: string): boolean;
+  /** Largest single file to push. Bigger files are skipped, loudly. */
+  maxBytes: number;
+  /** Coalesces a burst of writes; also the interval between stability samples. */
+  debounceMs: number;
+  setTimer(cb: () => void, ms: number): unknown;
+  clearTimer(handle: unknown): void;
+  /** Surfaced to the user (a Notice). Called once per failing path. */
+  onError?(rel: string, message: string): void;
+}
+
+/**
+ * Filename patterns that are never vault content: OS junk, editor
+ * swap/backup files, and the plugin's own atomic-write temp suffix.
+ * Pushing one would litter the remote with garbage that a later local
+ * cleanup then deletes again.
+ */
+const TEMP_FILE = /(^\.DS_Store$)|(^Thumbs\.db$)|(^desktop\.ini$)|(^\.~lock\.)|(^\.#)|(~$)|(\.sw[a-p]$)|(\.tmp$)|(\.rsh_tmp$)|(\.crswap$)/i;
+
+/**
+ * Build the "never write this back" predicate for a vault-relative path.
+ *
+ * `configDir` is excluded because `SftpDataAdapter.writeThroughConfig`
+ * already owns that tree in the other direction — the local copy there
+ * is a cache the plugin itself writes, so pushing it back would echo
+ * our own bytes, and `SharedConfigWatcher` handles the files that DO
+ * need to travel. `ignoreDirs` is the same list the remote walk prunes
+ * (`DEFAULT_WALK_IGNORE_DIRS`): a directory we refuse to read from the
+ * remote must not be pushed to it either.
+ */
+export function makeLocalWriteIgnore(
+  configDir: string,
+  ignoreDirs: readonly string[],
+): (rel: string) => boolean {
+  const pruned = new Set<string>([configDir, '.trash', ...ignoreDirs]);
+  return (rel: string): boolean => {
+    const segments = rel.split('/').filter(s => s !== '');
+    if (segments.length === 0) return true;
+    if (segments.some(s => pruned.has(s))) return true;
+    return TEMP_FILE.test(segments[segments.length - 1]);
+  };
+}
+
+/**
+ * Carries writes made under the shadow vault's local root by anything
+ * OTHER than the vault API up to the remote vault (#429).
+ *
+ * ## The bug this closes
+ *
+ * `adapter.basePath` hands out the shadow vault's local root, because
+ * plugins that join paths onto it would otherwise crash (#170). But
+ * the note tree there is virtual — served from the remote, never
+ * mirrored — so a plugin doing
+ *
+ *     fs.writeFileSync(path.join(adapter.basePath, 'note.md'), body)
+ *
+ * wrote into a directory nobody reads: the bytes never reached the
+ * remote and never entered `vault.fileMap`. The original report (#429)
+ * is Claudian, a Claude Code wrapper, and the write does not even come
+ * from the renderer — it comes from a child process. That rules out
+ * intercepting `fs` inside Obsidian: only a real filesystem watcher
+ * sees it.
+ *
+ * ## Why it is not a sync engine
+ *
+ * The flow is one-way and event-driven: local disk → remote, through
+ * the SAME patched adapter every other write uses, so the existing
+ * mtime precondition, conflict resolver and vault-model reflection all
+ * apply unchanged. Nothing is pre-fetched, nothing is mirrored, and
+ * the remote stays the single source of truth. What the local disk
+ * holds is still only what somebody put there.
+ *
+ * ## Safety rules
+ *
+ *  - **Two-sample stability.** A path is pushed only once two
+ *    consecutive samples, one debounce apart, agree on (size, mtime).
+ *    A subprocess streaming a large file out is therefore pushed once,
+ *    complete, instead of truncated mid-write.
+ *  - **Deletes only for paths we pushed.** A local file disappearing
+ *    removes its remote counterpart ONLY if this session pushed that
+ *    path. Anything else — a stray cleanup, a path that was never
+ *    ours — must never delete a remote note.
+ *  - **Ledger.** The (size, mtime) of the last successful push is
+ *    remembered so a repeated event for unchanged bytes is not pushed
+ *    again.
+ */
+export class LocalWriteWatcher {
+  private closer: { close(): void } | null = null;
+  private timer: unknown = null;
+  private flushing = false;
+  /** Paths with an observed change that has not yet been pushed. */
+  private readonly dirty = new Set<string>();
+  /** Last sample seen for a dirty path — the other half of the stability check. */
+  private readonly sample = new Map<string, string>();
+  /** path → signature of the bytes this session last pushed successfully. */
+  private readonly pushed = new Map<string, string>();
+  /** Paths already reported to the user, so one broken file is not a Notice storm. */
+  private readonly reported = new Set<string>();
+
+  constructor(private readonly deps: LocalWriteWatcherDeps) {}
+
+  start(): void {
+    if (this.closer) return;
+    this.closer = this.deps.watch((rel) => this.onEvent(rel));
+    logger.info('LocalWriteWatcher: watching the shadow vault root for out-of-band writes');
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      this.deps.clearTimer(this.timer);
+      this.timer = null;
+    }
+    if (this.closer) {
+      try { this.closer.close(); } catch { /* best effort */ }
+      this.closer = null;
+    }
+    this.dirty.clear();
+    this.sample.clear();
+    this.reported.clear();
+  }
+
+  /** Number of paths this session has pushed. Test/diagnostic hook. */
+  pushedCount(): number {
+    return this.pushed.size;
+  }
+
+  private onEvent(rel: string | null): void {
+    if (rel === null) {
+      // The platform saw *something* but would not say what. Scanning
+      // is cheap here precisely because the note tree is virtual: the
+      // local root holds the config dir (ignored) and whatever an
+      // out-of-band writer put there.
+      for (const p of this.deps.scan()) {
+        if (!this.deps.ignore(p)) this.dirty.add(p);
+      }
+    } else {
+      const norm = rel.replace(/^\/+/, '');
+      if (norm === '' || this.deps.ignore(norm)) return;
+      this.dirty.add(norm);
+    }
+    this.arm();
+  }
+
+  private arm(): void {
+    if (this.timer !== null) this.deps.clearTimer(this.timer);
+    this.timer = this.deps.setTimer(() => {
+      this.timer = null;
+      void this.flush();
+    }, this.deps.debounceMs);
+  }
+
+  private async flush(): Promise<void> {
+    if (this.flushing) {
+      // A push is still in flight; come back after it lands rather
+      // than interleaving two pushes for the same path.
+      this.arm();
+      return;
+    }
+    this.flushing = true;
+    const candidates = [...this.dirty];
+    this.dirty.clear();
+    try {
+      for (const rel of candidates) {
+        await this.flushOne(rel);
+      }
+    } finally {
+      this.flushing = false;
+    }
+    if (this.dirty.size > 0) this.arm();
+  }
+
+  private async flushOne(rel: string): Promise<void> {
+    const st = this.deps.stat(rel);
+
+    if (st === null) {
+      this.sample.delete(rel);
+      const sig = this.pushed.get(rel);
+      if (sig === undefined) return;   // never ours — leave the remote alone
+      try {
+        await this.deps.removeRemote(rel);
+        this.pushed.delete(rel);
+        logger.info(`LocalWriteWatcher: "${rel}" deleted locally — removed on the remote`);
+      } catch (e) {
+        this.fail(rel, `could not delete "${rel}" on the remote: ${errorMessage(e)}`);
+      }
+      return;
+    }
+
+    const sig = `${st.size}:${st.mtimeMs}`;
+    if (this.pushed.get(rel) === sig) {
+      this.sample.set(rel, sig);
+      return;                          // already on the remote, byte-identical
+    }
+    if (this.sample.get(rel) !== sig) {
+      // First sighting of this generation. Wait one more debounce and
+      // compare again — a file still being written keeps changing.
+      this.sample.set(rel, sig);
+      this.dirty.add(rel);
+      return;
+    }
+    if (st.size > this.deps.maxBytes) {
+      this.fail(
+        rel,
+        `"${rel}" is ${Math.round(st.size / 1024 / 1024)} MB, over the ` +
+        `${Math.round(this.deps.maxBytes / 1024 / 1024)} MB write-back limit — not pushed`,
+      );
+      // Remember the signature so the same oversized file is not
+      // re-reported on every later event for it.
+      this.pushed.set(rel, sig);
+      return;
+    }
+
+    const data = this.deps.read(rel);
+    if (data === null) {
+      this.sample.delete(rel);
+      return;                          // vanished between stat and read
+    }
+    try {
+      await this.deps.push(rel, data);
+      this.pushed.set(rel, sig);
+      this.reported.delete(rel);
+      logger.info(`LocalWriteWatcher: pushed out-of-band write "${rel}" (${data.length} bytes)`);
+    } catch (e) {
+      this.fail(rel, `could not push "${rel}" to the remote: ${errorMessage(e)}`);
+    }
+  }
+
+  private fail(rel: string, message: string): void {
+    logger.warn(`LocalWriteWatcher: ${message}`);
+    if (this.reported.has(rel)) return;
+    this.reported.add(rel);
+    this.deps.onError?.(rel, message);
+  }
+}

--- a/plugin/src/adapter/MaterializedCache.ts
+++ b/plugin/src/adapter/MaterializedCache.ts
@@ -1,0 +1,206 @@
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/** What a materialised file looked like at the moment we wrote it. */
+export interface MaterializedStat {
+  size: number;
+  mtimeMs: number;
+}
+
+/** Filesystem surface, injected so the budget/LRU logic tests without a disk. */
+export interface MaterializedCacheDeps {
+  /** Absolute path on the shadow disk for a vault-relative path. */
+  absOf(rel: string): string;
+  /** Create parents and write. Returns the resulting stat, or null on failure. */
+  writeFile(abs: string, data: Buffer): MaterializedStat | null;
+  /** Current stat of a local path; null when absent or not a regular file. */
+  statFile(abs: string): MaterializedStat | null;
+  /** Delete a local path. */
+  deleteFile(abs: string): void;
+  /**
+   * Total bytes that may sit on the shadow disk as materialised copies.
+   * A file bigger than this is never fetched at all.
+   */
+  budgetBytes: number;
+  /** Per-file ceiling, so one huge attachment cannot consume the budget. */
+  maxFileBytes: number;
+}
+
+/**
+ * The bounded, on-demand disk cache behind `getFullPath` / `getFilePath`.
+ *
+ * ## The rule this encodes
+ *
+ * The remote vault is NOT cloned. The note tree stays virtual: a file
+ * exists on the shadow disk only because something asked for a real
+ * path to it (or read it through the vault API), and only while it fits
+ * in the configured budget. Nothing is pre-fetched, and a file over the
+ * budget is never fetched at all — not fetched and then discarded.
+ *
+ * ## Why eviction has to be careful
+ *
+ * A materialised copy sits in the same directory a plugin may write to,
+ * and `LocalWriteWatcher` pushes what it finds there to the remote. Two
+ * rules keep the two from fighting:
+ *
+ *  - **A copy we wrote is never pushed back.** The watcher asks
+ *    {@link isMirroredCopy}; a file whose (size, mtime) still matches
+ *    what we wrote is the remote's own bytes, not an edit.
+ *  - **A locally modified copy is never evicted.** Its stat no longer
+ *    matches the ledger, which means somebody changed it; deleting it
+ *    would throw away an edit that has not been pushed yet. Such an
+ *    entry is dropped from the ledger and left on disk — from then on
+ *    it is an ordinary local file and the watcher owns it.
+ */
+export class MaterializedCache {
+  /** rel → stat as written. Insertion order is the LRU order. */
+  private readonly entries = new Map<string, MaterializedStat>();
+  private total = 0;
+
+  constructor(private readonly deps: MaterializedCacheDeps) {}
+
+  /** Bytes currently accounted for by the ledger. */
+  bytes(): number {
+    return this.total;
+  }
+
+  /** Number of materialised files. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** True when a payload would be refused for its size alone. */
+  tooBig(byteLength: number): boolean {
+    return byteLength > this.deps.maxFileBytes || byteLength > this.deps.budgetBytes;
+  }
+
+  /** True when the cache is switched off entirely (budget of zero). */
+  disabled(): boolean {
+    return this.deps.budgetBytes <= 0;
+  }
+
+  /**
+   * Most bytes worth fetching for one file. Handed to the synchronous
+   * fetch so an over-limit file is refused by the transport instead of
+   * being pulled and then thrown away.
+   */
+  fetchLimit(): number {
+    return Math.min(this.deps.maxFileBytes, this.deps.budgetBytes);
+  }
+
+  /**
+   * Write `data` to the shadow disk and record it. Returns false when
+   * the cache is disabled, the file is over a limit, or the write
+   * fails — callers treat that as "not materialised" and carry on.
+   */
+  put(rel: string, data: Buffer): boolean {
+    if (this.disabled()) return false;
+    if (this.tooBig(data.byteLength)) {
+      logger.info(
+        `MaterializedCache: "${rel}" (${data.byteLength} bytes) exceeds the cache limit — ` +
+        'not written to disk',
+      );
+      return false;
+    }
+    const abs = this.deps.absOf(rel);
+    let stat: MaterializedStat | null;
+    try {
+      stat = this.deps.writeFile(abs, data);
+    } catch (e) {
+      logger.warn(`MaterializedCache: could not materialise "${rel}" (${errorMessage(e)})`);
+      return false;
+    }
+    if (!stat) return false;
+    this.forget(rel);
+    this.entries.set(rel, stat);
+    this.total += stat.size;
+    this.evictDownToBudget();
+    return this.entries.has(rel);
+  }
+
+  /** True when `rel` has a materialised copy that is still untouched. */
+  has(rel: string): boolean {
+    const known = this.entries.get(rel);
+    if (!known) return false;
+    const now = this.deps.statFile(this.deps.absOf(rel));
+    if (!now) {
+      this.forget(rel);
+      return false;
+    }
+    if (now.size !== known.size || now.mtimeMs !== known.mtimeMs) {
+      // Somebody edited our copy. It is theirs now.
+      this.forget(rel);
+      return false;
+    }
+    this.touch(rel, known);
+    return true;
+  }
+
+  /**
+   * The predicate `LocalWriteWatcher` consults before pushing: true
+   * when the bytes on disk are the copy we put there, so pushing them
+   * back to the remote would be an echo of the remote's own content.
+   */
+  isMirroredCopy(rel: string, stat: MaterializedStat): boolean {
+    const known = this.entries.get(rel);
+    if (!known) return false;
+    return known.size === stat.size && known.mtimeMs === stat.mtimeMs;
+  }
+
+  /** Drop a path from the ledger without touching the disk. */
+  forget(rel: string): void {
+    const known = this.entries.get(rel);
+    if (!known) return;
+    this.entries.delete(rel);
+    this.total -= known.size;
+    if (this.total < 0) this.total = 0;
+  }
+
+  /**
+   * Delete every materialised copy that is still untouched. Called on
+   * disconnect: the cache is per-session, so nothing the user did not
+   * put there themselves is left behind on the disk.
+   */
+  clear(): void {
+    for (const rel of [...this.entries.keys()]) this.evictOne(rel);
+    this.entries.clear();
+    this.total = 0;
+  }
+
+  private touch(rel: string, stat: MaterializedStat): void {
+    this.entries.delete(rel);
+    this.entries.set(rel, stat);
+  }
+
+  private evictDownToBudget(): void {
+    for (const rel of [...this.entries.keys()]) {
+      if (this.total <= this.deps.budgetBytes) return;
+      this.evictOne(rel);
+    }
+  }
+
+  /**
+   * Remove one entry. Deletes the file only when it still matches what
+   * we wrote — a modified copy is abandoned to the watcher instead.
+   */
+  private evictOne(rel: string): void {
+    const known = this.entries.get(rel);
+    if (!known) return;
+    const abs = this.deps.absOf(rel);
+    const now = this.deps.statFile(abs);
+    if (now && (now.size !== known.size || now.mtimeMs !== known.mtimeMs)) {
+      logger.info(
+        `MaterializedCache: "${rel}" changed on disk since it was materialised — ` +
+        'left in place instead of evicted',
+      );
+      this.forget(rel);
+      return;
+    }
+    try {
+      this.deps.deleteFile(abs);
+    } catch (e) {
+      logger.warn(`MaterializedCache: could not evict "${rel}" (${errorMessage(e)})`);
+    }
+    this.forget(rel);
+  }
+}

--- a/plugin/src/adapter/ResourceBridge.ts
+++ b/plugin/src/adapter/ResourceBridge.ts
@@ -245,6 +245,12 @@ export class ResourceBridge {
       res.writeHead(405, { 'Allow': 'GET, HEAD' }).end();
       return;
     }
+    // `<img src>` needs no CORS, but the synchronous XHR that
+    // `getFullPath` uses to materialise a file on demand does — the
+    // renderer's origin (`app://obsidian.md`) is not this server's.
+    // The token in the path is what actually guards the bridge; this
+    // header only stops the browser from hiding an authorised reply.
+    res.setHeader('Access-Control-Allow-Origin', '*');
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
     const m = /^\/r\/([0-9a-f]+)$/.exec(url.pathname);
     if (!m) {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -23,6 +23,9 @@ function isThumbnailEligible(vaultPath: string): boolean {
 }
 import * as fs from 'fs';
 import * as nodePath from 'path';
+import { pathToFileURL } from 'url';
+import type { MaterializedCache } from './MaterializedCache';
+import { syncHttpGetBinary } from '../util/syncHttpGet';
 import type { RemoteFsClient } from './RemoteFsClient';
 import type { WriterReflector } from './WriterReflector';
 import type { LocalOpRegistry } from './LocalOpRegistry';
@@ -163,6 +166,84 @@ export class SftpDataAdapter {
    */
   getBasePath(): string {
     return this.shadowBasePath;
+  }
+
+  /**
+   * Bounded on-demand disk cache. Null (the default) leaves every
+   * materialisation call a no-op, which is what unit tests and any
+   * non-shadow caller want.
+   */
+  private materializedCache: MaterializedCache | null = null;
+
+  setMaterializedCache(cache: MaterializedCache | null): void {
+    this.materializedCache = cache;
+  }
+
+  /**
+   * Absolute path of a vault file on this device — and, unlike the
+   * stock `FileSystemAdapter`, a path that has a real file behind it.
+   *
+   * The stock implementation just joins onto the base, which over a
+   * virtual note tree means handing a plugin a path to nothing (#429).
+   * Asking for a full path IS the request that materialises the file:
+   * we fetch it synchronously through the ResourceBridge and write it
+   * into the bounded cache, so `fs.readFileSync(adapter.getFullPath(p))`
+   * works for the file that was asked about. Files over the cache
+   * limits are not fetched, and callers still get the joined path —
+   * exactly what they got before, no worse.
+   */
+  getFullPath(normalizedPath: string): string {
+    this.ensureMaterialized(normalizedPath);
+    return nodePath.join(this.shadowBasePath, normalizedPath);
+  }
+
+  /**
+   * `file://` URL for a vault file. Same contract as
+   * {@link getFullPath}: the file is materialised first, because what
+   * follows this URL is usually `<img>`, `shell.openPath` or an
+   * external editor — none of which can be intercepted.
+   */
+  getFilePath(normalizedPath: string): string {
+    return pathToFileURL(this.getFullPath(normalizedPath)).href;
+  }
+
+  /**
+   * Best-effort synchronous materialisation. Silent about everything
+   * except the two outcomes a user could act on (over the limit, and
+   * a bridge that isn't running), and never throws: the caller wants a
+   * path, and a path is what it gets either way.
+   */
+  private ensureMaterialized(normalizedPath: string): void {
+    const cache = this.materializedCache;
+    if (!cache || cache.disabled()) return;
+    if (cache.has(normalizedPath)) return;
+
+    // Free hit: the bytes are already in the in-memory read cache
+    // (the note was just opened), so no request goes out at all.
+    const cached = this.readCache.peek(this.toRemote(normalizedPath));
+    if (cached) {
+      cache.put(normalizedPath, cached.data);
+      return;
+    }
+    if (!this.resourceBridge?.isRunning()) return;
+
+    let url: string;
+    try {
+      url = this.resourceBridge.urlFor(normalizedPath);
+    } catch {
+      return;                          // bridge stopped between the check and here
+    }
+    const result = syncHttpGetBinary(url, cache.fetchLimit());
+    if (result.kind === 'ok') {
+      cache.put(normalizedPath, result.bytes);
+      return;
+    }
+    if (result.kind === 'too-large') {
+      logger.info(
+        `getFullPath("${normalizedPath}"): ${result.totalSize} bytes is over the ` +
+        'materialisation limit — the path is returned but no file was written',
+      );
+    }
   }
 
   /**
@@ -378,6 +459,7 @@ export class SftpDataAdapter {
 
   async read(normalizedPath: string): Promise<string> {
     const buf = await this.readBuffer(normalizedPath);
+    this.materializedCache?.put(normalizedPath, buf);
     const text = buf.toString('utf8');
     // Snapshot the just-read content so a subsequent conflicting write
     // can show the user a real ancestor pane in the 3-way modal.
@@ -390,6 +472,7 @@ export class SftpDataAdapter {
 
   async readBinary(normalizedPath: string): Promise<ArrayBuffer> {
     const buf = await this.readBuffer(normalizedPath);
+    this.materializedCache?.put(normalizedPath, buf);
     // Copy into a fresh ArrayBuffer so callers can't accidentally mutate
     // the cached Buffer's underlying memory through the returned view.
     const ab = new ArrayBuffer(buf.byteLength);

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -49,6 +49,12 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   // rather than eager-walking the whole (potentially huge, deep) tree at
   // connect. Default on; safe to turn off for small vaults.
   lazyFolderLoad: true,
+  // #429 — push writes a plugin (or a subprocess it spawned) makes
+  // under `adapter.basePath` up to the remote. On by default: the
+  // alternative is the reported bug, where those bytes are silently
+  // stranded on the local disk. 32 MB caps a single push.
+  localWriteBack: true,
+  localWriteBackMaxMB: 32,
   // Phase 4 marker for shadow vaults; null on a normal vault. Only
   // `ShadowVaultBootstrap` writes a non-null value.
   autoConnectProfileId: null,

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -55,6 +55,11 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   // stranded on the local disk. 32 MB caps a single push.
   localWriteBack: true,
   localWriteBackMaxMB: 32,
+  // #429 read side — on-demand materialisation budget. Nothing is
+  // pre-fetched and nothing survives a disconnect; this only bounds how
+  // much of what was actually asked for may sit on the disk at once.
+  fsCacheMB: 128,
+  fsCacheMaxFileMB: 8,
   // Phase 4 marker for shadow vaults; null on a normal vault. Only
   // `ShadowVaultBootstrap` writes a non-null value.
   autoConnectProfileId: null,

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -782,6 +782,10 @@ export default class RemoteSshPlugin extends Plugin {
           },
           removeRemote: (rel) => da.remove(rel),
           ignore,
+          // A file the disk cache materialised is the remote's own
+          // content; pushing it back would be an echo.
+          isMirroredCopy: (rel, st) =>
+            this.adapterMgr.materialized?.isMirroredCopy(rel, st) ?? false,
           maxBytes,
           debounceMs: 400,
           setTimer: (cb, ms) => window.setTimeout(cb, ms),

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -31,6 +31,8 @@ import { ObsidianRegistry } from './shadow/ObsidianRegistry';
 import { ShadowVaultBootstrap } from './shadow/ShadowVaultBootstrap';
 import type { SharedConfigReader, BootstrapResult } from './shadow/ShadowVaultBootstrap';
 import { SharedConfigWatcher } from './shadow/SharedConfigWatcher';
+import { LocalWriteWatcher, makeLocalWriteIgnore } from './adapter/LocalWriteWatcher';
+import { watchTree, listTreeFiles } from './util/watchTree';
 import { ShadowVaultManager } from './shadow/ShadowVaultManager';
 import { WindowSpawner } from './shadow/WindowSpawner';
 import { ShadowStartupCoordinator } from './shadow/ShadowStartupCoordinator';
@@ -116,6 +118,7 @@ export default class RemoteSshPlugin extends Plugin {
    * stopped on disconnect/unload).
    */
   private sharedConfigWatcher: SharedConfigWatcher | null = null;
+  private localWriteWatcher: LocalWriteWatcher | null = null;
   private observability: ObservabilityInstaller | null = null;
   /**
    * #149 — re-entrant guard for `openRemoteTerminal()`. The
@@ -734,6 +737,60 @@ export default class RemoteSshPlugin extends Plugin {
       }
       watcher.start();
       this.sharedConfigWatcher = watcher;
+
+      // #429: everything above moves the CONFIG tree. The note tree has
+      // the mirror-image hole — `adapter.basePath` hands out this local
+      // root (#170), so a plugin that joins onto it and writes with raw
+      // `fs`, or a subprocess it spawned (the reported case is Claudian,
+      // a Claude Code wrapper), lands bytes here that nothing ever
+      // carries anywhere. A real filesystem watcher is the only thing
+      // that sees a write from another process; it pushes through the
+      // patched adapter, so the mtime precondition, conflict resolver
+      // and vault-model reflection all apply as they do for any write.
+      this.localWriteWatcher?.stop();
+      this.localWriteWatcher = null;
+      if (this.settings.localWriteBack !== false) {
+        const vaultRoot = hostAdapter.getBasePath();
+        const ignore = makeLocalWriteIgnore(
+          this.app.vault.configDir,
+          profile.walkIgnoreDirs ?? DEFAULT_WALK_IGNORE_DIRS,
+        );
+        const abs = (rel: string): string => path.join(vaultRoot, rel);
+        const maxBytes = Math.max(1, this.settings.localWriteBackMaxMB ?? 32) * 1024 * 1024;
+        const lww = new LocalWriteWatcher({
+          watch: (onChange) => watchTree(vaultRoot, onChange, ignore),
+          scan: () => listTreeFiles(vaultRoot, ignore),
+          stat: (rel) => {
+            const s = fs.statSync(abs(rel), { throwIfNoEntry: false });
+            return s?.isFile() ? { size: s.size, mtimeMs: s.mtimeMs } : null;
+          },
+          read: (rel) => {
+            try { return fs.readFileSync(abs(rel)); } catch { return null; }
+          },
+          push: async (rel, data) => {
+            // `.md` goes through the text path so a mid-air collision
+            // gets the 3-way merge UI rather than a binary overwrite
+            // prompt; everything else is bytes.
+            if (rel.toLowerCase().endsWith('.md')) {
+              await da.write(rel, data.toString('utf-8'));
+            } else {
+              await da.writeBinary(
+                rel,
+                data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer,
+              );
+            }
+          },
+          removeRemote: (rel) => da.remove(rel),
+          ignore,
+          maxBytes,
+          debounceMs: 400,
+          setTimer: (cb, ms) => window.setTimeout(cb, ms),
+          clearTimer: (h) => window.clearTimeout(h as number),
+          onError: (_rel, message) => new Notice(`Remote SSH: ${message}`),
+        });
+        lww.start();
+        this.localWriteWatcher = lww;
+      }
     }
 
     // Adapter is patched; build the file model so File Explorer
@@ -827,6 +884,8 @@ export default class RemoteSshPlugin extends Plugin {
       // setReconnecting flag goes with it.
       this.sharedConfigWatcher?.stop();
       this.sharedConfigWatcher = null;
+      this.localWriteWatcher?.stop();
+      this.localWriteWatcher = null;
       this.adapterMgr.restore();
       this.setState(SyncState.ERROR);
       // s.reason is a string from ReconnectManager; wrap into Error
@@ -865,6 +924,10 @@ export default class RemoteSshPlugin extends Plugin {
     // flush pushes through the (about-to-be-restored) adapter.
     this.sharedConfigWatcher?.stop();
     this.sharedConfigWatcher = null;
+    // Same for the #429 write-back: its push goes through the adapter
+    // we are about to restore.
+    this.localWriteWatcher?.stop();
+    this.localWriteWatcher = null;
     this.adapterMgr.restore();
     // Drop lazy-load state — the walker it captured is now disconnected. A
     // stray File-Explorer click after this finds a null loader and no-ops.

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -108,6 +108,21 @@ export class SettingsTab extends PluginSettingTab {
           }
         }));
 
+    new Setting(containerEl)
+      .setName('Push out-of-band file writes to the remote')
+      .setDesc(
+        'Some plugins write notes with raw filesystem calls (or hand the job to a ' +
+        'subprocess) instead of the vault API. Those writes land in the local shadow ' +
+        'folder. With this on they are carried up to the remote vault and appear in the ' +
+        'file explorer; with it off they stay local.',
+      )
+      .addToggle(t => t.setValue(this.plugin.settings.localWriteBack !== false)
+        .onChange(async v => {
+          this.plugin.settings.localWriteBack = v;
+          await this.plugin.saveSettings();
+          new Notice('Remote SSH: reconnect for this to take effect');
+        }));
+
     this.renderTerminalPanel(containerEl);
   }
 

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -123,6 +123,25 @@ export class SettingsTab extends PluginSettingTab {
           new Notice('Remote SSH: reconnect for this to take effect');
         }));
 
+    new Setting(containerEl)
+      .setName('On-demand file cache')
+      .setDesc(
+        'Budget in megabytes for materialising remote files on this device so paths handed to plugins ' +
+        '(getFullPath / getFilePath) point at a real file. The vault is never cloned: a ' +
+        'file is written only when something asks for it, anything bigger than the budget ' +
+        'is not downloaded at all, and the cache is deleted on disconnect. 0 disables it.',
+      )
+      .addText(t => t
+        .setPlaceholder('128')
+        .setValue(String(this.plugin.settings.fsCacheMB ?? 128))
+        .onChange(async v => {
+          const n = parseInt(v, 10);
+          if (Number.isFinite(n) && n >= 0 && n <= 100_000) {
+            this.plugin.settings.fsCacheMB = n;
+            await this.plugin.saveSettings();
+          }
+        }));
+
     this.renderTerminalPanel(containerEl);
   }
 

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -177,6 +177,24 @@ export interface PluginSettings {
    */
   localWriteBackMaxMB?: number;
   /**
+   * #429 read side — budget, in MB, for materialising remote files onto
+   * the shadow disk so `getFullPath()` / `getFilePath()` return paths
+   * that actually resolve. The remote vault is never cloned: a file is
+   * written only because something asked for a real path to it (or read
+   * it through the vault API), a file bigger than the budget is not
+   * fetched at all, and the least recently used copies are evicted to
+   * stay inside it. The whole cache is deleted on disconnect. Default
+   * 128; 0 disables materialisation entirely.
+   */
+  fsCacheMB?: number;
+  /**
+   * Per-file ceiling for the same cache, in MB. Default 8 — big enough
+   * for notes and ordinary attachments, small enough that one video
+   * cannot evict everything else. Files above it are never materialised
+   * (`getFullPath` still returns the joined path, as before).
+   */
+  fsCacheMaxFileMB?: number;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -160,6 +160,23 @@ export interface PluginSettings {
    */
   lazyFolderLoad?: boolean;
   /**
+   * #429 — carry writes made under the shadow vault's LOCAL root by
+   * something other than the vault API (a plugin's raw `fs`, or a
+   * subprocess it spawns, joining onto `adapter.basePath`) up to the
+   * remote vault. Default true: without it those bytes sit on the local
+   * disk forever — invisible to the vault model, to search, and to
+   * every other device. Set false to restore the older behaviour where
+   * such writes are inert.
+   */
+  localWriteBack?: boolean;
+  /**
+   * Largest single file the write-back will push, in MB. Default 32.
+   * A bigger file is left where it is and reported once: the write-back
+   * exists for notes a plugin produced, not for shipping arbitrary
+   * payloads over the SSH session.
+   */
+  localWriteBackMaxMB?: number;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/src/util/syncHttpGet.ts
+++ b/plugin/src/util/syncHttpGet.ts
@@ -1,0 +1,92 @@
+import { logger } from './logger';
+import { errorMessage } from './errorMessage';
+
+/** Outcome of {@link syncHttpGetBinary}. */
+export type SyncGetResult =
+  | { kind: 'ok'; bytes: Buffer }
+  /** The resource is larger than `maxBytes`; nothing was materialised. */
+  | { kind: 'too-large'; totalSize: number }
+  /** No vehicle, or the request failed. `why` is for the log, not the user. */
+  | { kind: 'unavailable'; why: string };
+
+/** Logged once per session — a missing vehicle is a fact, not a per-call event. */
+let vehicleReported = false;
+
+/**
+ * Fetch a localhost URL **synchronously** and return its bytes.
+ *
+ * This exists for `getFullPath` / `getFilePath`, which are synchronous
+ * in Obsidian's `DataAdapter` API: a plugin calls one and then
+ * immediately opens the path it got back. Returning a path and
+ * materialising it asynchronously would lose that race, so the fetch
+ * has to block.
+ *
+ * The vehicle is a synchronous `XMLHttpRequest` against the
+ * ResourceBridge (already running on 127.0.0.1 behind a per-session
+ * token). Synchronous XHR cannot use `responseType`, so the body comes
+ * back through `overrideMimeType('text/plain; charset=x-user-defined')`,
+ * which maps each byte to one code unit — the standard way to read
+ * binary out of a synchronous request.
+ *
+ * `Range: bytes=0-(maxBytes-1)` is sent so an over-budget file is
+ * recognised from `Content-Range` without transferring all of it
+ * (a transport that cannot honour a range still sends the whole body;
+ * it is then discarded rather than written to disk).
+ *
+ * Never throws: every failure is a `kind: 'unavailable'` the caller
+ * degrades on.
+ */
+export function syncHttpGetBinary(url: string, maxBytes: number): SyncGetResult {
+  // `activeWindow` is Obsidian's handle on the window the user is
+  // actually in (pop-out windows have their own); it is absent outside
+  // Obsidian, where the plain `window` is the right — and only — scope.
+  const scope = (typeof activeWindow !== 'undefined' ? activeWindow : window) as unknown as
+    { XMLHttpRequest?: new () => XMLHttpRequest } | undefined;
+  const XHRCtor = scope?.XMLHttpRequest;
+  if (typeof XHRCtor !== 'function') {
+    if (!vehicleReported) {
+      vehicleReported = true;
+      logger.info(
+        'syncHttpGetBinary: no XMLHttpRequest in this context — on-demand materialisation is off',
+      );
+    }
+    return { kind: 'unavailable', why: 'no XMLHttpRequest' };
+  }
+  try {
+    const xhr = new XHRCtor();
+    xhr.open('GET', url, false);
+    xhr.setRequestHeader('Range', `bytes=0-${Math.max(0, maxBytes - 1)}`);
+    xhr.overrideMimeType('text/plain; charset=x-user-defined');
+    xhr.send();
+
+    if (xhr.status !== 200 && xhr.status !== 206) {
+      return { kind: 'unavailable', why: `HTTP ${xhr.status}` };
+    }
+    const total = totalFromContentRange(xhr.getResponseHeader('Content-Range'));
+    if (total !== null && total > maxBytes) {
+      return { kind: 'too-large', totalSize: total };
+    }
+    const text = xhr.responseText;
+    if (text.length > maxBytes) {
+      return { kind: 'too-large', totalSize: text.length };
+    }
+    const out = Buffer.allocUnsafe(text.length);
+    for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i) & 0xff;
+    return { kind: 'ok', bytes: out };
+  } catch (e) {
+    if (!vehicleReported) {
+      vehicleReported = true;
+      logger.info(`syncHttpGetBinary: synchronous request failed (${errorMessage(e)})`);
+    }
+    return { kind: 'unavailable', why: errorMessage(e) };
+  }
+}
+
+/** `bytes 0-1023/4096` → 4096. Null when the header is absent or unparseable. */
+export function totalFromContentRange(header: string | null): number | null {
+  if (!header) return null;
+  const m = /\/\s*(\d+)\s*$/.exec(header);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) ? n : null;
+}

--- a/plugin/src/util/watchTree.ts
+++ b/plugin/src/util/watchTree.ts
@@ -1,0 +1,200 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { logger } from './logger';
+import { errorMessage } from './errorMessage';
+
+/** Handle returned by {@link watchTree}. `close()` is idempotent. */
+export interface TreeWatcher {
+  close(): void;
+}
+
+/**
+ * Filesystem surface {@link watchTree} needs, injected so the
+ * platform-fallback logic is unit-testable without real watchers.
+ */
+export interface WatchTreeDeps {
+  /**
+   * Watch one directory. `recursive` asks the platform for a subtree
+   * watch; implementations MUST throw when they cannot honour it, so
+   * `watchTree` can fall back instead of silently watching one level.
+   * The callback receives the path the platform reports (relative to
+   * `dir`), or `null` when it reports an event without a filename.
+   */
+  watch(dir: string, recursive: boolean, onEvent: (filename: string | null) => void): { close(): void };
+  /** Immediate child directory names of `dir`. Empty on any error. */
+  listDirs(dir: string): string[];
+}
+
+/**
+ * Upper bound on directories watched in the fallback path. A shadow
+ * vault's local disk holds only the config tree plus whatever a plugin
+ * wrote there, so this is far above any realistic tree — but a user
+ * who points a profile at a huge directory would otherwise exhaust the
+ * process's inotify budget. Hitting it is logged, never silent.
+ */
+const MAX_WATCHED_DIRS = 2048;
+
+const nodeDeps: WatchTreeDeps = {
+  watch: (dir, recursive, onEvent) => {
+    const w = fs.watch(
+      dir,
+      { persistent: false, recursive },
+      (_evt, filename) => onEvent(filename === null || filename === undefined ? null : String(filename)),
+    );
+    return { close: () => w.close() };
+  },
+  listDirs: (dir) => {
+    try {
+      return fs.readdirSync(dir, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => e.name);
+    } catch {
+      return [];
+    }
+  },
+};
+
+/**
+ * Watch `root` and everything under it, reporting each change as a
+ * path RELATIVE to `root` with `/` separators (or `null` when the
+ * platform gave no filename — the caller must then re-scan).
+ *
+ * `fs.watch(..., { recursive: true })` is native on Windows and macOS
+ * and on Linux only from Node 20.13; Electron builds below that throw
+ * `ERR_FEATURE_UNAVAILABLE_ON_PLATFORM`. Rather than degrade to a
+ * root-only watch (which would see a plugin's write into a subfolder
+ * as nothing at all), we fall back to watching every directory
+ * individually and adopting new ones as they appear.
+ *
+ * `prune` keeps the fallback off trees we would never act on anyway
+ * (the config dir, `.git`, `node_modules`); it takes a root-relative
+ * directory path.
+ */
+export function watchTree(
+  root: string,
+  onChange: (rel: string | null) => void,
+  prune: (relDir: string) => boolean = () => false,
+  deps: WatchTreeDeps = nodeDeps,
+): TreeWatcher {
+  try {
+    const w = deps.watch(root, true, (filename) => {
+      onChange(filename === null ? null : toPosix(filename));
+    });
+    return { close: () => { try { w.close(); } catch { /* best effort */ } } };
+  } catch (e) {
+    logger.info(
+      `watchTree: recursive watch unavailable (${errorMessage(e)}); ` +
+      'falling back to per-directory watchers',
+    );
+  }
+
+  const watchers = new Map<string, { close(): void }>();
+  let closed = false;
+
+  const add = (relDir: string): void => {
+    if (closed || watchers.has(relDir)) return;
+    if (relDir !== '' && prune(relDir)) return;
+    if (watchers.size >= MAX_WATCHED_DIRS) {
+      logger.warn(
+        `watchTree: watcher budget (${MAX_WATCHED_DIRS} dirs) exhausted — ` +
+        `"${relDir}" and any deeper directory are NOT watched`,
+      );
+      return;
+    }
+    const abs = relDir === '' ? root : path.join(root, relDir);
+    let w: { close(): void };
+    try {
+      w = deps.watch(abs, false, (filename) => {
+        if (filename === null) {
+          onChange(null);
+          return;
+        }
+        const rel = relDir === '' ? toPosix(filename) : `${relDir}/${toPosix(filename)}`;
+        // A newly created directory needs its own watcher, and the
+        // files a plugin drops into it may already exist by the time
+        // we get here — so adopt it (which recurses) before reporting.
+        adopt(rel);
+        onChange(rel);
+      });
+    } catch (err) {
+      // Racing removal, or a permission we don't have. Not fatal: the
+      // parent's watcher still reports changes to the directory entry.
+      logger.info(`watchTree: cannot watch "${abs}" (${errorMessage(err)})`);
+      return;
+    }
+    watchers.set(relDir, w);
+    for (const child of deps.listDirs(abs)) {
+      add(relDir === '' ? child : `${relDir}/${child}`);
+    }
+  };
+
+  /** Adopt `rel` if it turned out to be a directory (cheap no-op otherwise). */
+  const adopt = (rel: string): void => {
+    const abs = path.join(root, rel);
+    if (deps.listDirs(path.dirname(abs)).includes(path.basename(abs))) add(rel);
+  };
+
+  add('');
+
+  return {
+    close: () => {
+      closed = true;
+      for (const w of watchers.values()) {
+        try { w.close(); } catch { /* best effort */ }
+      }
+      watchers.clear();
+    },
+  };
+}
+
+/**
+ * Cap on {@link listTreeFiles}. The local root of a shadow vault holds
+ * the config tree plus whatever an out-of-band writer left there, so
+ * this is unreachable in practice; a scan that hits it is truncated
+ * LOUDLY rather than silently returning a partial tree.
+ */
+const MAX_SCAN_FILES = 20_000;
+
+/**
+ * Every regular file under `root`, as root-relative posix paths.
+ * `prune` is consulted with the root-relative path of each directory
+ * and file, so callers pass the same predicate they watch with.
+ *
+ * Used when the platform reports a change without a filename: the only
+ * way to find out what moved is to look.
+ */
+export function listTreeFiles(
+  root: string,
+  prune: (rel: string) => boolean = () => false,
+): string[] {
+  const found: string[] = [];
+  const stack: string[] = [''];
+  while (stack.length > 0) {
+    const relDir = stack.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(relDir === '' ? root : path.join(root, relDir), { withFileTypes: true });
+    } catch {
+      continue;                       // vanished or unreadable — nothing to report
+    }
+    for (const e of entries) {
+      const rel = relDir === '' ? e.name : `${relDir}/${e.name}`;
+      if (prune(rel)) continue;
+      if (e.isDirectory()) {
+        stack.push(rel);
+      } else if (e.isFile()) {
+        if (found.length >= MAX_SCAN_FILES) {
+          logger.warn(
+            `listTreeFiles: stopped at ${MAX_SCAN_FILES} files under "${root}" — ` +
+            'the rest of the tree was NOT scanned',
+          );
+          return found;
+        }
+        found.push(rel);
+      }
+    }
+  }
+  return found;
+}
+
+const toPosix = (p: string): string => p.split(path.sep).join('/').replace(/\\/g, '/');

--- a/plugin/tests/LocalWriteWatcher.test.ts
+++ b/plugin/tests/LocalWriteWatcher.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  LocalWriteWatcher,
+  makeLocalWriteIgnore,
+  type LocalFileStat,
+} from '../src/adapter/LocalWriteWatcher';
+
+/**
+ * Harness: an in-memory local disk (`files`), a manual debounce timer
+ * (`tick()` fires it and drains the microtask queue), and spies for
+ * the two remote-facing deps.
+ *
+ * The watcher pushes only after TWO consecutive samples agree, so a
+ * settled file needs `tick()` twice — that is the stability rule, not
+ * an accident of the harness, and the tests assert it directly.
+ */
+function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
+  let onChange: ((rel: string | null) => void) | null = null;
+  let pending: (() => void) | null = null;
+  let closed = false;
+  const mtimes: Record<string, number> = {};
+  for (const p of Object.keys(files)) mtimes[p] = 1000;
+
+  const push = vi.fn(async (_rel: string, _data: Buffer) => {});
+  const removeRemote = vi.fn(async (_rel: string) => {});
+  const onError = vi.fn((_rel: string, _msg: string) => {});
+
+  const w = new LocalWriteWatcher({
+    watch: (cb) => { onChange = cb; return { close: () => { closed = true; } }; },
+    scan: () => Object.keys(files),
+    stat: (rel): LocalFileStat | null =>
+      rel in files ? { size: files[rel].length, mtimeMs: mtimes[rel] } : null,
+    read: (rel) => (rel in files ? Buffer.from(files[rel]) : null),
+    push,
+    removeRemote,
+    ignore: makeLocalWriteIgnore('.obsidian', ['.git', 'node_modules']),
+    maxBytes,
+    debounceMs: 400,
+    setTimer: (cb) => { pending = cb; return 1; },
+    clearTimer: () => { pending = null; },
+    onError,
+  });
+
+  return {
+    w, push, removeRemote, onError,
+    trigger: (rel: string | null) => onChange?.(rel),
+    /** Fire the pending debounce and let the async flush settle. */
+    tick: async () => {
+      const p = pending;
+      pending = null;
+      p?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    hasTimer: () => pending !== null,
+    isClosed: () => closed,
+    write: (rel: string, body: string) => {
+      files[rel] = body;
+      mtimes[rel] = (mtimes[rel] ?? 1000) + 1;
+    },
+    unlink: (rel: string) => { delete files[rel]; },
+  };
+}
+
+describe('LocalWriteWatcher', () => {
+  it('pushes a file a plugin wrote under the vault root (#429)', async () => {
+    const h = harness();
+    h.w.start();
+    h.write('note.md', '# hello');
+    h.trigger('note.md');
+
+    await h.tick();
+    expect(h.push, 'pushed on the first sample — the stability rule is gone').not.toHaveBeenCalled();
+
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+    expect(h.push.mock.calls[0][0]).toBe('note.md');
+    expect(h.push.mock.calls[0][1].toString()).toBe('# hello');
+  });
+
+  it('does not push a file that is still growing', async () => {
+    const h = harness();
+    h.w.start();
+    h.write('big.md', 'aaa');
+    h.trigger('big.md');
+    await h.tick();
+
+    // A subprocess is still streaming it out: the second sample differs.
+    h.write('big.md', 'aaabbb');
+    await h.tick();
+    expect(h.push, 'pushed a half-written file').not.toHaveBeenCalled();
+
+    // Now it has settled.
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+    expect(h.push.mock.calls[0][1].toString()).toBe('aaabbb');
+  });
+
+  it('does not re-push unchanged bytes on a repeated event', async () => {
+    const h = harness({ 'note.md': 'body' });
+    h.w.start();
+    h.trigger('note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+
+    h.trigger('note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push, 'the ledger did not suppress an echo of our own push').toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the config tree, VCS dirs and editor temp files', async () => {
+    const h = harness({
+      '.obsidian/app.json': '{}',
+      '.git/HEAD': 'ref',
+      'node_modules/pkg/index.js': 'x',
+      '.DS_Store': 'junk',
+      'note.md~': 'backup',
+    });
+    h.w.start();
+    for (const p of ['.obsidian/app.json', '.git/HEAD', 'node_modules/pkg/index.js', '.DS_Store', 'note.md~']) {
+      h.trigger(p);
+    }
+    expect(h.hasTimer(), 'an ignored path armed the debounce').toBe(false);
+    await h.tick();
+    await h.tick();
+    expect(h.push).not.toHaveBeenCalled();
+  });
+
+  it('deletes on the remote ONLY for a path it pushed itself', async () => {
+    const h = harness();
+    h.w.start();
+
+    // A file that was never ours simply disappearing must not touch the remote.
+    h.trigger('someone-elses.md');
+    await h.tick();
+    await h.tick();
+    expect(h.removeRemote).not.toHaveBeenCalled();
+
+    // One we pushed, then deleted locally, does propagate.
+    h.write('ours.md', 'x');
+    h.trigger('ours.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+
+    h.unlink('ours.md');
+    h.trigger('ours.md');
+    await h.tick();
+    expect(h.removeRemote).toHaveBeenCalledWith('ours.md');
+  });
+
+  it('skips a file over the size cap and reports it once', async () => {
+    const h = harness({}, 8);
+    h.w.start();
+    h.write('huge.bin', 'x'.repeat(64));
+    h.trigger('huge.bin');
+    await h.tick();
+    await h.tick();
+    expect(h.push).not.toHaveBeenCalled();
+    expect(h.onError).toHaveBeenCalledTimes(1);
+
+    h.trigger('huge.bin');
+    await h.tick();
+    await h.tick();
+    expect(h.onError, 'the same oversized file was reported twice').toHaveBeenCalledTimes(1);
+  });
+
+  it('re-scans when the platform reports an event with no filename', async () => {
+    const h = harness({ 'note.md': 'body', '.obsidian/app.json': '{}' });
+    h.w.start();
+    h.trigger(null);
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+    expect(h.push.mock.calls[0][0]).toBe('note.md');
+  });
+
+  it('surfaces a failed push and retries it on the next change', async () => {
+    const h = harness();
+    h.w.start();
+    h.push.mockRejectedValueOnce(new Error('socket closed'));
+    h.write('note.md', 'v1');
+    h.trigger('note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.onError).toHaveBeenCalledTimes(1);
+    expect(h.w.pushedCount(), 'a failed push was recorded as done').toBe(0);
+
+    h.write('note.md', 'v2');
+    h.trigger('note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(2);
+    expect(h.w.pushedCount()).toBe(1);
+  });
+
+  it('stop() closes the watcher and drops pending work', () => {
+    const h = harness({ 'note.md': 'body' });
+    h.w.start();
+    h.trigger('note.md');
+    expect(h.hasTimer()).toBe(true);
+    h.w.stop();
+    expect(h.isClosed()).toBe(true);
+    expect(h.hasTimer()).toBe(false);
+  });
+});
+
+describe('makeLocalWriteIgnore', () => {
+  const ignore = makeLocalWriteIgnore('.obsidian', ['.git', 'node_modules']);
+
+  it('keeps ordinary notes and attachments', () => {
+    expect(ignore('note.md')).toBe(false);
+    expect(ignore('folder/sub/note.md')).toBe(false);
+    expect(ignore('attachments/diagram.png')).toBe(false);
+    expect(ignore('.hidden-but-real.md')).toBe(false);
+  });
+
+  it('prunes the config dir, trash, VCS and dependency dirs at any depth', () => {
+    expect(ignore('.obsidian/app.json')).toBe(true);
+    expect(ignore('.trash/old.md')).toBe(true);
+    expect(ignore('.git/HEAD')).toBe(true);
+    expect(ignore('project/node_modules/pkg/index.js')).toBe(true);
+  });
+
+  it('prunes OS junk, editor swap files and the atomic-write temp suffix', () => {
+    expect(ignore('.DS_Store')).toBe(true);
+    expect(ignore('folder/Thumbs.db')).toBe(true);
+    expect(ignore('note.md~')).toBe(true);
+    expect(ignore('.#note.md')).toBe(true);
+    expect(ignore('note.md.swp')).toBe(true);
+    expect(ignore('note.md.rsh_tmp')).toBe(true);
+  });
+
+  it('honours a non-default configDir', () => {
+    const custom = makeLocalWriteIgnore('.config-dir', []);
+    expect(custom('.config-dir/app.json')).toBe(true);
+    expect(custom('.obsidian/app.json')).toBe(false);
+  });
+});

--- a/plugin/tests/LocalWriteWatcher.test.ts
+++ b/plugin/tests/LocalWriteWatcher.test.ts
@@ -24,6 +24,8 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   const push = vi.fn(async (_rel: string, _data: Buffer) => {});
   const removeRemote = vi.fn(async (_rel: string) => {});
   const onError = vi.fn((_rel: string, _msg: string) => {});
+  /** Paths the disk cache currently claims as its own materialised copy. */
+  const mirrored = new Set<string>();
 
   const w = new LocalWriteWatcher({
     watch: (cb) => { onChange = cb; return { close: () => { closed = true; } }; },
@@ -34,6 +36,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
     push,
     removeRemote,
     ignore: makeLocalWriteIgnore('.obsidian', ['.git', 'node_modules']),
+    isMirroredCopy: (rel) => mirrored.has(rel),
     maxBytes,
     debounceMs: 400,
     setTimer: (cb) => { pending = cb; return 1; },
@@ -42,7 +45,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   });
 
   return {
-    w, push, removeRemote, onError,
+    w, push, removeRemote, onError, mirrored,
     trigger: (rel: string | null) => onChange?.(rel),
     /** Fire the pending debounce and let the async flush settle. */
     tick: async () => {
@@ -195,6 +198,26 @@ describe('LocalWriteWatcher', () => {
     await h.tick();
     expect(h.push).toHaveBeenCalledTimes(2);
     expect(h.w.pushedCount()).toBe(1);
+  });
+
+  it('does not push back a copy the disk cache materialised', async () => {
+    const h = harness();
+    h.w.start();
+    h.write('remote-note.md', 'bytes fetched from the remote');
+    // The disk cache reports this exact (size, mtime) as its own copy.
+    h.mirrored.add('remote-note.md');
+    h.trigger('remote-note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push, 'the materialised copy was echoed back to the remote').not.toHaveBeenCalled();
+
+    // A plugin then edits it: no longer our copy, so it must travel.
+    h.mirrored.delete('remote-note.md');
+    h.write('remote-note.md', 'edited by a plugin');
+    h.trigger('remote-note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
   });
 
   it('stop() closes the watcher and drops pending work', () => {

--- a/plugin/tests/MaterializedCache.test.ts
+++ b/plugin/tests/MaterializedCache.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MaterializedCache, type MaterializedStat } from '../src/adapter/MaterializedCache';
+import { syncHttpGetBinary, totalFromContentRange } from '../src/util/syncHttpGet';
+
+/**
+ * In-memory disk. `mtimeMs` advances on every write, so a rewrite is
+ * distinguishable from the copy that was already there — which is
+ * exactly how the real ledger tells "our copy" from "somebody edited
+ * it".
+ */
+function fakeDisk() {
+  const files = new Map<string, { data: Buffer; stat: MaterializedStat }>();
+  let clock = 1000;
+  return {
+    files,
+    deps: {
+      absOf: (rel: string) => `/root/${rel}`,
+      writeFile: (abs: string, data: Buffer): MaterializedStat => {
+        const stat = { size: data.byteLength, mtimeMs: ++clock };
+        files.set(abs, { data, stat });
+        return stat;
+      },
+      statFile: (abs: string) => files.get(abs)?.stat ?? null,
+      deleteFile: (abs: string) => { files.delete(abs); },
+      budgetBytes: 100,
+      maxFileBytes: 50,
+    },
+    /** Simulate someone else editing a file we materialised. */
+    tamper: (abs: string, body: string) => {
+      files.set(abs, { data: Buffer.from(body), stat: { size: body.length, mtimeMs: ++clock } });
+    },
+  };
+}
+
+describe('MaterializedCache', () => {
+  it('writes a requested file and reports it as present', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    expect(c.put('note.md', Buffer.from('hello'))).toBe(true);
+    expect(d.files.get('/root/note.md')?.data.toString()).toBe('hello');
+    expect(c.has('note.md')).toBe(true);
+    expect(c.bytes()).toBe(5);
+  });
+
+  it('refuses a file over the per-file ceiling without writing anything', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    expect(c.tooBig(51)).toBe(true);
+    expect(c.put('big.bin', Buffer.alloc(51))).toBe(false);
+    expect(d.files.size, 'an over-limit file was written to disk anyway').toBe(0);
+  });
+
+  it('never exceeds the budget — the least recently used copy goes first', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('a.md', Buffer.alloc(40));
+    c.put('b.md', Buffer.alloc(40));
+    c.has('a.md');                     // a is now the most recently used
+    c.put('c.md', Buffer.alloc(40));   // 120 > 100 budget
+
+    expect(c.bytes()).toBeLessThanOrEqual(100);
+    expect(d.files.has('/root/b.md'), 'the LRU victim is still on disk').toBe(false);
+    expect(d.files.has('/root/a.md')).toBe(true);
+    expect(d.files.has('/root/c.md')).toBe(true);
+  });
+
+  it('does NOT evict a copy somebody edited — that would destroy an unpushed edit', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('a.md', Buffer.alloc(40));
+    d.tamper('/root/a.md', 'x'.repeat(40));   // same size, new mtime: a local edit
+    c.put('b.md', Buffer.alloc(40));
+    c.put('c.md', Buffer.alloc(40));
+
+    expect(d.files.has('/root/a.md'), 'an edited file was evicted').toBe(true);
+    expect(c.isMirroredCopy('a.md', d.deps.statFile('/root/a.md')!)).toBe(false);
+  });
+
+  it('stops calling an edited copy its own', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('note.md', Buffer.from('remote body'));
+    const asWritten = d.deps.statFile('/root/note.md')!;
+    expect(c.isMirroredCopy('note.md', asWritten)).toBe(true);
+
+    d.tamper('/root/note.md', 'edited by a plugin');
+    const now = d.deps.statFile('/root/note.md')!;
+    expect(
+      c.isMirroredCopy('note.md', now),
+      'an edited file still looked like our copy — the write-back would drop it',
+    ).toBe(false);
+    expect(c.has('note.md')).toBe(false);
+  });
+
+  it('clear() removes our untouched copies and leaves edited ones behind', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('clean.md', Buffer.from('remote'));
+    c.put('edited.md', Buffer.from('remote'));
+    d.tamper('/root/edited.md', 'local changes');
+
+    c.clear();
+    expect(d.files.has('/root/clean.md')).toBe(false);
+    expect(d.files.has('/root/edited.md'), 'clear() deleted an edited file').toBe(true);
+    expect(c.bytes()).toBe(0);
+  });
+
+  it('a zero budget disables it entirely', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache({ ...d.deps, budgetBytes: 0 });
+    expect(c.disabled()).toBe(true);
+    expect(c.put('note.md', Buffer.from('x'))).toBe(false);
+    expect(d.files.size).toBe(0);
+  });
+
+  it('forgets a file that vanished from disk', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('note.md', Buffer.from('body'));
+    d.files.delete('/root/note.md');
+    expect(c.has('note.md')).toBe(false);
+    expect(c.bytes()).toBe(0);
+  });
+});
+
+describe('syncHttpGetBinary', () => {
+  const stub = (over: Record<string, unknown>) => ({
+    open: vi.fn(), setRequestHeader: vi.fn(), overrideMimeType: vi.fn(), send: vi.fn(),
+    getResponseHeader: () => null,
+    status: 200, responseText: '',
+    ...over,
+  });
+
+  const withXhr = <T>(impl: object, run: () => T): T => {
+    const g = globalThis as { XMLHttpRequest?: unknown };
+    const saved = g.XMLHttpRequest;
+    g.XMLHttpRequest = function XHR() { return impl; } as unknown;
+    try { return run(); } finally { g.XMLHttpRequest = saved; }
+  };
+
+  it('maps the response back to raw bytes', () => {
+    const r = withXhr(stub({ status: 200, responseText: 'H\u00ff\u0000' }), () =>
+      syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 1024));
+    expect(r.kind).toBe('ok');
+    expect(r.kind === 'ok' && [...r.bytes]).toEqual([0x48, 0xff, 0x00]);
+  });
+
+  it('refuses a file whose Content-Range says it is over the limit', () => {
+    const r = withXhr(
+      stub({ status: 206, responseText: 'partial', getResponseHeader: () => 'bytes 0-6/999999' }),
+      () => syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 8),
+    );
+    expect(r).toEqual({ kind: 'too-large', totalSize: 999999 });
+  });
+
+  it('reports unavailable instead of throwing when there is no vehicle', () => {
+    const g = globalThis as { XMLHttpRequest?: unknown };
+    const saved = g.XMLHttpRequest;
+    delete g.XMLHttpRequest;
+    try {
+      expect(syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 8).kind).toBe('unavailable');
+    } finally {
+      g.XMLHttpRequest = saved;
+    }
+  });
+
+  it('parses the total out of a Content-Range header', () => {
+    expect(totalFromContentRange('bytes 0-1023/4096')).toBe(4096);
+    expect(totalFromContentRange('bytes 0-1023/*')).toBeNull();
+    expect(totalFromContentRange(null)).toBeNull();
+  });
+});

--- a/plugin/tests/watchTree.test.ts
+++ b/plugin/tests/watchTree.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { watchTree, listTreeFiles, type WatchTreeDeps } from '../src/util/watchTree';
+
+/** Virtual root for the fake-platform tests; never touched on disk. */
+const ROOT = path.join(path.sep === '\\' ? 'C:\\' : '/', 'vault-root');
+
+const relOf = (abs: string): string =>
+  path.relative(ROOT, abs).split(path.sep).join('/');
+
+/**
+ * Fake platform. `tree` maps a root-relative directory path ('' = the
+ * root) to its immediate child directory names. `recursiveSupported`
+ * decides whether a subtree watch is honoured — throwing is exactly
+ * what Node does on a build without recursive support, and is the
+ * condition `watchTree` must fall back on.
+ */
+function fakeDeps(tree: Record<string, string[]>, recursiveSupported: boolean) {
+  const watched: string[] = [];
+  const handlers = new Map<string, (f: string | null) => void>();
+  const closed: string[] = [];
+  const deps: WatchTreeDeps = {
+    watch: (dir, recursive, onEvent) => {
+      if (recursive && !recursiveSupported) {
+        throw new Error('ERR_FEATURE_UNAVAILABLE_ON_PLATFORM');
+      }
+      const rel = relOf(dir);
+      watched.push(rel);
+      handlers.set(rel, onEvent);
+      return { close: () => { closed.push(rel); } };
+    },
+    listDirs: (dir) => tree[relOf(dir)] ?? [],
+  };
+  return {
+    deps, watched, closed,
+    emit: (relDir: string, filename: string | null) => handlers.get(relDir)?.(filename),
+    isWatching: (relDir: string) => watched.includes(relDir),
+  };
+}
+
+describe('watchTree', () => {
+  it('uses the platform recursive watch when it is available', () => {
+    const f = fakeDeps({}, true);
+    const seen: (string | null)[] = [];
+    watchTree(ROOT, (rel) => seen.push(rel), () => false, f.deps);
+
+    expect(f.watched, 'more than the single recursive watcher was created').toEqual(['']);
+    f.emit('', path.join('sub', 'note.md'));
+    expect(seen, 'the reported path was not normalised to posix').toEqual(['sub/note.md']);
+  });
+
+  it('falls back to per-directory watchers when recursive is unsupported', () => {
+    const f = fakeDeps({ '': ['sub'], 'sub': ['deep'], 'sub/deep': [] }, false);
+    const seen: (string | null)[] = [];
+    watchTree(ROOT, (rel) => seen.push(rel), () => false, f.deps);
+
+    expect(f.isWatching(''), 'the root itself is unwatched').toBe(true);
+    expect(f.isWatching('sub'), 'an existing subdirectory is unwatched').toBe(true);
+    expect(f.isWatching('sub/deep'), 'the fallback did not recurse').toBe(true);
+
+    f.emit('sub/deep', 'note.md');
+    expect(seen).toEqual(['sub/deep/note.md']);
+  });
+
+  it('adopts a directory created after the watch started', () => {
+    const tree: Record<string, string[]> = { '': [] };
+    const f = fakeDeps(tree, false);
+    watchTree(ROOT, () => { /* ignore */ }, () => false, f.deps);
+    expect(f.isWatching('fresh')).toBe(false);
+
+    // A plugin just created `fresh/` and the root watcher reports it.
+    tree[''] = ['fresh'];
+    tree['fresh'] = [];
+    f.emit('', 'fresh');
+    expect(
+      f.isWatching('fresh'),
+      'a new directory was never adopted — writes under it stay invisible',
+    ).toBe(true);
+  });
+
+  it('does not watch pruned directories', () => {
+    const f = fakeDeps({ '': ['.obsidian', 'notes'], '.obsidian': ['plugins'], 'notes': [] }, false);
+    watchTree(ROOT, () => { /* ignore */ }, (rel) => rel.split('/')[0] === '.obsidian', f.deps);
+
+    expect(f.isWatching('notes')).toBe(true);
+    expect(f.isWatching('.obsidian'), 'the pruned config tree got a watcher').toBe(false);
+    expect(f.isWatching('.obsidian/plugins')).toBe(false);
+  });
+
+  it('passes a filename-less event straight through as null', () => {
+    const f = fakeDeps({ '': [] }, false);
+    const seen: (string | null)[] = [];
+    watchTree(ROOT, (rel) => seen.push(rel), () => false, f.deps);
+    f.emit('', null);
+    expect(seen).toEqual([null]);
+  });
+
+  it('close() releases every watcher it created', () => {
+    const f = fakeDeps({ '': ['a'], 'a': [] }, false);
+    const w = watchTree(ROOT, () => { /* ignore */ }, () => false, f.deps);
+    w.close();
+    expect(f.closed.sort()).toEqual(['', 'a']);
+  });
+});
+
+describe('listTreeFiles', () => {
+  const made: string[] = [];
+
+  afterEach(() => {
+    for (const d of made.splice(0)) fs.rmSync(d, { recursive: true, force: true });
+  });
+
+  function scaffold(): string {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'watchtree-'));
+    made.push(root);
+    fs.mkdirSync(path.join(root, 'folder', 'nested'), { recursive: true });
+    fs.mkdirSync(path.join(root, '.obsidian', 'plugins'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'note.md'), 'a');
+    fs.writeFileSync(path.join(root, 'folder', 'nested', 'deep.md'), 'b');
+    fs.writeFileSync(path.join(root, '.obsidian', 'app.json'), '{}');
+    return root;
+  }
+
+  it('lists every file as a root-relative posix path', () => {
+    const root = scaffold();
+    expect(listTreeFiles(root).sort()).toEqual([
+      '.obsidian/app.json', 'folder/nested/deep.md', 'note.md',
+    ]);
+  });
+
+  it('honours the prune predicate for whole subtrees', () => {
+    const root = scaffold();
+    const files = listTreeFiles(root, (rel) => rel.split('/')[0] === '.obsidian');
+    expect(files.sort()).toEqual(['folder/nested/deep.md', 'note.md']);
+  });
+
+  it('returns nothing for a root that does not exist', () => {
+    expect(listTreeFiles(path.join(os.tmpdir(), 'watchtree-absent-root'))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

`adapter.basePath` hands out the shadow vault's local root (#170), but the note tree there is virtual. A plugin that joins onto it and writes with raw `fs`:

```js
fs.writeFileSync(path.join(this.app.vault.adapter.basePath, 'note.md'), body)
```

dropped bytes into a directory nobody reads — they never reached the remote and never entered `vault.fileMap`. From the user's seat the note did not exist.

The reported case ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)) is **Claudian, a Claude Code wrapper, and the write comes from a child process**. That rules out patching `fs` inside the renderer: only a real filesystem watcher sees a write from another process.

## How

`LocalWriteWatcher` watches the shadow root and pushes what it finds **through the same patched adapter every other write uses**, so the mtime precondition, the conflict resolver and the vault-model reflection apply unchanged. One-way and event-driven — nothing is pre-fetched, nothing is mirrored, the remote stays the single source of truth.

Safety rules, each with a test:

| rule | why |
| --- | --- |
| push only when two samples one debounce apart agree on (size, mtime) | a subprocess streaming a file out must not be pushed truncated |
| delete on the remote **only** for a path this session pushed itself | nothing else may ever delete a remote note |
| exclude config tree / `.trash` / VCS + dependency dirs / editor temp files | `writeThroughConfig` and `SharedConfigWatcher` already own the config direction |
| a file over the size cap is reported, not pushed | the write-back is for notes, not for shipping payloads over SSH |

`watchTree` adds a per-directory fallback to the recursive watch: Node supports `{ recursive: true }` on Linux only from 20.13, and degrading to a root-only watch would silently miss every write into a subfolder.

## Where the line is

Writes propagate; **reads do not**. `fs.readFileSync` / `readdirSync` under `basePath` still see only what is physically there. Materialising the note tree on disk would mean keeping a local clone of the remote vault — the thing this design exists to avoid — so an agent that greps the vault directory still finds nothing. `docs/en/user-guide/plugin-compatibility.md` now states that asymmetry plainly instead of the old blanket "writes don't reach the remote", and the `basePath` survey's stale "syncs up to the remote" mitigations are qualified to writes only.

## E2E

Turns three reds green in `e2e/fs-visibility.spec.ts` (the standing statement of the defect):

- `a file a plugin writes under adapter.basePath reaches the REMOTE vault`
- `a file a plugin writes under adapter.basePath appears in the vault model`
- `REAL-PLUGIN REPRODUCTION: a plugin's fs.writeFileSync in onload() reaches the remote`

The four read-side reds in that file stay red on purpose — they are the line above.

## Settings

`localWriteBack` (default on, toggle in Advanced) and `localWriteBackMaxMB` (default 32).

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning) and `vitest run` (83 files, 1280 tests) green locally. 22 new unit tests.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)