### PR TITLE
feat(adapter): extend the fs patch to fs.promises (#429)

### DIFF
--- a/docs/en/user-guide/plugin-compatibility.md
+++ b/docs/en/user-guide/plugin-compatibility.md
@@ -146,9 +146,12 @@ Things that aren't a specific plugin but trip plugins in general:
     pushed. The whole behaviour is switchable: *Push out-of-band file
     writes to the remote*.
   - **Reads work from inside Obsidian, on demand.** `readFileSync`,
-    `readdirSync`, `existsSync`, `statSync` and `lstatSync` are taken
-    over *for paths under the vault folder only* — the config dir and
-    everything outside the vault run the stock function untouched.
+    `readdirSync`, `existsSync`, `statSync` and `lstatSync` — plus the
+    promise forms `fs.promises.readFile / readdir / stat / lstat /
+    access`, which is the same object `require('fs/promises')` returns —
+    are taken over *for paths under the vault folder only*; the config
+    dir and everything outside the vault run the stock function
+    untouched. Callback-style async `fs` is not patched.
     Names and sizes are answered from the vault model, so listing or
     stat-ing the vault costs **no download at all**, and a file's
     content is fetched only when something actually reads it.

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.8",
+  "version": "1.1.8-beta.9",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.8",
+  "version": "1.1.8-beta.9",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.8",
+  "version": "1.1.8-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.8",
+      "version": "1.1.8-beta.9",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.8",
+  "version": "1.1.8-beta.9",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/FsModulePatcher.ts
+++ b/plugin/src/adapter/FsModulePatcher.ts
@@ -36,10 +36,27 @@ export interface FsModulePatcherDeps {
    * caller gets the real filesystem's answer.
    */
   materialize(rel: string): boolean;
+  /**
+   * Same, for the promise-based surface, where blocking is neither
+   * needed nor wanted: it can go through the ordinary async read path
+   * instead of the synchronous bridge fetch.
+   */
+  materializeAsync(rel: string): Promise<boolean>;
 }
 
 /** The functions we take over. Everything else stays stock. */
 const PATCHED = ['readFileSync', 'readdirSync', 'existsSync', 'statSync', 'lstatSync'] as const;
+
+/**
+ * The promise-based equivalents. `require('fs/promises')` and
+ * `fs.promises` are the same object in Node, so patching it once covers
+ * both spellings — and it is the surface most plugins written in the
+ * last few years actually use.
+ */
+const PATCHED_PROMISES = ['readFile', 'readdir', 'stat', 'lstat', 'access'] as const;
+
+/** `fs.constants.W_OK`. An access check for writability is never answered from the model. */
+const W_OK = 2;
 
 /**
  * Makes the remote vault visible to plugins that use Node's `fs`
@@ -79,6 +96,7 @@ const PATCHED = ['readFileSync', 'readdirSync', 'existsSync', 'statSync', 'lstat
  */
 export class FsModulePatcher {
   private readonly originals = new Map<string, unknown>();
+  private readonly promiseOriginals = new Map<string, unknown>();
   private patched = false;
 
   constructor(private readonly deps: FsModulePatcherDeps) {}
@@ -104,6 +122,7 @@ export class FsModulePatcher {
       mod.statSync = this.makeStatSync('statSync');
       mod.lstatSync = this.makeStatSync('lstatSync');
       this.patched = true;
+      this.patchPromises();
       logger.info(`FsModulePatcher: patched fs.[${PATCHED.join(', ')}] for the shadow vault root`);
       return true;
     } catch (e) {
@@ -119,7 +138,101 @@ export class FsModulePatcher {
       try { mod[name] = fn; } catch { /* best effort */ }
     }
     this.originals.clear();
+    const promises = mod.promises as Record<string, unknown> | undefined;
+    if (promises) {
+      for (const [name, fn] of this.promiseOriginals) {
+        try { promises[name] = fn; } catch { /* best effort */ }
+      }
+    }
+    this.promiseOriginals.clear();
     this.patched = false;
+  }
+
+  /**
+   * Take over `fs.promises` too. Best-effort and separate from the sync
+   * patch: a build that hides `fs.promises` (or changes its shape) must
+   * cost us the async surface, not the whole feature.
+   */
+  private patchPromises(): void {
+    const promises = this.deps.fsModule.promises as Record<string, unknown> | undefined;
+    if (!promises || PATCHED_PROMISES.some(n => typeof promises[n] !== 'function')) {
+      logger.info('FsModulePatcher: fs.promises is not in the expected shape — sync surface only');
+      return;
+    }
+    for (const name of PATCHED_PROMISES) this.promiseOriginals.set(name, promises[name]);
+    promises.readFile = this.makeReadFilePromise();
+    promises.readdir = this.makeReaddirPromise();
+    promises.stat = this.makeStatPromise('stat');
+    promises.lstat = this.makeStatPromise('lstat');
+    promises.access = this.makeAccessPromise();
+    logger.info(`FsModulePatcher: patched fs.promises.[${PATCHED_PROMISES.join(', ')}]`);
+  }
+
+  private promiseOrig<T>(name: string): T {
+    return this.promiseOriginals.get(name) as T;
+  }
+
+  private makeReadFilePromise() {
+    const original = this.promiseOrig<(...a: unknown[]) => Promise<unknown>>('readFile');
+    return async (target: unknown, ...rest: unknown[]): Promise<unknown> => {
+      const rel = this.toVaultRel(target);
+      if (rel !== null && rel !== '' && !this.existsOnDisk(target)) {
+        try {
+          await this.deps.materializeAsync(rel);
+        } catch (e) {
+          logger.info(`FsModulePatcher: materialise "${rel}" failed (${errorMessage(e)})`);
+        }
+      }
+      return original(target, ...rest);
+    };
+  }
+
+  private makeReaddirPromise() {
+    const original = this.promiseOrig<(...a: unknown[]) => Promise<unknown>>('readdir');
+    return async (target: unknown, ...rest: unknown[]): Promise<unknown> => {
+      const rel = this.toVaultRel(target);
+      if (rel === null) return original(target, ...rest);
+      const modelChildren = this.deps.tree.children(rel);
+      if (!modelChildren) return original(target, ...rest);
+      let real: unknown[] = [];
+      try {
+        real = await original(target, ...rest) as unknown[];
+      } catch {
+        real = [];                     // virtual-only directory
+      }
+      return mergeListing(real, modelChildren, wantsFileTypes(rest[0]));
+    };
+  }
+
+  private makeStatPromise(name: 'stat' | 'lstat') {
+    const original = this.promiseOrig<(...a: unknown[]) => Promise<unknown>>(name);
+    return async (target: unknown, ...rest: unknown[]): Promise<unknown> => {
+      if (this.existsOnDisk(target)) return original(target, ...rest);
+      const rel = this.toVaultRel(target);
+      if (rel === null || rel === '') return original(target, ...rest);
+      const entry = this.deps.tree.entry(rel);
+      if (!entry) return original(target, ...rest);
+      return makeStats(entry);
+    };
+  }
+
+  private makeAccessPromise() {
+    const original = this.promiseOrig<(...a: unknown[]) => Promise<unknown>>('access');
+    return async (target: unknown, ...rest: unknown[]): Promise<unknown> => {
+      try {
+        return await original(target, ...rest);
+      } catch (e) {
+        // Readability can be answered from the model; writability cannot
+        // — the file is not there, and claiming otherwise would send a
+        // caller straight into a failing write.
+        const mode = typeof rest[0] === 'number' ? rest[0] : 0;
+        if ((mode & W_OK) !== 0) throw e;
+        const rel = this.toVaultRel(target);
+        if (rel === null) throw e;
+        if (rel === '' || this.deps.tree.entry(rel) !== null) return undefined;
+        throw e;
+      }
+    };
   }
 
   /**
@@ -178,17 +291,7 @@ export class FsModulePatcher {
       } catch {
         real = [];                     // virtual-only directory: the model is the answer
       }
-      const withFileTypes = Boolean(
-        rest[0] && typeof rest[0] === 'object'
-        && (rest[0] as { withFileTypes?: boolean }).withFileTypes,
-      );
-      const seen = new Set(
-        real.map(e => (typeof e === 'string' ? e : String((e as { name?: string }).name ?? ''))),
-      );
-      const extra = modelChildren
-        .filter(c => !seen.has(c.name))
-        .map(c => (withFileTypes ? makeDirent(c.name, c.entry.isDir) : c.name));
-      return [...real, ...extra];
+      return mergeListing(real, modelChildren, wantsFileTypes(rest[0]));
     };
   }
 
@@ -222,6 +325,33 @@ export class FsModulePatcher {
       return false;
     }
   }
+}
+
+/** True when the caller passed `{ withFileTypes: true }` to a readdir. */
+function wantsFileTypes(options: unknown): boolean {
+  return Boolean(
+    options && typeof options === 'object'
+    && (options as { withFileTypes?: boolean }).withFileTypes,
+  );
+}
+
+/**
+ * Real directory entries first, then the vault entries the disk does not
+ * have. A name present in both is listed once — the real one, since that
+ * is what a subsequent read would open.
+ */
+function mergeListing(
+  real: unknown[],
+  modelChildren: { name: string; entry: VaultEntry }[],
+  withFileTypes: boolean,
+): unknown[] {
+  const seen = new Set(
+    real.map(e => (typeof e === 'string' ? e : String((e as { name?: string }).name ?? ''))),
+  );
+  const extra = modelChildren
+    .filter(c => !seen.has(c.name))
+    .map(c => (withFileTypes ? makeDirent(c.name, c.entry.isDir) : c.name));
+  return [...real, ...extra];
 }
 
 /**

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -843,6 +843,23 @@ export default class RemoteSshPlugin extends Plugin {
               entry: (rel) => asEntry(this.app.vault.getAbstractFileByPath(rel)),
             },
             materialize: (rel) => da.materializeSync(rel),
+            // The promise surface can afford the ordinary async read
+            // path — no synchronous bridge fetch needed. The size is
+            // checked against the budget FIRST, from the model, so an
+            // over-budget file is never pulled just to be refused.
+            materializeAsync: async (rel) => {
+              const f = this.app.vault.getAbstractFileByPath(rel);
+              if (!(f instanceof TFile)) return false;
+              const cache = this.adapterMgr.materialized;
+              if (!cache || cache.disabled() || cache.tooBig(f.stat.size)) return false;
+              try {
+                await da.readBinary(rel);
+                return true;
+              } catch (e) {
+                logger.info(`fs.promises materialise "${rel}" failed: ${errorMessage(e)}`);
+                return false;
+              }
+            },
           });
           if (patcher.patch()) this.fsModulePatcher = patcher;
         }

--- a/plugin/tests/FsModulePatcher.test.ts
+++ b/plugin/tests/FsModulePatcher.test.ts
@@ -16,42 +16,56 @@ const abs = (rel: string) => nodePath.join(ROOT, ...rel.split('/'));
 function harness(onDisk: Record<string, string> = {}, model: Record<string, VaultEntry> = {}) {
   const enoent = (p: string) => Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
 
+  const readImpl = (p: string) => {
+    if (!(p in onDisk)) throw enoent(p);
+    return Buffer.from(onDisk[p]);
+  };
+  const readdirImpl = (p: string) => {
+    const prefix = p.endsWith(nodePath.sep) ? p : p + nodePath.sep;
+    const kids = new Set<string>();
+    let isDir = false;
+    for (const f of Object.keys(onDisk)) {
+      if (!f.startsWith(prefix)) continue;
+      isDir = true;
+      kids.add(f.slice(prefix.length).split(nodePath.sep)[0]);
+    }
+    if (!isDir) throw enoent(p);
+    return [...kids];
+  };
+  const statImpl = (p: string) => {
+    if (!(p in onDisk)) throw enoent(p);
+    return { size: onDisk[p].length, real: true, isFile: () => true, isDirectory: () => false };
+  };
+
+  const promises: Record<string, unknown> = {
+    readFile: vi.fn(async (p: string) => readImpl(p)),
+    readdir: vi.fn(async (p: string) => readdirImpl(p)),
+    stat: vi.fn(async (p: string) => statImpl(p)),
+    lstat: vi.fn(async (p: string) => statImpl(p)),
+    access: vi.fn(async (p: string) => { statImpl(p); }),
+  };
   const fsModule: Record<string, unknown> = {
-    readFileSync: vi.fn((p: string) => {
-      if (!(p in onDisk)) throw enoent(p);
-      return Buffer.from(onDisk[p]);
-    }),
-    readdirSync: vi.fn((p: string) => {
-      const prefix = p.endsWith(nodePath.sep) ? p : p + nodePath.sep;
-      const kids = new Set<string>();
-      let isDir = false;
-      for (const f of Object.keys(onDisk)) {
-        if (!f.startsWith(prefix)) continue;
-        isDir = true;
-        kids.add(f.slice(prefix.length).split(nodePath.sep)[0]);
-      }
-      if (!isDir) throw enoent(p);
-      return [...kids];
-    }),
+    readFileSync: vi.fn(readImpl),
+    readdirSync: vi.fn(readdirImpl),
     existsSync: vi.fn((p: string) => p in onDisk
       || Object.keys(onDisk).some(f => f.startsWith(p + nodePath.sep))),
-    statSync: vi.fn((p: string) => {
-      if (!(p in onDisk)) throw enoent(p);
-      return { size: onDisk[p].length, real: true, isFile: () => true, isDirectory: () => false };
-    }),
-    lstatSync: vi.fn((p: string) => {
-      if (!(p in onDisk)) throw enoent(p);
-      return { size: onDisk[p].length, real: true, isFile: () => true, isDirectory: () => false };
-    }),
+    statSync: vi.fn(statImpl),
+    lstatSync: vi.fn(statImpl),
+    promises,
   };
   const originals = { ...fsModule };
+  const promiseOriginals = { ...promises };
 
-  const materialize = vi.fn((rel: string) => {
+  // Kept as a plain function so the two spies stay independent: the
+  // async surface must not be seen calling the blocking one.
+  const doMaterialize = (rel: string) => {
     const entry = model[rel];
     if (!entry || entry.isDir) return false;
     onDisk[abs(rel)] = `content of ${rel}`;
     return true;
-  });
+  };
+  const materialize = vi.fn(doMaterialize);
+  const materializeAsync = vi.fn(async (rel: string) => doMaterialize(rel));
 
   const patcher = new FsModulePatcher({
     fsModule,
@@ -74,9 +88,13 @@ function harness(onDisk: Record<string, string> = {}, model: Record<string, Vaul
       entry: (rel) => model[rel] ?? null,
     },
     materialize,
+    materializeAsync,
   });
 
-  return { patcher, fsModule, originals, onDisk, model, materialize };
+  return {
+    patcher, fsModule, promises, originals, promiseOriginals,
+    onDisk, model, materialize, materializeAsync,
+  };
 }
 
 const file = (size = 10, mtimeMs = 1700): VaultEntry => ({ isDir: false, size, mtimeMs });
@@ -194,10 +212,93 @@ describe('FsModulePatcher', () => {
     expect(h.patcher.isPatched()).toBe(false);
   });
 
+  it('restore() puts the promise surface back too', () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    expect(h.promises.readFile).not.toBe(h.promiseOriginals.readFile);
+    h.patcher.restore();
+    for (const name of ['readFile', 'readdir', 'stat', 'lstat', 'access']) {
+      expect(h.promises[name], `fs.promises.${name} was not restored`).toBe(h.promiseOriginals[name]);
+    }
+  });
+
   it('refuses to patch a module that is missing one of the functions', () => {
     const h = harness();
     delete h.fsModule.statSync;
     expect(h.patcher.patch()).toBe(false);
     expect(h.fsModule.readFileSync, 'a partial patch was left behind').toBe(h.originals.readFileSync);
+  });
+});
+
+/**
+ * The promise surface is what most plugins written in the last few
+ * years actually use, and `require('fs/promises')` is the same object,
+ * so patching it once covers both spellings.
+ */
+describe('FsModulePatcher — fs.promises', () => {
+  const readFile = (h: ReturnType<typeof harness>) =>
+    h.promises.readFile as (p: string) => Promise<Buffer>;
+
+  it('materialises a remote note on readFile and returns its bytes', async () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    const body = await readFile(h)(abs('note.md'));
+    expect(h.materializeAsync).toHaveBeenCalledWith('note.md');
+    expect(h.materialize, 'the async path used the blocking fetch').not.toHaveBeenCalled();
+    expect(body.toString()).toBe('content of note.md');
+  });
+
+  it('still rejects with ENOENT when the file cannot be materialised', async () => {
+    const h = harness({}, {});
+    h.patcher.patch();
+    await expect(readFile(h)(abs('ghost.md'))).rejects.toThrow(/ENOENT/);
+  });
+
+  it('lists the vault through readdir without downloading anything', async () => {
+    const h = harness({}, { 'note.md': file(), 'folder': dir() });
+    h.patcher.patch();
+    const entries = await (h.promises.readdir as (p: string) => Promise<string[]>)(ROOT);
+    expect(entries.sort()).toEqual(['folder', 'note.md']);
+    expect(h.materializeAsync, 'listing fetched content').not.toHaveBeenCalled();
+  });
+
+  it('answers stat from the model with the real size', async () => {
+    const h = harness({}, { 'note.md': file(2048, 1767225600000) });
+    h.patcher.patch();
+    const st = await (h.promises.stat as (p: string) => Promise<{ size: number; mtimeMs: number }>)(
+      abs('note.md'),
+    );
+    expect(st.size).toBe(2048);
+    expect(st.mtimeMs).toBe(1767225600000);
+    expect(h.materializeAsync).not.toHaveBeenCalled();
+  });
+
+  it('access resolves for readability but never claims writability', async () => {
+    const h = harness({}, { 'note.md': file() });
+    h.patcher.patch();
+    const access = h.promises.access as (p: string, mode?: number) => Promise<void>;
+    await expect(access(abs('note.md'))).resolves.toBeUndefined();
+    await expect(access(abs('note.md'), 4)).resolves.toBeUndefined();   // R_OK
+    await expect(
+      access(abs('note.md'), 2),                                        // W_OK
+      'claimed a file that is not on disk is writable',
+    ).rejects.toThrow(/ENOENT/);
+  });
+
+  it('leaves paths outside the vault and inside the config dir alone', async () => {
+    const h = harness({}, { 'note.md': file(), '.obsidian/app.json': file() });
+    h.patcher.patch();
+    await expect(readFile(h)(abs('.obsidian/app.json'))).rejects.toThrow(/ENOENT/);
+    await expect(readFile(h)(nodePath.resolve(ROOT, '..', 'other', 'note.md')))
+      .rejects.toThrow(/ENOENT/);
+    expect(h.materializeAsync).not.toHaveBeenCalled();
+  });
+
+  it('patches the sync surface even when fs.promises is missing', () => {
+    const h = harness({}, { 'note.md': file() });
+    delete h.fsModule.promises;
+    expect(h.patcher.patch()).toBe(true);
+    expect((h.fsModule.readFileSync as (p: string) => Buffer)(abs('note.md')).toString())
+      .toBe('content of note.md');
   });
 });


### PR DESCRIPTION
Follow-up to #485. The patch only covered the **synchronous** surface, so a plugin written any time in the last few years — `await fs.promises.readFile(...)`, or `require('fs/promises')`, which is literally the same object — still saw an empty vault.

## Same contract, different vehicle

| | source | cost |
| --- | --- | --- |
| `promises.readdir` / `stat` / `lstat` / `access` | `vault.fileMap` | **no download** |
| `promises.readFile` | ordinary async adapter read | one fetch, inside the budget |

Nothing on this path has to block, so materialisation goes through the normal async read instead of the synchronous bridge fetch. The size is checked against the budget **first, from the model**, so an over-budget file is never pulled just to be refused — the same "not downloaded at all" rule the sync path gets from its `Range` request.

## `access` needed thought

Readability can be answered from the model; **writability cannot**. A file that is not on disk is not writable, and saying otherwise would send the caller straight into a failing write. `W_OK` therefore always falls through to the real error.

## Blast radius

Patching promises is best-effort and **separate** from the sync patch: a build that hides or reshapes `fs.promises` costs us the async surface, not the whole feature (there is a test for exactly that). `restore()` puts both sets back on disconnect. Scope is unchanged — under the shadow root, outside the config dir, not already on disk.

Callback-style async `fs` stays unpatched; that is now stated in the docs rather than left to be discovered.

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning), `vitest run` (85 files, 1314 tests) green locally. 8 new unit tests, including "the async path must not use the blocking fetch" and "patches the sync surface even when fs.promises is missing".

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)