### PR TITLE
ci(workflows): gate every open PR, not just PRs into main/next

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,14 @@
 name: CI
 
+# `pull_request` carries NO `branches:` filter on purpose. The gate
+# belongs wherever a PR is open, not only on the two release branches
+# — a PR into a long-lived feature track (`cli`, and any future one)
+# is exactly where an unreviewed regression can sit for weeks. Push
+# stays pinned to main/next: outside a PR there is nothing to gate.
 on:
   push:
     branches: [main, next]
   pull_request:
-    branches: [main, next]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -13,10 +13,15 @@ name: Commitlint
 # PRs whose commits already passed; running on every push to main
 # would be redundant and would re-fire on the merge commit which
 # has its own (also Conventional) format.
+#
+# Every PR, whatever its base — no `branches:` filter. A commit
+# landing on a feature track (`cli`) reaches `next` later carrying
+# whatever message it was written with, so catching the format there
+# is strictly earlier than catching it on the track's promotion PR.
+# This is also the first gate an outside contributor meets.
 
 on:
   pull_request:
-    branches: [main, next]
 
 concurrency:
   group: commitlint-${{ github.ref }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,13 +21,18 @@ name: E2E smoke (Playwright + Obsidian)
 
 on:
   pull_request:
-    # Both release branches. `next` is where features (and the
-    # connect-lifecycle / connect-failure specs) land first — gating
-    # it here is what stops a broken connect reaching stable again
-    # (1.0.49 shipped connect-broken because nothing exercised the
-    # real connect path on a next PR). Mark "Obsidian E2E smoke" as a
-    # required check on next in branch protection to make it binding.
-    branches: [main, next]
+    # No `branches:` filter — every open PR, whatever its base.
+    # `next` is where features (and the connect-lifecycle /
+    # connect-failure specs) land first, and gating there is what
+    # stops a broken connect reaching stable again (1.0.49 shipped
+    # connect-broken because nothing exercised the real connect path
+    # on a next PR). But a feature track like `cli` accumulates the
+    # same risk for weeks before it ever opens a PR into `next`, so
+    # restricting the gate to the release branches just delays the
+    # signal. Mark "Obsidian E2E smoke" as a required check on next
+    # in branch protection to make it binding.
+    #
+    # The paths filter stays: it is what keeps docs-only PRs free.
     paths:
       # Plugin or daemon source — anything that could change the
       # Obsidian-side behaviour the spec drives.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,11 +5,12 @@ name: Integration
 # startup) so it lives on its own workflow with no concurrency
 # group sharing — main CI keeps moving while this runs.
 
+# No `branches:` filter on `pull_request` — see ci.yml for the
+# rationale (gate every open PR, whatever its base).
 on:
   push:
     branches: [main, next]
   pull_request:
-    branches: [main, next]
 
 concurrency:
   group: integration-${{ github.ref }}

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -6,10 +6,12 @@ name: Cross-version test replay
 # it's actually broken (see `plugin/scripts/replay-prev-tests.mjs`
 # for the rationale).
 #
-# **Trigger:** PRs into `main` only — push-to-main is redundant
-# (already checked at PR time) and would just burn CI cycles. The
-# matching push-to-main run can be added later if signal stays
-# clean over a few weeks of operation.
+# **Trigger:** every open PR, whatever its base — no `branches:`
+# filter. The frozen contract is `origin/main`'s latest tag, which is
+# the same reference regardless of where the PR is headed, so the
+# check is just as meaningful on a feature-track PR as on a `next`
+# one. Push is deliberately absent: outside a PR there is nothing to
+# gate, and the merge commit was already checked at PR time.
 #
 # **Status:** advisory (`continue-on-error: true` on the job's
 # `Run replay` step so a regression surfaces in the PR's checks
@@ -17,7 +19,6 @@ name: Cross-version test replay
 # signal-to-noise ratio has been proven over real PR traffic.
 on:
   pull_request:
-    branches: [main, next]
 
 concurrency:
   group: replay-${{ github.ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,8 +28,10 @@ name: Security
 on:
   push:
     branches: [main, next]
+  # No `branches:` filter — see ci.yml. Scanners are already
+  # `continue-on-error`, so widening this adds visibility on feature-
+  # track PRs without adding a way to block the queue.
   pull_request:
-    branches: [main, next]
   schedule:
     - cron: '0 6 * * 1'
   workflow_dispatch:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -27,6 +27,13 @@ name: Version check
 # (`1.0.44-beta.10` > `1.0.44-beta.2`, `1.0.44` > `1.0.44-beta.N`) is
 # handled correctly.
 
+# This is the ONE workflow that keeps a `branches:` filter. Every
+# other gate runs on any open PR, but the rules below ARE the
+# two-channel release model — "beta shape on next, stable shape on
+# main, strictly greater than base". A feature track like `cli` is
+# not a release channel: its stacked PRs share one version on
+# purpose, so enforcing a bump per PR there would go red for
+# following the convention rather than for breaking it.
 on:
   pull_request:
     branches: [main, next]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,18 @@ npm run sshd:stop
 A working dev vault path can be configured via `REMOTE_SSH_DEV_VAULT`
 env var; `npm run build:full` then ships the plugin into that vault.
 
-The E2E suite also runs nightly via `.github/workflows/e2e.yml`
-(03:00 UTC / 12:00 JST). Trigger off-cycle from GitHub Actions →
-"E2E smoke (Playwright + Obsidian)" → "Run workflow".
+In CI, `.github/workflows/e2e.yml` runs the suite on every open PR
+that touches plugin/server/docker sources — whatever branch the PR is
+based on — plus weekly (Sundays 03:00 UTC / 12:00 JST) to catch
+environment drift. Trigger off-cycle from GitHub Actions → "E2E smoke
+(Playwright + Obsidian)" → "Run workflow".
+
+Note on bases: the CI gates (lint, type-check, tests, integration,
+E2E, replay, commitlint, security scans) run on **any** open PR, so a
+PR into a feature track such as `cli` is checked exactly like one into
+`next`. The single exception is `version-check.yml`, which encodes the
+`next`/`main` release model and therefore only runs on PRs into those
+two branches.
 
 ## Branch + commit convention
 

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.11",
+      "version": "1.1.8-beta.12",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
## Problem

Every workflow's `pull_request` trigger carried `branches: [main, next]`. A PR based on anything else was **not gated at all**.

#482 (lalate, fork → `cli`) is the concrete case — the entire check list on it:

```
label   pass   7s
```

That's it. `labeler.yml` ran only because it was the one workflow using `pull_request_target` with no branches filter. No lint, no type-check, no tests, no integration, no E2E, no commitlint, no security scan.

A long-lived feature track like `cli` therefore accumulates weeks of unchecked work and first meets CI on its promotion PR into `next` — the worst possible moment to find a regression, and the point where it is hardest to attribute.

## Change

Drop the `branches:` filter from `pull_request` in `ci`, `integration`, `security`, `e2e`, `replay`, `commitlint`. `docs.yml` already had none. The gate now follows the PR, not the base branch.

| workflow | `pull_request` before | after | `push` |
|---|---|---|---|
| `ci` | main, next | **any base** | main, next *(unchanged)* |
| `integration` | main, next | **any base** | main, next *(unchanged)* |
| `security` | main, next | **any base** | main, next *(unchanged)* |
| `e2e` | main, next (paths) | **any base** (paths kept) | — |
| `replay` | main, next | **any base** | — |
| `commitlint` | main, next | **any base** | — |
| `docs` | any (paths) | *unchanged* | main, next *(unchanged)* |
| `version-check` | main, next | **kept** — see below | — |
| `bench` / `release` / `sync-main-to-next` / `demo-capture` / `labeler` | — | *unchanged* | *unchanged* |

## Two deliberate non-changes

**No `push` trigger is added anywhere.** Outside a PR there is nothing to gate, and the merge commit was already checked at PR time. `bench.yml` in particular stays on `push: [main]` + nightly.

**`version-check.yml` keeps its filter.** Its rules *are* the two-channel release model — beta shape on `next`, stable shape on `main`, strictly greater than base. A feature track is not a release channel: #482's head and its `cli` base both sit at `1.2.0-beta.0` on purpose, so enforcing a per-PR bump there would go red for *following* the convention rather than for breaking it. The reasoning is now a comment in the file so it doesn't get "fixed" later.

## Verification

Triggers parsed back out of all 13 workflow files rather than eyeballed (`any` = no branches filter):

```
workflow               pull_request           pr_target    push
bench.yml              -                      -            main
ci.yml                 any                    -            main,next
commitlint.yml         any                    -            -
demo-capture.yml       -                      -            -
docs.yml               any [paths:2]          -            main,next [paths:2]
e2e.yml                any [paths:12]         -            -
integration.yml        any                    -            main,next
labeler.yml            -                      any          -
release.yml            -                      -            main,next
replay.yml             any                    -            -
security.yml           any                    -            main,next
sync-main-to-next.yml  -                      -            main
version-check.yml      main,next              -            -
```

No job or step bodies were touched — only `on:` blocks and comments.

## Expected fallout

- **#482** will start running the full suite once its workflows are approved (fork PR from a first-time contributor still needs the one-click "Approve and run"). Some of it may go red; that is the point of the PR.
- **#419** (`cli` → `next`) is unaffected — it was already gated.
- Pushes to `cli` now cost a full CI run per stacked PR. That is the intended trade.

## Also

`CONTRIBUTING.md` described the E2E suite as running nightly (it has been weekly + per-PR for a while) — corrected, and the base-branch rule above is now written where contributors will look for it.

Version: `1.1.8-beta.12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
