### PR TITLE
fix(adapter): keep the materialised cache out of the config tree

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.10",
+  "version": "1.1.8-beta.11",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.10",
+  "version": "1.1.8-beta.11",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.10",
+  "version": "1.1.8-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.10",
+      "version": "1.1.8-beta.11",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.10",
+  "version": "1.1.8-beta.11",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -179,6 +179,33 @@ export class SftpDataAdapter {
   }
 
   /**
+   * True for anything under the vault's config dir.
+   *
+   * The disk cache must never take ownership of that tree, and the
+   * reason is a bug this guard exists to prevent: `pullPluginBinaries`
+   * fetches `<configDir>/plugins/<id>/main.js` THROUGH this adapter, so
+   * the read-through below would file it in the cache ledger — and the
+   * ledger deletes what it owns on eviction and on disconnect. The next
+   * launch would then find the plugin gone and silently not load it.
+   *
+   * `<configDir>/**` already has an owner: `writeThroughConfig` on the
+   * way out, the bootstrap's pull/push on the way in. Both keep real
+   * files there on purpose.
+   */
+  private isConfigTree(normalizedPath: string): boolean {
+    const dir = this.pathMapper?.configDir;
+    if (!dir) return false;
+    const rel = normalizedPath.startsWith('/') ? normalizedPath.slice(1) : normalizedPath;
+    return rel === dir || rel.startsWith(`${dir}/`);
+  }
+
+  /** Read-through into the disk cache, minus the tree it must not own. */
+  private cacheOnRead(normalizedPath: string, buf: Buffer): void {
+    if (this.isConfigTree(normalizedPath)) return;
+    this.materializedCache?.put(normalizedPath, buf);
+  }
+
+  /**
    * Absolute path of a vault file on this device — and, unlike the
    * stock `FileSystemAdapter`, a path that has a real file behind it.
    *
@@ -217,10 +244,14 @@ export class SftpDataAdapter {
   materializeSync(normalizedPath: string): boolean {
     const cache = this.materializedCache;
     if (!cache || cache.disabled()) return false;
+    if (this.isConfigTree(normalizedPath)) {
+      // Never ours (see isConfigTree); answer from the real disk only.
+      return Boolean(this.shadowBasePath)
+        && fs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath));
+    }
     if (cache.has(normalizedPath)) return true;
-    // Already real on disk — the config tree, or a file somebody wrote.
-    // Checked before anything else so `getFullPath('.obsidian/…')`, which
-    // Obsidian itself calls throughout startup, costs one stat.
+    // Already real on disk — materialised earlier, or written by
+    // somebody. One stat, no network.
     if (this.shadowBasePath
       && fs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath))) {
       return true;
@@ -458,7 +489,7 @@ export class SftpDataAdapter {
 
   async read(normalizedPath: string): Promise<string> {
     const buf = await this.readBuffer(normalizedPath);
-    this.materializedCache?.put(normalizedPath, buf);
+    this.cacheOnRead(normalizedPath, buf);
     const text = buf.toString('utf8');
     // Snapshot the just-read content so a subsequent conflicting write
     // can show the user a real ancestor pane in the 3-way modal.
@@ -471,7 +502,7 @@ export class SftpDataAdapter {
 
   async readBinary(normalizedPath: string): Promise<ArrayBuffer> {
     const buf = await this.readBuffer(normalizedPath);
-    this.materializedCache?.put(normalizedPath, buf);
+    this.cacheOnRead(normalizedPath, buf);
     // Copy into a fresh ArrayBuffer so callers can't accidentally mutate
     // the cached Buffer's underlying memory through the returned view.
     const ab = new ArrayBuffer(buf.byteLength);

--- a/plugin/tests/SftpDataAdapter.test.ts
+++ b/plugin/tests/SftpDataAdapter.test.ts
@@ -1701,3 +1701,74 @@ describe('SftpDataAdapter — config write-through to the local shadow disk (#34
     await expect(fs.stat(victim)).rejects.toThrow();
   });
 });
+
+/**
+ * The disk cache must never take ownership of `<configDir>/**`.
+ *
+ * `pullPluginBinaries` fetches `<configDir>/plugins/<id>/main.js` THROUGH
+ * this adapter. When the read-through filed those bytes in the cache
+ * ledger, the ledger's own housekeeping — LRU eviction, and the wipe on
+ * disconnect — deleted the plugin from the shadow disk, and the next
+ * launch silently did not load it. Two e2e specs caught it as "the
+ * plugin was never staged" / "was never loaded".
+ */
+describe('SftpDataAdapter — the materialised cache and the config tree', () => {
+  const makeCache = () => {
+    const owned = new Set<string>();
+    return {
+      owned,
+      cache: {
+        put: (rel: string) => { owned.add(rel); return true; },
+        has: (rel: string) => owned.has(rel),
+        disabled: () => false,
+        isMirroredCopy: () => false,
+        forget: (rel: string) => { owned.delete(rel); },
+        clear: () => { owned.clear(); },
+        bytes: () => 0,
+        size: () => owned.size,
+        tooBig: () => false,
+      },
+    };
+  };
+
+  it('does not file a config-tree read in the cache ledger', async () => {
+    const fake = makeFakeClient({
+      files: {
+        '/srv/vault/.obsidian/plugins/some-plugin/main.js': { data: Buffer.from('module.exports={}'), mtime: 1 },
+        '/srv/vault/note.md': { data: Buffer.from('# note'), mtime: 1 },
+      },
+    });
+    const readCache = new ReadCache();
+    const dirCache = new DirCache();
+    const { owned, cache } = makeCache();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', readCache, dirCache, 'v',
+      new PathMapper('client-a', '.obsidian'),
+    );
+    adapter.setMaterializedCache(cache as never);
+
+    await adapter.read('.obsidian/plugins/some-plugin/main.js');
+    expect(
+      [...owned],
+      'a plugin binary entered the cache ledger — eviction or disconnect would delete it',
+    ).toEqual([]);
+
+    await adapter.read('note.md');
+    expect([...owned], 'an ordinary note should still be cached').toEqual(['note.md']);
+  });
+
+  it('materializeSync refuses config paths outright', () => {
+    const fake = makeFakeClient();
+    const { owned, cache } = makeCache();
+    const adapter = new SftpDataAdapter(
+      fake.client, '/srv/vault', new ReadCache(), new DirCache(), 'v',
+      new PathMapper('client-a', '.obsidian'),
+    );
+    adapter.setMaterializedCache(cache as never);
+
+    // No shadow base path is set, so the real-disk answer is "no" — the
+    // point is that it never reaches the cache either way.
+    expect(adapter.materializeSync('.obsidian/plugins/x/main.js')).toBe(false);
+    expect([...owned]).toEqual([]);
+  });
+});


### PR DESCRIPTION
Second bug from #483, found by E2E.

## What happened

`pullPluginBinaries` fetches `<configDir>/plugins/<id>/main.js` **through this adapter**, and the read-through I added filed whatever it read into the disk cache's ledger. That ledger deletes what it owns — on LRU eviction, and wholesale on disconnect — so the plugin binary that had just been staged onto the shadow disk was removed again, and the next launch quietly did not load the plugin.

Two E2E specs caught it from opposite ends:

```
fs-visibility  "the reproduction plugin was never staged onto the shadow disk from the remote"
vault-features "a Dataview-CLASS plugin sees the whole vault: 'e2e-dataview-probe' was never
                loaded (loaded: remote-ssh)"
```

## The fix

`<configDir>/**` already has an owner in both directions — `writeThroughConfig` outbound, the bootstrap's pull/push inbound — and both keep **real** files there on purpose. The cache now refuses that subtree entirely:

- the read-through in `read` / `readBinary` skips it;
- `materializeSync` answers from the real disk without touching the ledger.

Two regression tests: a config-tree read leaves the ledger empty (an ordinary note still caches), and `materializeSync` on a config path never files anything.

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning), `vitest run` (85 files, 1312 tests) green locally.

**No auto-merge on this one.** E2E is the check that matters and it is not required; merging on unit tests alone is what let the previous two bugs land.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)