### PR TITLE
feat(adapter): let plugins see the vault through Node's fs, on demand (#429)

### DIFF
--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -145,23 +145,32 @@ Things that aren't a specific plugin but trip plugins in general:
     limit (Settings → Advanced, 32 MB default) is reported rather than
     pushed. The whole behaviour is switchable: *Push out-of-band file
     writes to the remote*.
-  - **Reads work only for a file you asked for by path.**
-    `getFullPath(path)` and `getFilePath(path)` materialise that one
-    file onto the shadow disk before returning, so the path they hand
-    back resolves and `shell.openPath` / an `<img>` / an external editor
-    opens the real note. Files read through the vault API are cached the
-    same way. Everything else is still absent: the note tree is **not**
-    mirrored, because that would mean keeping a local clone of the
-    remote vault — the thing this design exists to avoid. So
-    `fs.readFileSync(path.join(basePath, 'note.md'))` on a note nobody
-    asked for fails, and `fs.readdirSync(basePath)` lists only the
-    config tree plus whatever happens to be materialised — never the
-    vault. A plugin that discovers notes by walking the filesystem sees
-    an empty vault; read through the vault API instead.
-    The cache is bounded (Settings → Advanced, *On-demand file cache*,
+  - **Reads work from inside Obsidian, on demand.** `readFileSync`,
+    `readdirSync`, `existsSync`, `statSync` and `lstatSync` are taken
+    over *for paths under the vault folder only* — the config dir and
+    everything outside the vault run the stock function untouched.
+    Names and sizes are answered from the vault model, so listing or
+    stat-ing the vault costs **no download at all**, and a file's
+    content is fetched only when something actually reads it.
+    `getFullPath(path)` / `getFilePath(path)` do the same before
+    returning, so the path they hand back resolves for `shell.openPath`,
+    an `<img>` or an external editor.
+    The note tree is still **not** mirrored: that would be a local clone
+    of the remote vault, which is what this design exists to avoid. The
+    cache is bounded (Settings → Advanced, *On-demand file cache*,
     128 MB default, 8 MB per file), evicts least-recently-used copies,
     refuses anything over the limit rather than fetching and discarding
-    it, and is deleted on disconnect.
+    it, and is deleted on disconnect. A file over that limit reads as
+    `ENOENT`, exactly as before.
+    Two things this cannot reach, both moot if you switch off *Let
+    plugins read the vault with filesystem calls*:
+    - a plugin that captured the function before we patched it —
+      `const { readFileSync } = require('fs')` at module scope;
+    - **anything in another process.** A subprocess (a CLI the plugin
+      spawns, `git`, `ripgrep`, an external editor) has its own `fs` and
+      sees only what is physically on disk: the config tree plus
+      whatever has been materialised. Point such a tool at specific
+      files rather than expecting it to walk the vault.
   See *Direct-disk / agentic plugins* (#429) and the
   **basePath survey** (#133) — its "syncs up to the remote" mitigations
   now hold for writes, and only for writes. **Exception:** plugins that shell out to a local
@@ -195,13 +204,14 @@ Things that aren't a specific plugin but trip plugins in general:
   adapter ([#429](https://github.com/sotashimozono/obsidian-remote-ssh/issues/429)).
   The files they *create or edit* now reach the remote vault and the
   file explorer, via the write-back watcher described above — a
-  one-way, event-driven push, not a reconciler. Reading is the half
-  that stays limited: an agent that greps the vault directory finds
-  only what has been materialised (a note it was pointed at by
-  `getFullPath`, or one that was opened), never the vault as a whole,
-  because the tree is not mirrored. Point such a plugin at specific
-  notes rather than expecting it to discover the vault by walking
-  `basePath`.
+  one-way, event-driven push, not a reconciler. Reading works too, as
+  long as it happens **in Obsidian's own process**: the patched `fs`
+  answers listings from the vault model and fetches a file's content
+  when it is read. What such a plugin hands to a *subprocess* is the
+  gap — Claude Code, `git` and friends run with their own `fs` and see
+  only what is physically on disk. Point them at specific files (the
+  path from `getFullPath` is real by the time you get it) rather than
+  letting them discover the vault by walking `basePath`.
 
 ## Why we can't auto-test all of this
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.7",
+  "version": "1.1.8-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.7",
+  "version": "1.1.8-beta.8",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.7",
+  "version": "1.1.8-beta.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.7",
+      "version": "1.1.8-beta.8",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.7",
+  "version": "1.1.8-beta.8",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/FsModulePatcher.ts
+++ b/plugin/src/adapter/FsModulePatcher.ts
@@ -1,0 +1,277 @@
+import * as nodePath from 'path';
+import { logger } from '../util/logger';
+import { errorMessage } from '../util/errorMessage';
+
+/** One entry of the vault model, as the filesystem needs to see it. */
+export interface VaultEntry {
+  isDir: boolean;
+  size: number;
+  mtimeMs: number;
+}
+
+/**
+ * Read-only window onto `vault.fileMap` — names and stats only. It is
+ * free: the model already holds the whole remote tree (the background
+ * indexer fills it), so listing a directory or stat-ing a note costs no
+ * network at all. Content is a separate, explicit request.
+ */
+export interface VaultTreeView {
+  /** Immediate children of a vault-relative dir ('' = root), or null if it is not a known folder. */
+  children(relDir: string): { name: string; entry: VaultEntry }[] | null;
+  /** Info for a vault-relative path, or null when the model has never heard of it. */
+  entry(rel: string): VaultEntry | null;
+}
+
+export interface FsModulePatcherDeps {
+  /** The shared `require('fs')` object — the very one plugins get. */
+  fsModule: Record<string, unknown>;
+  /** Absolute shadow-vault root. Only paths under it are virtualised. */
+  root: string;
+  /** Vault-relative config dir; it is real on disk and must stay untouched. */
+  configDir: string;
+  tree: VaultTreeView;
+  /**
+   * Put one file on the disk, synchronously. True when it is there
+   * afterwards. Bounded by the cache budget — a refusal just means the
+   * caller gets the real filesystem's answer.
+   */
+  materialize(rel: string): boolean;
+}
+
+/** The functions we take over. Everything else stays stock. */
+const PATCHED = ['readFileSync', 'readdirSync', 'existsSync', 'statSync', 'lstatSync'] as const;
+
+/**
+ * Makes the remote vault visible to plugins that use Node's `fs`
+ * directly instead of the vault API — the read half of #429.
+ *
+ * ## What it does, and what it deliberately does not
+ *
+ * The vault is not cloned, so the shadow disk holds almost nothing.
+ * This patch supplies the missing answers from the two sources that
+ * already exist:
+ *
+ *  - **names and stats** come from `vault.fileMap`, which the
+ *    background indexer already fills with the whole remote tree. So
+ *    `readdirSync(basePath)` lists the vault and `statSync` reports a
+ *    real size — with **no download at all**.
+ *  - **content** comes from `materialize`, and only when somebody
+ *    actually calls `readFileSync`. That call IS the request. A file
+ *    over the cache budget is not fetched, and the caller then gets the
+ *    same ENOENT it would have got before.
+ *
+ * Writes are NOT patched: they already land on the real disk, where
+ * `LocalWriteWatcher` picks them up and pushes them to the remote.
+ *
+ * ## Scope discipline
+ *
+ * `fs` is shared with Obsidian itself and every other plugin, so the
+ * patch answers ONLY for paths that (a) resolve under the shadow root,
+ * (b) are outside the config dir — which is real on disk and owned by
+ * the config write-through — and (c) do not already exist on disk. In
+ * every other case the original function runs, untouched, first.
+ *
+ * ## The limit worth knowing
+ *
+ * A plugin that destructures before we patch —
+ * `const { readFileSync } = require('fs')` at module scope — captured
+ * the original and never sees this. Nothing can fix that from here.
+ */
+export class FsModulePatcher {
+  private readonly originals = new Map<string, unknown>();
+  private patched = false;
+
+  constructor(private readonly deps: FsModulePatcherDeps) {}
+
+  isPatched(): boolean {
+    return this.patched;
+  }
+
+  patch(): boolean {
+    if (this.patched) return true;
+    const mod = this.deps.fsModule;
+    for (const name of PATCHED) {
+      if (typeof mod[name] !== 'function') {
+        logger.warn(`FsModulePatcher: fs.${name} is not a function — not patching anything`);
+        return false;
+      }
+    }
+    try {
+      for (const name of PATCHED) this.originals.set(name, mod[name]);
+      mod.readFileSync = this.makeReadFileSync();
+      mod.readdirSync = this.makeReaddirSync();
+      mod.existsSync = this.makeExistsSync();
+      mod.statSync = this.makeStatSync('statSync');
+      mod.lstatSync = this.makeStatSync('lstatSync');
+      this.patched = true;
+      logger.info(`FsModulePatcher: patched fs.[${PATCHED.join(', ')}] for the shadow vault root`);
+      return true;
+    } catch (e) {
+      logger.error(`FsModulePatcher: patch failed (${errorMessage(e)}); restoring`);
+      this.restore();
+      return false;
+    }
+  }
+
+  restore(): void {
+    const mod = this.deps.fsModule;
+    for (const [name, fn] of this.originals) {
+      try { mod[name] = fn; } catch { /* best effort */ }
+    }
+    this.originals.clear();
+    this.patched = false;
+  }
+
+  /**
+   * Vault-relative path for something under the shadow root, or null
+   * when the path is none of our business. Resolves first, so `..`
+   * cannot walk out of the root and back in through a lie.
+   */
+  private toVaultRel(target: unknown): string | null {
+    if (typeof target !== 'string' || target === '') return null;
+    let abs: string;
+    try {
+      abs = nodePath.resolve(target);
+    } catch {
+      return null;
+    }
+    const root = nodePath.resolve(this.deps.root);
+    if (abs !== root && !abs.startsWith(root + nodePath.sep)) return null;
+    const rel = abs === root ? '' : abs.slice(root.length + 1).split(nodePath.sep).join('/');
+    if (rel.split('/')[0] === this.deps.configDir) return null;   // real on disk; not ours
+    return rel;
+  }
+
+  private orig<T>(name: string): T {
+    return this.originals.get(name) as T;
+  }
+
+  private makeReadFileSync() {
+    const original = this.orig<(...a: unknown[]) => unknown>('readFileSync');
+    return (target: unknown, ...rest: unknown[]): unknown => {
+      const rel = this.toVaultRel(target);
+      if (rel !== null && rel !== '' && !this.existsOnDisk(target)) {
+        // The request that materialises. If it is refused (over budget,
+        // no bridge, unknown path) the original throws ENOENT below,
+        // which is exactly what the caller would have got before.
+        try {
+          this.deps.materialize(rel);
+        } catch (e) {
+          logger.info(`FsModulePatcher: materialise "${rel}" failed (${errorMessage(e)})`);
+        }
+      }
+      return original(target, ...rest);
+    };
+  }
+
+  private makeReaddirSync() {
+    const original = this.orig<(...a: unknown[]) => unknown>('readdirSync');
+    return (target: unknown, ...rest: unknown[]): unknown => {
+      const rel = this.toVaultRel(target);
+      if (rel === null) return original(target, ...rest);
+      const modelChildren = this.deps.tree.children(rel);
+      if (!modelChildren) return original(target, ...rest);
+
+      let real: unknown[] = [];
+      try {
+        real = original(target, ...rest) as unknown[];
+      } catch {
+        real = [];                     // virtual-only directory: the model is the answer
+      }
+      const withFileTypes = Boolean(
+        rest[0] && typeof rest[0] === 'object'
+        && (rest[0] as { withFileTypes?: boolean }).withFileTypes,
+      );
+      const seen = new Set(
+        real.map(e => (typeof e === 'string' ? e : String((e as { name?: string }).name ?? ''))),
+      );
+      const extra = modelChildren
+        .filter(c => !seen.has(c.name))
+        .map(c => (withFileTypes ? makeDirent(c.name, c.entry.isDir) : c.name));
+      return [...real, ...extra];
+    };
+  }
+
+  private makeExistsSync() {
+    const original = this.orig<(p: unknown) => boolean>('existsSync');
+    return (target: unknown): boolean => {
+      if (original(target)) return true;
+      const rel = this.toVaultRel(target);
+      if (rel === null) return false;
+      if (rel === '') return true;
+      return this.deps.tree.entry(rel) !== null;
+    };
+  }
+
+  private makeStatSync(name: 'statSync' | 'lstatSync') {
+    const original = this.orig<(...a: unknown[]) => unknown>(name);
+    return (target: unknown, ...rest: unknown[]): unknown => {
+      if (this.existsOnDisk(target)) return original(target, ...rest);
+      const rel = this.toVaultRel(target);
+      if (rel === null || rel === '') return original(target, ...rest);
+      const entry = this.deps.tree.entry(rel);
+      if (!entry) return original(target, ...rest);   // let the real ENOENT happen
+      return makeStats(entry);
+    };
+  }
+
+  private existsOnDisk(target: unknown): boolean {
+    try {
+      return this.orig<(p: unknown) => boolean>('existsSync')(target);
+    } catch {
+      return false;
+    }
+  }
+}
+
+/**
+ * `Dirent`-shaped record for a path that exists in the vault but not on
+ * disk. Only the predicates consumers actually call are implemented;
+ * everything the real `Dirent` would report about links or devices is
+ * false, which is true of a remote vault entry.
+ */
+function makeDirent(name: string, isDir: boolean): Record<string, unknown> {
+  return {
+    name,
+    isFile: () => !isDir,
+    isDirectory: () => isDir,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  };
+}
+
+/** `Stats`-shaped record built from the vault model. Sizes and mtimes are real. */
+function makeStats(entry: VaultEntry): Record<string, unknown> {
+  const when = new Date(entry.mtimeMs);
+  const size = entry.isDir ? 0 : entry.size;
+  return {
+    size,
+    mtimeMs: entry.mtimeMs,
+    ctimeMs: entry.mtimeMs,
+    atimeMs: entry.mtimeMs,
+    birthtimeMs: entry.mtimeMs,
+    mtime: when,
+    ctime: when,
+    atime: when,
+    birthtime: when,
+    mode: entry.isDir ? 0o040755 : 0o100644,
+    nlink: 1,
+    uid: 0,
+    gid: 0,
+    dev: 0,
+    ino: 0,
+    rdev: 0,
+    blksize: 4096,
+    blocks: Math.ceil(size / 512),
+    isFile: () => !entry.isDir,
+    isDirectory: () => entry.isDir,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+  };
+}

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -193,7 +193,7 @@ export class SftpDataAdapter {
    * exactly what they got before, no worse.
    */
   getFullPath(normalizedPath: string): string {
-    this.ensureMaterialized(normalizedPath);
+    this.materializeSync(normalizedPath);
     return nodePath.join(this.shadowBasePath, normalizedPath);
   }
 
@@ -208,42 +208,43 @@ export class SftpDataAdapter {
   }
 
   /**
-   * Best-effort synchronous materialisation. Silent about everything
-   * except the two outcomes a user could act on (over the limit, and
-   * a bridge that isn't running), and never throws: the caller wants a
-   * path, and a path is what it gets either way.
+   * Put one file on the shadow disk, synchronously, and report whether
+   * it is there afterwards. This is the single "a request came in"
+   * entry point: `getFullPath` / `getFilePath` call it, and so does the
+   * patched `fs.readFileSync`. Never throws — a caller that wanted a
+   * path still gets one, and a caller that wanted bytes falls back to
+   * the real filesystem's own ENOENT.
    */
-  private ensureMaterialized(normalizedPath: string): void {
+  materializeSync(normalizedPath: string): boolean {
     const cache = this.materializedCache;
-    if (!cache || cache.disabled()) return;
-    if (cache.has(normalizedPath)) return;
+    if (!cache || cache.disabled()) return false;
+    if (cache.has(normalizedPath)) return true;
 
     // Free hit: the bytes are already in the in-memory read cache
     // (the note was just opened), so no request goes out at all.
     const cached = this.readCache.peek(this.toRemote(normalizedPath));
     if (cached) {
-      cache.put(normalizedPath, cached.data);
-      return;
+      return cache.put(normalizedPath, cached.data);
     }
-    if (!this.resourceBridge?.isRunning()) return;
+    if (!this.resourceBridge?.isRunning()) return false;
 
     let url: string;
     try {
       url = this.resourceBridge.urlFor(normalizedPath);
     } catch {
-      return;                          // bridge stopped between the check and here
+      return false;                    // bridge stopped between the check and here
     }
     const result = syncHttpGetBinary(url, cache.fetchLimit());
     if (result.kind === 'ok') {
-      cache.put(normalizedPath, result.bytes);
-      return;
+      return cache.put(normalizedPath, result.bytes);
     }
     if (result.kind === 'too-large') {
       logger.info(
-        `getFullPath("${normalizedPath}"): ${result.totalSize} bytes is over the ` +
-        'materialisation limit — the path is returned but no file was written',
+        `materializeSync("${normalizedPath}"): ${result.totalSize} bytes is over the ` +
+        'materialisation limit — nothing was written',
       );
     }
+    return false;
   }
 
   /**

--- a/plugin/src/constants.ts
+++ b/plugin/src/constants.ts
@@ -60,6 +60,9 @@ export const DEFAULT_SETTINGS: PluginSettings = {
   // much of what was actually asked for may sit on the disk at once.
   fsCacheMB: 128,
   fsCacheMaxFileMB: 8,
+  // Answer raw `fs` reads for the vault: names/stats from the model,
+  // content on demand. Scoped to the shadow root, outside the config dir.
+  fsModulePatch: true,
   // Phase 4 marker for shadow vaults; null on a normal vault. Only
   // `ShadowVaultBootstrap` writes a non-null value.
   autoConnectProfileId: null,

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -32,6 +32,7 @@ import { ShadowVaultBootstrap } from './shadow/ShadowVaultBootstrap';
 import type { SharedConfigReader, BootstrapResult } from './shadow/ShadowVaultBootstrap';
 import { SharedConfigWatcher } from './shadow/SharedConfigWatcher';
 import { LocalWriteWatcher, makeLocalWriteIgnore } from './adapter/LocalWriteWatcher';
+import { FsModulePatcher } from './adapter/FsModulePatcher';
 import { watchTree, listTreeFiles } from './util/watchTree';
 import { ShadowVaultManager } from './shadow/ShadowVaultManager';
 import { WindowSpawner } from './shadow/WindowSpawner';
@@ -119,6 +120,7 @@ export default class RemoteSshPlugin extends Plugin {
    */
   private sharedConfigWatcher: SharedConfigWatcher | null = null;
   private localWriteWatcher: LocalWriteWatcher | null = null;
+  private fsModulePatcher: FsModulePatcher | null = null;
   private observability: ObservabilityInstaller | null = null;
   /**
    * #149 — re-entrant guard for `openRemoteTerminal()`. The
@@ -795,6 +797,56 @@ export default class RemoteSshPlugin extends Plugin {
         lww.start();
         this.localWriteWatcher = lww;
       }
+
+      // #429 read side. The write-back above carries bytes OUT; nothing
+      // carried the vault IN, because the note tree is virtual: a plugin
+      // doing `fs.readdirSync(basePath)` saw the config dir and no notes,
+      // and `fs.readFileSync` on a note the user is looking at got ENOENT.
+      //
+      // Rather than mirror the tree (that is a clone of the remote, which
+      // this design refuses), answer from what already exists: names and
+      // stats come from `vault.fileMap` — free, no download — and content
+      // only when a `readFileSync` actually asks for it.
+      this.fsModulePatcher?.restore();
+      this.fsModulePatcher = null;
+      if (this.settings.fsModulePatch !== false) {
+        const req = (window as unknown as { require?: (m: string) => unknown }).require;
+        const fsModule = typeof req === 'function'
+          ? (req('fs') as Record<string, unknown> | null)
+          : null;
+        if (!fsModule) {
+          logger.info(
+            'fs patch: window.require is unavailable in this renderer — plugins that read ' +
+            'the vault through Node fs will not see it',
+          );
+        } else {
+          const asEntry = (f: unknown) => {
+            if (f instanceof TFile) return { isDir: false, size: f.stat.size, mtimeMs: f.stat.mtime };
+            if (f instanceof TFolder) return { isDir: true, size: 0, mtimeMs: 0 };
+            return null;
+          };
+          const patcher = new FsModulePatcher({
+            fsModule,
+            root: hostAdapter.getBasePath(),
+            configDir: this.app.vault.configDir,
+            tree: {
+              children: (relDir) => {
+                const folder = relDir === ''
+                  ? this.app.vault.getRoot()
+                  : this.app.vault.getAbstractFileByPath(relDir);
+                if (!(folder instanceof TFolder)) return null;
+                return folder.children.flatMap((c) => {
+                  const entry = asEntry(c);
+                  return entry ? [{ name: c.name, entry }] : [];
+                });
+              },
+              entry: (rel) => asEntry(this.app.vault.getAbstractFileByPath(rel)),
+            },
+            materialize: (rel) => da.materializeSync(rel),
+          });
+          if (patcher.patch()) this.fsModulePatcher = patcher;
+        }
+      }
     }
 
     // Adapter is patched; build the file model so File Explorer
@@ -890,6 +942,8 @@ export default class RemoteSshPlugin extends Plugin {
       this.sharedConfigWatcher = null;
       this.localWriteWatcher?.stop();
       this.localWriteWatcher = null;
+      this.fsModulePatcher?.restore();
+      this.fsModulePatcher = null;
       this.adapterMgr.restore();
       this.setState(SyncState.ERROR);
       // s.reason is a string from ReconnectManager; wrap into Error
@@ -932,6 +986,10 @@ export default class RemoteSshPlugin extends Plugin {
     // we are about to restore.
     this.localWriteWatcher?.stop();
     this.localWriteWatcher = null;
+    // Hand Node's fs back before the adapter goes: a stale patch would
+    // keep answering for a vault model that is about to be torn down.
+    this.fsModulePatcher?.restore();
+    this.fsModulePatcher = null;
     this.adapterMgr.restore();
     // Drop lazy-load state — the walker it captured is now disconnected. A
     // stray File-Explorer click after this finds a null loader and no-ops.

--- a/plugin/src/settings/SettingsTab.ts
+++ b/plugin/src/settings/SettingsTab.ts
@@ -124,6 +124,21 @@ export class SettingsTab extends PluginSettingTab {
         }));
 
     new Setting(containerEl)
+      .setName('Let plugins read the vault with filesystem calls')
+      .setDesc(
+        'Some plugins list or read notes with raw filesystem calls instead of the vault API. ' +
+        'With this on, those calls see the remote vault: names and sizes come from the vault ' +
+        'model at no cost, and the content of a file is fetched only when something actually ' +
+        'reads it. Only the vault folder is affected. Turn it off if a plugin misbehaves.',
+      )
+      .addToggle(t => t.setValue(this.plugin.settings.fsModulePatch !== false)
+        .onChange(async v => {
+          this.plugin.settings.fsModulePatch = v;
+          await this.plugin.saveSettings();
+          new Notice('Remote SSH: reconnect for this to take effect');
+        }));
+
+    new Setting(containerEl)
       .setName('On-demand file cache')
       .setDesc(
         'Budget in megabytes for materialising remote files on this device so paths handed to plugins ' +

--- a/plugin/src/types.ts
+++ b/plugin/src/types.ts
@@ -195,6 +195,17 @@ export interface PluginSettings {
    */
   fsCacheMaxFileMB?: number;
   /**
+   * #429 read side — let plugins that use Node's `fs` directly see the
+   * vault. Names and stats are answered from `vault.fileMap` (no
+   * download at all); a `readFileSync` materialises that one file,
+   * within the cache budget. Only paths under the shadow vault root and
+   * outside the config dir are answered for; everything else runs the
+   * stock function untouched. Default true. Turn it off if a plugin
+   * misbehaves — the cost is that raw `fs` reads see an empty vault
+   * again.
+   */
+  fsModulePatch?: boolean;
+  /**
    * #149 — terminal pane preferences. All optional; the View applies
    * sensible defaults when missing. `terminalShell` overrides the
    * remote login shell (e.g. `/usr/bin/zsh -l`); blank/missing means

--- a/plugin/tests/FsModulePatcher.test.ts
+++ b/plugin/tests/FsModulePatcher.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as nodePath from 'path';
+import { FsModulePatcher, type VaultEntry } from '../src/adapter/FsModulePatcher';
+
+const ROOT = nodePath.resolve(nodePath.sep === '\\' ? 'C:\\shadow\\vault' : '/shadow/vault');
+const abs = (rel: string) => nodePath.join(ROOT, ...rel.split('/'));
+
+/**
+ * A fake `fs` module plus a fake vault model.
+ *
+ * `onDisk` is what physically exists (the config tree, and whatever has
+ * been materialised); `model` is the remote tree the vault knows about.
+ * The whole point of the patch is that the second becomes visible
+ * through the first without being copied into it.
+ */
+function harness(onDisk: Record<string, string> = {}, model: Record<string, VaultEntry> = {}) {
+  const enoent = (p: string) => Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+
+  const fsModule: Record<string, unknown> = {
+    readFileSync: vi.fn((p: string) => {
+      if (!(p in onDisk)) throw enoent(p);
+      return Buffer.from(onDisk[p]);
+    }),
+    readdirSync: vi.fn((p: string) => {
+      const prefix = p.endsWith(nodePath.sep) ? p : p + nodePath.sep;
+      const kids = new Set<string>();
+      let isDir = false;
+      for (const f of Object.keys(onDisk)) {
+        if (!f.startsWith(prefix)) continue;
+        isDir = true;
+        kids.add(f.slice(prefix.length).split(nodePath.sep)[0]);
+      }
+      if (!isDir) throw enoent(p);
+      return [...kids];
+    }),
+    existsSync: vi.fn((p: string) => p in onDisk
+      || Object.keys(onDisk).some(f => f.startsWith(p + nodePath.sep))),
+    statSync: vi.fn((p: string) => {
+      if (!(p in onDisk)) throw enoent(p);
+      return { size: onDisk[p].length, real: true, isFile: () => true, isDirectory: () => false };
+    }),
+    lstatSync: vi.fn((p: string) => {
+      if (!(p in onDisk)) throw enoent(p);
+      return { size: onDisk[p].length, real: true, isFile: () => true, isDirectory: () => false };
+    }),
+  };
+  const originals = { ...fsModule };
+
+  const materialize = vi.fn((rel: string) => {
+    const entry = model[rel];
+    if (!entry || entry.isDir) return false;
+    onDisk[abs(rel)] = `content of ${rel}`;
+    return true;
+  });
+
+  const patcher = new FsModulePatcher({
+    fsModule,
+    root: ROOT,
+    configDir: '.obsidian',
+    tree: {
+      children: (relDir) => {
+        const self = relDir === '' ? { isDir: true, size: 0, mtimeMs: 0 } : model[relDir];
+        if (!self?.isDir) return null;
+        const prefix = relDir === '' ? '' : `${relDir}/`;
+        const seen = new Map<string, VaultEntry>();
+        for (const [p, e] of Object.entries(model)) {
+          if (!p.startsWith(prefix) || p === relDir) continue;
+          const rest = p.slice(prefix.length);
+          if (rest.includes('/')) continue;
+          seen.set(rest, e);
+        }
+        return [...seen].map(([name, entry]) => ({ name, entry }));
+      },
+      entry: (rel) => model[rel] ?? null,
+    },
+    materialize,
+  });
+
+  return { patcher, fsModule, originals, onDisk, model, materialize };
+}
+
+const file = (size = 10, mtimeMs = 1700): VaultEntry => ({ isDir: false, size, mtimeMs });
+const dir = (): VaultEntry => ({ isDir: true, size: 0, mtimeMs: 0 });
+
+describe('FsModulePatcher', () => {
+  it('materialises a remote note on readFileSync and returns its bytes', () => {
+    const h = harness({}, { 'note.md': file() });
+    expect(h.patcher.patch()).toBe(true);
+
+    const body = (h.fsModule.readFileSync as (p: string) => Buffer)(abs('note.md'));
+    expect(h.materialize).toHaveBeenCalledWith('note.md');
+    expect(body.toString()).toBe('content of note.md');
+  });
+
+  it('does not re-materialise a file that is already on disk', () => {
+    const h = harness({ [abs('note.md')]: 'already here' }, { 'note.md': file() });
+    h.patcher.patch();
+    const body = (h.fsModule.readFileSync as (p: string) => Buffer)(abs('note.md'));
+    expect(h.materialize).not.toHaveBeenCalled();
+    expect(body.toString()).toBe('already here');
+  });
+
+  it('still throws ENOENT when the file cannot be materialised', () => {
+    const h = harness({}, {});
+    h.patcher.patch();
+    expect(() => (h.fsModule.readFileSync as (p: string) => Buffer)(abs('ghost.md')))
+      .toThrow(/ENOENT/);
+  });
+
+  it('lists the vault through readdirSync without downloading anything', () => {
+    const h = harness(
+      { [abs('.obsidian/app.json')]: '{}' },
+      { 'note.md': file(), 'folder': dir(), 'folder/deep.md': file() },
+    );
+    h.patcher.patch();
+    const entries = (h.fsModule.readdirSync as (p: string) => string[])(ROOT);
+
+    expect(entries).toContain('note.md');
+    expect(entries).toContain('folder');
+    expect(entries, 'the real config dir disappeared from the listing').toContain('.obsidian');
+    expect(h.materialize, 'listing a directory fetched content').not.toHaveBeenCalled();
+  });
+
+  it('lists a folder that exists only in the model', () => {
+    const h = harness({}, { 'folder': dir(), 'folder/deep.md': file() });
+    h.patcher.patch();
+    expect((h.fsModule.readdirSync as (p: string) => string[])(abs('folder'))).toEqual(['deep.md']);
+  });
+
+  it('returns Dirent-shaped entries when asked for them', () => {
+    const h = harness({}, { 'note.md': file(), 'folder': dir() });
+    h.patcher.patch();
+    const readdir = h.fsModule.readdirSync as
+      (p: string, o: unknown) => { name: string; isDirectory(): boolean }[];
+    const byName = Object.fromEntries(
+      readdir(ROOT, { withFileTypes: true }).map(e => [e.name, e]),
+    );
+    expect(byName['note.md'].isDirectory()).toBe(false);
+    expect(byName['folder'].isDirectory()).toBe(true);
+  });
+
+  it('does not duplicate a name that is both materialised and in the model', () => {
+    const h = harness({ [abs('note.md')]: 'materialised' }, { 'note.md': file() });
+    h.patcher.patch();
+    const entries = (h.fsModule.readdirSync as (p: string) => string[])(ROOT);
+    expect(entries.filter(e => e === 'note.md')).toHaveLength(1);
+  });
+
+  it('answers existsSync and statSync from the model, with the real size', () => {
+    const h = harness({}, { 'note.md': file(4096, 1767225600000) });
+    h.patcher.patch();
+    expect((h.fsModule.existsSync as (p: string) => boolean)(abs('note.md'))).toBe(true);
+    const st = (h.fsModule.statSync as (p: string) =>
+      { size: number; isFile(): boolean; mtimeMs: number })(abs('note.md'));
+    expect(st.size).toBe(4096);
+    expect(st.mtimeMs).toBe(1767225600000);
+    expect(st.isFile()).toBe(true);
+    expect(h.materialize, 'stat fetched the file').not.toHaveBeenCalled();
+  });
+
+  it('leaves the config dir entirely to the real filesystem', () => {
+    const h = harness({}, { '.obsidian/app.json': file() });
+    h.patcher.patch();
+    expect((h.fsModule.existsSync as (p: string) => boolean)(abs('.obsidian/app.json'))).toBe(false);
+    expect(() => (h.fsModule.readFileSync as (p: string) => Buffer)(abs('.obsidian/app.json')))
+      .toThrow(/ENOENT/);
+    expect(h.materialize).not.toHaveBeenCalled();
+  });
+
+  it('never answers for a path outside the shadow root', () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    const outside = nodePath.resolve(ROOT, '..', 'somewhere-else', 'note.md');
+    expect((h.fsModule.existsSync as (p: string) => boolean)(outside)).toBe(false);
+    expect(() => (h.fsModule.readFileSync as (p: string) => Buffer)(outside)).toThrow(/ENOENT/);
+    expect(h.materialize, 'a path outside the vault was materialised').not.toHaveBeenCalled();
+  });
+
+  it('cannot be tricked out of the root and back in with ..', () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    const sneaky = nodePath.join(ROOT, '..', 'elsewhere', '..', 'vault-ish', 'note.md');
+    expect((h.fsModule.existsSync as (p: string) => boolean)(sneaky)).toBe(false);
+  });
+
+  it('restore() puts the original functions back', () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    expect(h.fsModule.readFileSync).not.toBe(h.originals.readFileSync);
+    h.patcher.restore();
+    for (const name of ['readFileSync', 'readdirSync', 'existsSync', 'statSync', 'lstatSync']) {
+      expect(h.fsModule[name], `fs.${name} was not restored`).toBe(h.originals[name]);
+    }
+    expect(h.patcher.isPatched()).toBe(false);
+  });
+
+  it('refuses to patch a module that is missing one of the functions', () => {
+    const h = harness();
+    delete h.fsModule.statSync;
+    expect(h.patcher.patch()).toBe(false);
+    expect(h.fsModule.readFileSync, 'a partial patch was left behind').toBe(h.originals.readFileSync);
+  });
+});


### PR DESCRIPTION
The last piece of #429's read side, built to the constraint that **the remote vault is never cloned**.

## The problem

A plugin that lists or reads notes with `fs` instead of the vault API saw an empty vault. The note tree is virtual, so `readdirSync(basePath)` returned the config dir and nothing else, and `readFileSync` on a note the user was looking at threw ENOENT.

## The approach

`FsModulePatcher` takes over five read functions on the shared `require('fs')` object — the same one plugins get — and answers from what already exists:

| call | source | cost |
| --- | --- | --- |
| `readdirSync`, `statSync`, `lstatSync`, `existsSync` | `vault.fileMap` (the background indexer already holds the whole remote tree) | **no download at all** |
| `readFileSync` | `SftpDataAdapter.materializeSync` — one file, on demand | one fetch, inside the cache budget |

So names and metadata are free, and content is fetched **only when something actually reads it**. That read *is* the request. Over the budget nothing is fetched and the caller gets the same ENOENT as before. The tree is still not mirrored — a local clone is exactly what this design avoids.

Writes are not patched: they already land on disk, where the write-back watcher pushes them.

## Scope discipline

`fs` is shared with Obsidian itself and every other plugin, so we answer **only** for paths that

1. resolve under the shadow vault root,
2. sit outside the config dir (real on disk, owned by the config write-through), and
3. do not already exist on disk.

Everything else runs the original, untouched, first. `restore()` puts all five functions back on disconnect. Tested: the config dir stays with the real filesystem, a path outside the root is never answered for, `..` cannot walk out and back in, and a partial patch is never left behind.

## The limits, now stated instead of implied

- a plugin that destructured `const { readFileSync } = require('fs')` at module scope captured the original — unreachable from here;
- **a subprocess has its own `fs`.** Claude Code, `git`, `ripgrep` and external editors see only what is physically on disk. Point them at specific files — the path from `getFullPath` is real by the time you hold it.

Settings → Advanced: *Let plugins read the vault with filesystem calls* (default on).

## E2E

Targets the last two reds in `e2e/fs-visibility.spec.ts`:

- `a note that exists on the REMOTE is readable via raw fs under basePath`
- `a plugin reading the vault via fs.readdirSync(basePath) sees the vault's notes`

With #481 and #483 already on `next`, that would make the whole spec green except by-design gaps. The bridge-probe spec merged in #470 reports whether the synchronous vehicle really is available in Obsidian's renderer — if it is not, `readFileSync` degrades to today's ENOENT rather than misbehaving.

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning) and `vitest run` (85 files, 1306 tests) green locally. 13 new unit tests.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)