### PR TITLE
feat(adapter): materialise a file on demand so getFullPath resolves (#429 read side)

### DIFF
--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -145,14 +145,23 @@ Things that aren't a specific plugin but trip plugins in general:
     limit (Settings → Advanced, 32 MB default) is reported rather than
     pushed. The whole behaviour is switchable: *Push out-of-band file
     writes to the remote*.
-  - **Reads do not.** `fs.readFileSync` / `fs.readdirSync` under
-    `basePath` see only what is physically there — the config tree and
-    whatever an out-of-band writer left behind — never the remote
-    notes. Mirroring the note tree to disk would mean keeping a local
-    clone of the remote vault, which is the thing this design exists to
-    avoid. So a plugin that *reads* notes through Node `fs` (importers,
-    exporters, "open in external editor", anything that shells out to a
-    local binary) sees an empty vault. Read through the vault API.
+  - **Reads work only for a file you asked for by path.**
+    `getFullPath(path)` and `getFilePath(path)` materialise that one
+    file onto the shadow disk before returning, so the path they hand
+    back resolves and `shell.openPath` / an `<img>` / an external editor
+    opens the real note. Files read through the vault API are cached the
+    same way. Everything else is still absent: the note tree is **not**
+    mirrored, because that would mean keeping a local clone of the
+    remote vault — the thing this design exists to avoid. So
+    `fs.readFileSync(path.join(basePath, 'note.md'))` on a note nobody
+    asked for fails, and `fs.readdirSync(basePath)` lists only the
+    config tree plus whatever happens to be materialised — never the
+    vault. A plugin that discovers notes by walking the filesystem sees
+    an empty vault; read through the vault API instead.
+    The cache is bounded (Settings → Advanced, *On-demand file cache*,
+    128 MB default, 8 MB per file), evicts least-recently-used copies,
+    refuses anything over the limit rather than fetching and discarding
+    it, and is deleted on disconnect.
   See *Direct-disk / agentic plugins* (#429) and the
   **basePath survey** (#133) — its "syncs up to the remote" mitigations
   now hold for writes, and only for writes. **Exception:** plugins that shell out to a local
@@ -186,12 +195,13 @@ Things that aren't a specific plugin but trip plugins in general:
   adapter ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
   The files they *create or edit* now reach the remote vault and the
   file explorer, via the write-back watcher described above — a
-  one-way, event-driven push, not a reconciler. What they still cannot
-  do is **read**: an agent that greps the vault directory, or opens a
-  note by absolute path, finds nothing there, because the note tree is
-  never materialised on disk. Feed such a plugin content through the
-  vault API (or paste it in); don't expect it to discover the vault by
-  walking `basePath`.
+  one-way, event-driven push, not a reconciler. Reading is the half
+  that stays limited: an agent that greps the vault directory finds
+  only what has been materialised (a note it was pointed at by
+  `getFullPath`, or one that was opened), never the vault as a whole,
+  because the tree is not mirrored. Point such a plugin at specific
+  notes rather than expecting it to discover the vault by walking
+  `basePath`.
 
 ## Why we can't auto-test all of this
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.5",
+      "version": "1.1.8-beta.6",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.5",
+  "version": "1.1.8-beta.6",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/AdapterManager.ts
+++ b/plugin/src/adapter/AdapterManager.ts
@@ -6,6 +6,7 @@ import type { PluginSettings } from '../types';
 import { ReadCache } from '../cache/ReadCache';
 import { DirCache } from '../cache/DirCache';
 import { SftpDataAdapter } from './SftpDataAdapter';
+import { MaterializedCache } from './MaterializedCache';
 import { AdapterPatcher } from './AdapterPatcher';
 import { ResourceBridge } from './ResourceBridge';
 import { WriteConflictModal } from '../ui/WriteConflictModal';
@@ -24,6 +25,7 @@ import { PathMapper } from '../path/PathMapper';
 import { logger } from '../util/logger';
 import { errorMessage } from '../util/errorMessage';
 import * as path from 'path';
+import * as fs from 'fs';
 
 /**
  * The set of FileSystemAdapter methods that get monkey-patched onto
@@ -49,6 +51,11 @@ export const PATCHED_METHODS = [
   // through the replacement makes the contract explicit and gives
   // tests a single hook to assert on. #170, follow-up to #133.
   'basePath', 'getBasePath',
+  // Path surface — the stock FileSystemAdapter versions join onto the
+  // local base and so hand out a path to nothing, because the note tree
+  // is virtual (#429). The replacements materialise the file first,
+  // within the cache budget, so what they return actually resolves.
+  'getFullPath', 'getFilePath',
 ] as const;
 
 /**
@@ -68,6 +75,7 @@ export class AdapterManager {
   private ancestorTracker: AncestorTracker | null = null;
   private offlineQueue: OfflineQueue | null = null;
   private resourceBridge: ResourceBridge | null = null;
+  private materializedCache: MaterializedCache | null = null;
 
   constructor(
     private readonly app: App,
@@ -81,6 +89,15 @@ export class AdapterManager {
 
   get dataAdapter(): SftpDataAdapter | null {
     return this._dataAdapter;
+  }
+
+  /**
+   * The session's materialisation ledger. `LocalWriteWatcher` consults
+   * it so a copy we put on disk is never pushed back to the remote as
+   * if the user had written it.
+   */
+  get materialized(): MaterializedCache | null {
+    return this.materializedCache;
   }
 
   isPatched(): boolean {
@@ -245,6 +262,29 @@ export class AdapterManager {
     // stateless (only mutates the live Vault) and the adapter object
     // outlives a reconnect's swapClient, so wiring once here holds for
     // the whole patched lifetime — no per-swap re-policy needed.
+    // Bounded on-demand disk cache behind getFullPath / getFilePath and
+    // the read-through in read/readBinary. Zero budget switches the
+    // whole thing off; nothing is ever pre-fetched either way.
+    this.materializedCache = new MaterializedCache({
+      absOf: (rel) => path.join(shadowBasePath, rel),
+      writeFile: (abs, data) => {
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, data);
+        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        return s ? { size: s.size, mtimeMs: s.mtimeMs } : null;
+      },
+      statFile: (abs) => {
+        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        return s?.isFile() ? { size: s.size, mtimeMs: s.mtimeMs } : null;
+      },
+      deleteFile: (abs) => fs.rmSync(abs, { force: true }),
+      budgetBytes: shadowBasePath
+        ? Math.max(0, this.getSettings().fsCacheMB ?? 128) * 1024 * 1024
+        : 0,
+      maxFileBytes: Math.max(0, this.getSettings().fsCacheMaxFileMB ?? 8) * 1024 * 1024,
+    });
+    this._dataAdapter.setMaterializedCache(this.materializedCache);
+
     const localOpRegistry = new LocalOpRegistry();
     this._dataAdapter.setWriterReflector(
       new VaultModelBuilder(this.app.vault, { TFile, TFolder }),
@@ -291,6 +331,12 @@ export class AdapterManager {
     this._dataAdapter = null;
     this.readCache = null;
     this.dirCache = null;
+    // The disk cache is per-session: drop every untouched copy we put
+    // on the shadow disk so a disconnect leaves behind only what the
+    // user (or a plugin) actually created there. A copy somebody edited
+    // is left alone — the watcher owns it now.
+    this.materializedCache?.clear();
+    this.materializedCache = null;
     this.ancestorTracker?.clear();
     this.ancestorTracker = null;
     this.transferTracker?.clear();

--- a/plugin/src/adapter/LocalWriteWatcher.ts
+++ b/plugin/src/adapter/LocalWriteWatcher.ts
@@ -31,6 +31,13 @@ export interface LocalWriteWatcherDeps {
   removeRemote(rel: string): Promise<void>;
   /** True for paths the write-back must never touch (config tree, VCS, temp files). */
   ignore(rel: string): boolean;
+  /**
+   * True when the bytes on disk are a copy the plugin itself
+   * materialised from the remote (`MaterializedCache`), so pushing them
+   * back would be an echo of the remote's own content. Defaults to
+   * never — a deployment without the disk cache is unaffected.
+   */
+  isMirroredCopy?(rel: string, stat: LocalFileStat): boolean;
   /** Largest single file to push. Bigger files are skipped, loudly. */
   maxBytes: number;
   /** Coalesces a burst of writes; also the interval between stability samples. */
@@ -222,6 +229,13 @@ export class LocalWriteWatcher {
     if (this.pushed.get(rel) === sig) {
       this.sample.set(rel, sig);
       return;                          // already on the remote, byte-identical
+    }
+    if (this.deps.isMirroredCopy?.(rel, st)) {
+      // We put these bytes there ourselves, materialising the remote's
+      // own content. Pushing them back would be an echo — and on a
+      // stale copy it would be an echo that overwrites a newer remote.
+      this.sample.set(rel, sig);
+      return;
     }
     if (this.sample.get(rel) !== sig) {
       // First sighting of this generation. Wait one more debounce and

--- a/plugin/src/adapter/MaterializedCache.ts
+++ b/plugin/src/adapter/MaterializedCache.ts
@@ -1,0 +1,206 @@
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/** What a materialised file looked like at the moment we wrote it. */
+export interface MaterializedStat {
+  size: number;
+  mtimeMs: number;
+}
+
+/** Filesystem surface, injected so the budget/LRU logic tests without a disk. */
+export interface MaterializedCacheDeps {
+  /** Absolute path on the shadow disk for a vault-relative path. */
+  absOf(rel: string): string;
+  /** Create parents and write. Returns the resulting stat, or null on failure. */
+  writeFile(abs: string, data: Buffer): MaterializedStat | null;
+  /** Current stat of a local path; null when absent or not a regular file. */
+  statFile(abs: string): MaterializedStat | null;
+  /** Delete a local path. */
+  deleteFile(abs: string): void;
+  /**
+   * Total bytes that may sit on the shadow disk as materialised copies.
+   * A file bigger than this is never fetched at all.
+   */
+  budgetBytes: number;
+  /** Per-file ceiling, so one huge attachment cannot consume the budget. */
+  maxFileBytes: number;
+}
+
+/**
+ * The bounded, on-demand disk cache behind `getFullPath` / `getFilePath`.
+ *
+ * ## The rule this encodes
+ *
+ * The remote vault is NOT cloned. The note tree stays virtual: a file
+ * exists on the shadow disk only because something asked for a real
+ * path to it (or read it through the vault API), and only while it fits
+ * in the configured budget. Nothing is pre-fetched, and a file over the
+ * budget is never fetched at all — not fetched and then discarded.
+ *
+ * ## Why eviction has to be careful
+ *
+ * A materialised copy sits in the same directory a plugin may write to,
+ * and `LocalWriteWatcher` pushes what it finds there to the remote. Two
+ * rules keep the two from fighting:
+ *
+ *  - **A copy we wrote is never pushed back.** The watcher asks
+ *    {@link isMirroredCopy}; a file whose (size, mtime) still matches
+ *    what we wrote is the remote's own bytes, not an edit.
+ *  - **A locally modified copy is never evicted.** Its stat no longer
+ *    matches the ledger, which means somebody changed it; deleting it
+ *    would throw away an edit that has not been pushed yet. Such an
+ *    entry is dropped from the ledger and left on disk — from then on
+ *    it is an ordinary local file and the watcher owns it.
+ */
+export class MaterializedCache {
+  /** rel → stat as written. Insertion order is the LRU order. */
+  private readonly entries = new Map<string, MaterializedStat>();
+  private total = 0;
+
+  constructor(private readonly deps: MaterializedCacheDeps) {}
+
+  /** Bytes currently accounted for by the ledger. */
+  bytes(): number {
+    return this.total;
+  }
+
+  /** Number of materialised files. */
+  size(): number {
+    return this.entries.size;
+  }
+
+  /** True when a payload would be refused for its size alone. */
+  tooBig(byteLength: number): boolean {
+    return byteLength > this.deps.maxFileBytes || byteLength > this.deps.budgetBytes;
+  }
+
+  /** True when the cache is switched off entirely (budget of zero). */
+  disabled(): boolean {
+    return this.deps.budgetBytes <= 0;
+  }
+
+  /**
+   * Most bytes worth fetching for one file. Handed to the synchronous
+   * fetch so an over-limit file is refused by the transport instead of
+   * being pulled and then thrown away.
+   */
+  fetchLimit(): number {
+    return Math.min(this.deps.maxFileBytes, this.deps.budgetBytes);
+  }
+
+  /**
+   * Write `data` to the shadow disk and record it. Returns false when
+   * the cache is disabled, the file is over a limit, or the write
+   * fails — callers treat that as "not materialised" and carry on.
+   */
+  put(rel: string, data: Buffer): boolean {
+    if (this.disabled()) return false;
+    if (this.tooBig(data.byteLength)) {
+      logger.info(
+        `MaterializedCache: "${rel}" (${data.byteLength} bytes) exceeds the cache limit — ` +
+        'not written to disk',
+      );
+      return false;
+    }
+    const abs = this.deps.absOf(rel);
+    let stat: MaterializedStat | null;
+    try {
+      stat = this.deps.writeFile(abs, data);
+    } catch (e) {
+      logger.warn(`MaterializedCache: could not materialise "${rel}" (${errorMessage(e)})`);
+      return false;
+    }
+    if (!stat) return false;
+    this.forget(rel);
+    this.entries.set(rel, stat);
+    this.total += stat.size;
+    this.evictDownToBudget();
+    return this.entries.has(rel);
+  }
+
+  /** True when `rel` has a materialised copy that is still untouched. */
+  has(rel: string): boolean {
+    const known = this.entries.get(rel);
+    if (!known) return false;
+    const now = this.deps.statFile(this.deps.absOf(rel));
+    if (!now) {
+      this.forget(rel);
+      return false;
+    }
+    if (now.size !== known.size || now.mtimeMs !== known.mtimeMs) {
+      // Somebody edited our copy. It is theirs now.
+      this.forget(rel);
+      return false;
+    }
+    this.touch(rel, known);
+    return true;
+  }
+
+  /**
+   * The predicate `LocalWriteWatcher` consults before pushing: true
+   * when the bytes on disk are the copy we put there, so pushing them
+   * back to the remote would be an echo of the remote's own content.
+   */
+  isMirroredCopy(rel: string, stat: MaterializedStat): boolean {
+    const known = this.entries.get(rel);
+    if (!known) return false;
+    return known.size === stat.size && known.mtimeMs === stat.mtimeMs;
+  }
+
+  /** Drop a path from the ledger without touching the disk. */
+  forget(rel: string): void {
+    const known = this.entries.get(rel);
+    if (!known) return;
+    this.entries.delete(rel);
+    this.total -= known.size;
+    if (this.total < 0) this.total = 0;
+  }
+
+  /**
+   * Delete every materialised copy that is still untouched. Called on
+   * disconnect: the cache is per-session, so nothing the user did not
+   * put there themselves is left behind on the disk.
+   */
+  clear(): void {
+    for (const rel of [...this.entries.keys()]) this.evictOne(rel);
+    this.entries.clear();
+    this.total = 0;
+  }
+
+  private touch(rel: string, stat: MaterializedStat): void {
+    this.entries.delete(rel);
+    this.entries.set(rel, stat);
+  }
+
+  private evictDownToBudget(): void {
+    for (const rel of [...this.entries.keys()]) {
+      if (this.total <= this.deps.budgetBytes) return;
+      this.evictOne(rel);
+    }
+  }
+
+  /**
+   * Remove one entry. Deletes the file only when it still matches what
+   * we wrote — a modified copy is abandoned to the watcher instead.
+   */
+  private evictOne(rel: string): void {
+    const known = this.entries.get(rel);
+    if (!known) return;
+    const abs = this.deps.absOf(rel);
+    const now = this.deps.statFile(abs);
+    if (now && (now.size !== known.size || now.mtimeMs !== known.mtimeMs)) {
+      logger.info(
+        `MaterializedCache: "${rel}" changed on disk since it was materialised — ` +
+        'left in place instead of evicted',
+      );
+      this.forget(rel);
+      return;
+    }
+    try {
+      this.deps.deleteFile(abs);
+    } catch (e) {
+      logger.warn(`MaterializedCache: could not evict "${rel}" (${errorMessage(e)})`);
+    }
+    this.forget(rel);
+  }
+}

--- a/plugin/src/adapter/ResourceBridge.ts
+++ b/plugin/src/adapter/ResourceBridge.ts
@@ -245,6 +245,12 @@ export class ResourceBridge {
       res.writeHead(405, { 'Allow': 'GET, HEAD' }).end();
       return;
     }
+    // `<img src>` needs no CORS, but the synchronous XHR that
+    // `getFullPath` uses to materialise a file on demand does — the
+    // renderer's origin (`app://obsidian.md`) is not this server's.
+    // The token in the path is what actually guards the bridge; this
+    // header only stops the browser from hiding an authorised reply.
+    res.setHeader('Access-Control-Allow-Origin', '*');
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
     const m = /^\/r\/([0-9a-f]+)$/.exec(url.pathname);
     if (!m) {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -23,6 +23,9 @@ function isThumbnailEligible(vaultPath: string): boolean {
 }
 import * as fs from 'fs';
 import * as nodePath from 'path';
+import { pathToFileURL } from 'url';
+import type { MaterializedCache } from './MaterializedCache';
+import { syncHttpGetBinary } from '../util/syncHttpGet';
 import type { RemoteFsClient } from './RemoteFsClient';
 import type { WriterReflector } from './WriterReflector';
 import type { LocalOpRegistry } from './LocalOpRegistry';
@@ -163,6 +166,84 @@ export class SftpDataAdapter {
    */
   getBasePath(): string {
     return this.shadowBasePath;
+  }
+
+  /**
+   * Bounded on-demand disk cache. Null (the default) leaves every
+   * materialisation call a no-op, which is what unit tests and any
+   * non-shadow caller want.
+   */
+  private materializedCache: MaterializedCache | null = null;
+
+  setMaterializedCache(cache: MaterializedCache | null): void {
+    this.materializedCache = cache;
+  }
+
+  /**
+   * Absolute path of a vault file on this device — and, unlike the
+   * stock `FileSystemAdapter`, a path that has a real file behind it.
+   *
+   * The stock implementation just joins onto the base, which over a
+   * virtual note tree means handing a plugin a path to nothing (#429).
+   * Asking for a full path IS the request that materialises the file:
+   * we fetch it synchronously through the ResourceBridge and write it
+   * into the bounded cache, so `fs.readFileSync(adapter.getFullPath(p))`
+   * works for the file that was asked about. Files over the cache
+   * limits are not fetched, and callers still get the joined path —
+   * exactly what they got before, no worse.
+   */
+  getFullPath(normalizedPath: string): string {
+    this.ensureMaterialized(normalizedPath);
+    return nodePath.join(this.shadowBasePath, normalizedPath);
+  }
+
+  /**
+   * `file://` URL for a vault file. Same contract as
+   * {@link getFullPath}: the file is materialised first, because what
+   * follows this URL is usually `<img>`, `shell.openPath` or an
+   * external editor — none of which can be intercepted.
+   */
+  getFilePath(normalizedPath: string): string {
+    return pathToFileURL(this.getFullPath(normalizedPath)).href;
+  }
+
+  /**
+   * Best-effort synchronous materialisation. Silent about everything
+   * except the two outcomes a user could act on (over the limit, and
+   * a bridge that isn't running), and never throws: the caller wants a
+   * path, and a path is what it gets either way.
+   */
+  private ensureMaterialized(normalizedPath: string): void {
+    const cache = this.materializedCache;
+    if (!cache || cache.disabled()) return;
+    if (cache.has(normalizedPath)) return;
+
+    // Free hit: the bytes are already in the in-memory read cache
+    // (the note was just opened), so no request goes out at all.
+    const cached = this.readCache.peek(this.toRemote(normalizedPath));
+    if (cached) {
+      cache.put(normalizedPath, cached.data);
+      return;
+    }
+    if (!this.resourceBridge?.isRunning()) return;
+
+    let url: string;
+    try {
+      url = this.resourceBridge.urlFor(normalizedPath);
+    } catch {
+      return;                          // bridge stopped between the check and here
+    }
+    const result = syncHttpGetBinary(url, cache.fetchLimit());
+    if (result.kind === 'ok') {
+      cache.put(normalizedPath, result.bytes);
+      return;
+    }
+    if (result.kind === 'too-large') {
+      logger.info(
+        `getFullPath("${normalizedPath}"): ${result.totalSize} bytes is over the ` +
+        'materialisation limit — the path is returned but no file was written',
+      );
+    }
   }
 
   /**
@@ -378,6 +459,7 @@ export class SftpDataAdapter {
 
   async read(normalizedPath: string): Promise<string> {
     const buf = await this.readBuffer(normalizedPath);
+    this.materializedCache?.put(normalizedPath, buf);
     const text = buf.toString('utf8');
     // Snapshot the just-read content so a subsequent conflicting write
     // can show the user a real ancestor pane in the 3-way modal.
@@ -390,6 +472,7 @@ export class SftpDataAdapter {
 
   async readBinary(normalizedPath: string): Promise<ArrayBuffer> {
     const buf = await this.readBuffer(normalizedPath);
+    this.materializedCache?.put(normalizedPath, buf);
     // Copy into a fresh ArrayBuffer so callers can't accidentally mutate
     // the cached Buffer's underlying memory through the returned view.
     const ab = new ArrayBuffer(buf.byteLength);

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -55,6 +55,11 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   // stranded on the local disk. 32 MB caps a single push.
   localWriteBack: true,
   localWriteBackMaxMB: 32,
+  // #429 read side — on-demand materialisation budget. Nothing is
+  // pre-fetched and nothing survives a disconnect; this only bounds how
+  // much of what was actually asked for may sit on the disk at once.
+  fsCacheMB: 128,
+  fsCacheMaxFileMB: 8,
   // Phase 4 marker for shadow vaults; null on a normal vault. Only
   // `ShadowVaultBootstrap` writes a non-null value.
   autoConnectProfileId: null,

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -782,6 +782,10 @@ export default class RemoteSshPlugin extends Plugin {
           },
           removeRemote: (rel) => da.remove(rel),
           ignore,
+          // A file the disk cache materialised is the remote's own
+          // content; pushing it back would be an echo.
+          isMirroredCopy: (rel, st) =>
+            this.adapterMgr.materialized?.isMirroredCopy(rel, st) ?? false,
           maxBytes,
           debounceMs: 400,
           setTimer: (cb, ms) => window.setTimeout(cb, ms),

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -123,6 +123,25 @@ export class SettingsTab extends PluginSettingTab {
           new Notice('Remote SSH: reconnect for this to take effect');
         }));
 
+    new Setting(containerEl)
+      .setName('On-demand file cache')
+      .setDesc(
+        'Budget in megabytes for materialising remote files on this device so paths handed to plugins ' +
+        '(getFullPath / getFilePath) point at a real file. The vault is never cloned: a ' +
+        'file is written only when something asks for it, anything bigger than the budget ' +
+        'is not downloaded at all, and the cache is deleted on disconnect. 0 disables it.',
+      )
+      .addText(t => t
+        .setPlaceholder('128')
+        .setValue(String(this.plugin.settings.fsCacheMB ?? 128))
+        .onChange(async v => {
+          const n = parseInt(v, 10);
+          if (Number.isFinite(n) && n >= 0 && n <= 100_000) {
+            this.plugin.settings.fsCacheMB = n;
+            await this.plugin.saveSettings();
+          }
+        }));
+
     this.renderTerminalPanel(containerEl);
   }
 

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -177,6 +177,24 @@ export interface PluginSettings {
    */
   localWriteBackMaxMB?: number;
   /**
+   * #429 read side — budget, in MB, for materialising remote files onto
+   * the shadow disk so `getFullPath()` / `getFilePath()` return paths
+   * that actually resolve. The remote vault is never cloned: a file is
+   * written only because something asked for a real path to it (or read
+   * it through the vault API), a file bigger than the budget is not
+   * fetched at all, and the least recently used copies are evicted to
+   * stay inside it. The whole cache is deleted on disconnect. Default
+   * 128; 0 disables materialisation entirely.
+   */
+  fsCacheMB?: number;
+  /**
+   * Per-file ceiling for the same cache, in MB. Default 8 — big enough
+   * for notes and ordinary attachments, small enough that one video
+   * cannot evict everything else. Files above it are never materialised
+   * (`getFullPath` still returns the joined path, as before).
+   */
+  fsCacheMaxFileMB?: number;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/src/util/syncHttpGet.ts
+++ b/plugin/src/util/syncHttpGet.ts
@@ -1,0 +1,92 @@
+import { logger } from './logger';
+import { errorMessage } from './errorMessage';
+
+/** Outcome of {@link syncHttpGetBinary}. */
+export type SyncGetResult =
+  | { kind: 'ok'; bytes: Buffer }
+  /** The resource is larger than `maxBytes`; nothing was materialised. */
+  | { kind: 'too-large'; totalSize: number }
+  /** No vehicle, or the request failed. `why` is for the log, not the user. */
+  | { kind: 'unavailable'; why: string };
+
+/** Logged once per session — a missing vehicle is a fact, not a per-call event. */
+let vehicleReported = false;
+
+/**
+ * Fetch a localhost URL **synchronously** and return its bytes.
+ *
+ * This exists for `getFullPath` / `getFilePath`, which are synchronous
+ * in Obsidian's `DataAdapter` API: a plugin calls one and then
+ * immediately opens the path it got back. Returning a path and
+ * materialising it asynchronously would lose that race, so the fetch
+ * has to block.
+ *
+ * The vehicle is a synchronous `XMLHttpRequest` against the
+ * ResourceBridge (already running on 127.0.0.1 behind a per-session
+ * token). Synchronous XHR cannot use `responseType`, so the body comes
+ * back through `overrideMimeType('text/plain; charset=x-user-defined')`,
+ * which maps each byte to one code unit — the standard way to read
+ * binary out of a synchronous request.
+ *
+ * `Range: bytes=0-(maxBytes-1)` is sent so an over-budget file is
+ * recognised from `Content-Range` without transferring all of it
+ * (a transport that cannot honour a range still sends the whole body;
+ * it is then discarded rather than written to disk).
+ *
+ * Never throws: every failure is a `kind: 'unavailable'` the caller
+ * degrades on.
+ */
+export function syncHttpGetBinary(url: string, maxBytes: number): SyncGetResult {
+  // `activeWindow` is Obsidian's handle on the window the user is
+  // actually in (pop-out windows have their own); it is absent outside
+  // Obsidian, where the plain `window` is the right — and only — scope.
+  const scope = (typeof activeWindow !== 'undefined' ? activeWindow : window) as unknown as
+    { XMLHttpRequest?: new () => XMLHttpRequest } | undefined;
+  const XHRCtor = scope?.XMLHttpRequest;
+  if (typeof XHRCtor !== 'function') {
+    if (!vehicleReported) {
+      vehicleReported = true;
+      logger.info(
+        'syncHttpGetBinary: no XMLHttpRequest in this context — on-demand materialisation is off',
+      );
+    }
+    return { kind: 'unavailable', why: 'no XMLHttpRequest' };
+  }
+  try {
+    const xhr = new XHRCtor();
+    xhr.open('GET', url, false);
+    xhr.setRequestHeader('Range', `bytes=0-${Math.max(0, maxBytes - 1)}`);
+    xhr.overrideMimeType('text/plain; charset=x-user-defined');
+    xhr.send();
+
+    if (xhr.status !== 200 && xhr.status !== 206) {
+      return { kind: 'unavailable', why: `HTTP ${xhr.status}` };
+    }
+    const total = totalFromContentRange(xhr.getResponseHeader('Content-Range'));
+    if (total !== null && total > maxBytes) {
+      return { kind: 'too-large', totalSize: total };
+    }
+    const text = xhr.responseText;
+    if (text.length > maxBytes) {
+      return { kind: 'too-large', totalSize: text.length };
+    }
+    const out = Buffer.allocUnsafe(text.length);
+    for (let i = 0; i < text.length; i++) out[i] = text.charCodeAt(i) & 0xff;
+    return { kind: 'ok', bytes: out };
+  } catch (e) {
+    if (!vehicleReported) {
+      vehicleReported = true;
+      logger.info(`syncHttpGetBinary: synchronous request failed (${errorMessage(e)})`);
+    }
+    return { kind: 'unavailable', why: errorMessage(e) };
+  }
+}
+
+/** `bytes 0-1023/4096` → 4096. Null when the header is absent or unparseable. */
+export function totalFromContentRange(header: string | null): number | null {
+  if (!header) return null;
+  const m = /\/\s*(\d+)\s*$/.exec(header);
+  if (!m) return null;
+  const n = parseInt(m[1], 10);
+  return Number.isFinite(n) ? n : null;
+}

--- a/plugin/tests/LocalWriteWatcher.test.ts
+++ b/plugin/tests/LocalWriteWatcher.test.ts
@@ -24,6 +24,8 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   const push = vi.fn(async (_rel: string, _data: Buffer) => {});
   const removeRemote = vi.fn(async (_rel: string) => {});
   const onError = vi.fn((_rel: string, _msg: string) => {});
+  /** Paths the disk cache currently claims as its own materialised copy. */
+  const mirrored = new Set<string>();
 
   const w = new LocalWriteWatcher({
     watch: (cb) => { onChange = cb; return { close: () => { closed = true; } }; },
@@ -34,6 +36,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
     push,
     removeRemote,
     ignore: makeLocalWriteIgnore('.obsidian', ['.git', 'node_modules']),
+    isMirroredCopy: (rel) => mirrored.has(rel),
     maxBytes,
     debounceMs: 400,
     setTimer: (cb) => { pending = cb; return 1; },
@@ -42,7 +45,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   });
 
   return {
-    w, push, removeRemote, onError,
+    w, push, removeRemote, onError, mirrored,
     trigger: (rel: string | null) => onChange?.(rel),
     /** Fire the pending debounce and let the async flush settle. */
     tick: async () => {
@@ -195,6 +198,26 @@ describe('LocalWriteWatcher', () => {
     await h.tick();
     expect(h.push).toHaveBeenCalledTimes(2);
     expect(h.w.pushedCount()).toBe(1);
+  });
+
+  it('does not push back a copy the disk cache materialised', async () => {
+    const h = harness();
+    h.w.start();
+    h.write('remote-note.md', 'bytes fetched from the remote');
+    // The disk cache reports this exact (size, mtime) as its own copy.
+    h.mirrored.add('remote-note.md');
+    h.trigger('remote-note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push, 'the materialised copy was echoed back to the remote').not.toHaveBeenCalled();
+
+    // A plugin then edits it: no longer our copy, so it must travel.
+    h.mirrored.delete('remote-note.md');
+    h.write('remote-note.md', 'edited by a plugin');
+    h.trigger('remote-note.md');
+    await h.tick();
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
   });
 
   it('stop() closes the watcher and drops pending work', () => {

--- a/plugin/tests/MaterializedCache.test.ts
+++ b/plugin/tests/MaterializedCache.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MaterializedCache, type MaterializedStat } from '../src/adapter/MaterializedCache';
+import { syncHttpGetBinary, totalFromContentRange } from '../src/util/syncHttpGet';
+
+/**
+ * In-memory disk. `mtimeMs` advances on every write, so a rewrite is
+ * distinguishable from the copy that was already there — which is
+ * exactly how the real ledger tells "our copy" from "somebody edited
+ * it".
+ */
+function fakeDisk() {
+  const files = new Map<string, { data: Buffer; stat: MaterializedStat }>();
+  let clock = 1000;
+  return {
+    files,
+    deps: {
+      absOf: (rel: string) => `/root/${rel}`,
+      writeFile: (abs: string, data: Buffer): MaterializedStat => {
+        const stat = { size: data.byteLength, mtimeMs: ++clock };
+        files.set(abs, { data, stat });
+        return stat;
+      },
+      statFile: (abs: string) => files.get(abs)?.stat ?? null,
+      deleteFile: (abs: string) => { files.delete(abs); },
+      budgetBytes: 100,
+      maxFileBytes: 50,
+    },
+    /** Simulate someone else editing a file we materialised. */
+    tamper: (abs: string, body: string) => {
+      files.set(abs, { data: Buffer.from(body), stat: { size: body.length, mtimeMs: ++clock } });
+    },
+  };
+}
+
+describe('MaterializedCache', () => {
+  it('writes a requested file and reports it as present', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    expect(c.put('note.md', Buffer.from('hello'))).toBe(true);
+    expect(d.files.get('/root/note.md')?.data.toString()).toBe('hello');
+    expect(c.has('note.md')).toBe(true);
+    expect(c.bytes()).toBe(5);
+  });
+
+  it('refuses a file over the per-file ceiling without writing anything', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    expect(c.tooBig(51)).toBe(true);
+    expect(c.put('big.bin', Buffer.alloc(51))).toBe(false);
+    expect(d.files.size, 'an over-limit file was written to disk anyway').toBe(0);
+  });
+
+  it('never exceeds the budget — the least recently used copy goes first', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('a.md', Buffer.alloc(40));
+    c.put('b.md', Buffer.alloc(40));
+    c.has('a.md');                     // a is now the most recently used
+    c.put('c.md', Buffer.alloc(40));   // 120 > 100 budget
+
+    expect(c.bytes()).toBeLessThanOrEqual(100);
+    expect(d.files.has('/root/b.md'), 'the LRU victim is still on disk').toBe(false);
+    expect(d.files.has('/root/a.md')).toBe(true);
+    expect(d.files.has('/root/c.md')).toBe(true);
+  });
+
+  it('does NOT evict a copy somebody edited — that would destroy an unpushed edit', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('a.md', Buffer.alloc(40));
+    d.tamper('/root/a.md', 'x'.repeat(40));   // same size, new mtime: a local edit
+    c.put('b.md', Buffer.alloc(40));
+    c.put('c.md', Buffer.alloc(40));
+
+    expect(d.files.has('/root/a.md'), 'an edited file was evicted').toBe(true);
+    expect(c.isMirroredCopy('a.md', d.deps.statFile('/root/a.md')!)).toBe(false);
+  });
+
+  it('stops calling an edited copy its own', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('note.md', Buffer.from('remote body'));
+    const asWritten = d.deps.statFile('/root/note.md')!;
+    expect(c.isMirroredCopy('note.md', asWritten)).toBe(true);
+
+    d.tamper('/root/note.md', 'edited by a plugin');
+    const now = d.deps.statFile('/root/note.md')!;
+    expect(
+      c.isMirroredCopy('note.md', now),
+      'an edited file still looked like our copy — the write-back would drop it',
+    ).toBe(false);
+    expect(c.has('note.md')).toBe(false);
+  });
+
+  it('clear() removes our untouched copies and leaves edited ones behind', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('clean.md', Buffer.from('remote'));
+    c.put('edited.md', Buffer.from('remote'));
+    d.tamper('/root/edited.md', 'local changes');
+
+    c.clear();
+    expect(d.files.has('/root/clean.md')).toBe(false);
+    expect(d.files.has('/root/edited.md'), 'clear() deleted an edited file').toBe(true);
+    expect(c.bytes()).toBe(0);
+  });
+
+  it('a zero budget disables it entirely', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache({ ...d.deps, budgetBytes: 0 });
+    expect(c.disabled()).toBe(true);
+    expect(c.put('note.md', Buffer.from('x'))).toBe(false);
+    expect(d.files.size).toBe(0);
+  });
+
+  it('forgets a file that vanished from disk', () => {
+    const d = fakeDisk();
+    const c = new MaterializedCache(d.deps);
+    c.put('note.md', Buffer.from('body'));
+    d.files.delete('/root/note.md');
+    expect(c.has('note.md')).toBe(false);
+    expect(c.bytes()).toBe(0);
+  });
+});
+
+describe('syncHttpGetBinary', () => {
+  const stub = (over: Record<string, unknown>) => ({
+    open: vi.fn(), setRequestHeader: vi.fn(), overrideMimeType: vi.fn(), send: vi.fn(),
+    getResponseHeader: () => null,
+    status: 200, responseText: '',
+    ...over,
+  });
+
+  const withXhr = <T>(impl: object, run: () => T): T => {
+    const g = globalThis as { XMLHttpRequest?: unknown };
+    const saved = g.XMLHttpRequest;
+    g.XMLHttpRequest = function XHR() { return impl; } as unknown;
+    try { return run(); } finally { g.XMLHttpRequest = saved; }
+  };
+
+  it('maps the response back to raw bytes', () => {
+    const r = withXhr(stub({ status: 200, responseText: 'H\u00ff\u0000' }), () =>
+      syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 1024));
+    expect(r.kind).toBe('ok');
+    expect(r.kind === 'ok' && [...r.bytes]).toEqual([0x48, 0xff, 0x00]);
+  });
+
+  it('refuses a file whose Content-Range says it is over the limit', () => {
+    const r = withXhr(
+      stub({ status: 206, responseText: 'partial', getResponseHeader: () => 'bytes 0-6/999999' }),
+      () => syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 8),
+    );
+    expect(r).toEqual({ kind: 'too-large', totalSize: 999999 });
+  });
+
+  it('reports unavailable instead of throwing when there is no vehicle', () => {
+    const g = globalThis as { XMLHttpRequest?: unknown };
+    const saved = g.XMLHttpRequest;
+    delete g.XMLHttpRequest;
+    try {
+      expect(syncHttpGetBinary('http://127.0.0.1:1/r/tok?p=a', 8).kind).toBe('unavailable');
+    } finally {
+      g.XMLHttpRequest = saved;
+    }
+  });
+
+  it('parses the total out of a Content-Range header', () => {
+    expect(totalFromContentRange('bytes 0-1023/4096')).toBe(4096);
+    expect(totalFromContentRange('bytes 0-1023/*')).toBeNull();
+    expect(totalFromContentRange(null)).toBeNull();
+  });
+});


### PR DESCRIPTION
**Stacked on #481** — base is `feat/local-write-back`, so this diff shows only the read side. Merge #481 first; GitHub then retargets this to `next`.

## What

`getFullPath` / `getFilePath` were not in `PATCHED_METHODS`, so the stock `FileSystemAdapter` joined onto the local base and handed plugins **a path to nothing** — the note is on the remote and the tree is virtual. Anything that follows such a path (`shell.openPath`, an external editor, an `<img>`, a `readFileSync`) opened nothing.

Both are patched now, and **asking for a path is the request that materialises the file**: fetched synchronously through the running ResourceBridge, written into a bounded disk cache, so the path that comes back resolves. Vault-API reads are cached the same way; a path already in the in-memory `ReadCache` costs no request at all.

## The vault is not cloned

That constraint drove every decision:

- **nothing is pre-fetched** — a file is on disk only because something asked for it;
- **over the limit ⇒ not fetched at all** — the synchronous GET sends `Range: bytes=0-(max-1)`, so an over-budget file is recognised from `Content-Range` instead of being pulled and then thrown away;
- **LRU eviction** keeps the total inside the budget, and the whole cache is **deleted on disconnect**.

Settings: `fsCacheMB` (default 128, `0` disables) and `fsCacheMaxFileMB` (default 8).

## Two rules stop the cache and the write-back watcher from fighting

| rule | what it prevents |
| --- | --- |
| a copy we wrote is never pushed back (`isMirroredCopy`) | a materialisation read as a user edit — which on a stale copy would overwrite a **newer remote** |
| a copy somebody edited is never evicted | deleting an edit that has not been pushed yet; it leaves the ledger and the watcher owns it |

Both are tested directly.

## The vehicle

`getFullPath` is synchronous in Obsidian's API and callers open the path immediately, so the fetch must block — a synchronous `XMLHttpRequest` against the bridge (which now sends `Access-Control-Allow-Origin`, since the renderer's origin is not the bridge's). Binary comes back via `overrideMimeType('text/plain; charset=x-user-defined')`, one code unit per byte. **Where the vehicle is unavailable, every path degrades to exactly the old behaviour** (the joined path, no file) instead of throwing — so the worst case is today's behaviour, and `e2e/fs-visibility.spec.ts` is the oracle that says which we got.

## E2E

Targets two more reds in `e2e/fs-visibility.spec.ts`:

- `getFullPath returns a path that resolves to the file`
- `getFilePath returns a file:// URL that resolves`

Still red on purpose: `a note that exists on the REMOTE is readable via raw fs under basePath` and `fs.readdirSync(basePath) sees the vault's notes` — nobody asked for those paths, and listing the vault would require the clone this design refuses.

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning) and `vitest run` (84 files, 1293 tests) green locally. 13 new unit tests.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)