### PR TITLE
test(e2e): wait for the connect command to exist before driving it

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.13",
+  "version": "1.1.8-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -189,6 +189,51 @@ export async function driveConnectFlow(page: Page): Promise<void> {
   // The palette is not left untested: `smoke.spec.ts` drives it
   // directly, and the fallback below still runs whenever the command
   // registry is unreachable.
+  // Wait for the command to EXIST before trying to run it.
+  //
+  // This is what the old flow got wrong, and what the palette hid: a
+  // connect driven before `onload` finished registering commands has
+  // nothing to run. Through the palette that failure is SILENT — typing
+  // a command name that is not there still leaves some other suggestion
+  // highlighted, so Enter runs that instead, no shadow vault appears,
+  // and the error the spec eventually reports is "connect command
+  // likely never fired" with no hint as to why.
+  const registered = await page
+    .waitForFunction(
+      () => {
+        const registry = (window as unknown as {
+          app?: { commands?: { commands?: Record<string, unknown> } };
+        }).app?.commands?.commands;
+        return Boolean(registry)
+          && Object.keys(registry as Record<string, unknown>).some(k => k.endsWith('remote-ssh:connect'));
+      },
+      undefined,
+      { timeout: 30_000, polling: 250 },
+    )
+    .then(() => true)
+    .catch(() => false);
+
+  if (!registered) {
+    // Name which of the two things went wrong, with the evidence.
+    const diag = await page.evaluate(() => {
+      const w = window as unknown as {
+        app?: {
+          plugins?: { enabledPlugins?: Set<string>; plugins?: Record<string, unknown> };
+          commands?: { commands?: Record<string, unknown> };
+        };
+      };
+      return {
+        loadedPlugins: Object.keys(w.app?.plugins?.plugins ?? {}),
+        enabledPlugins: [...(w.app?.plugins?.enabledPlugins ?? [])],
+        commandCount: Object.keys(w.app?.commands?.commands ?? {}).length,
+      };
+    }).catch(() => null);
+    throw new Error(
+      'driveConnectFlow: remote-ssh:connect never appeared in Obsidian\'s command registry '
+      + `within 30s — the plugin did not load. ${JSON.stringify(diag)}`,
+    );
+  }
+
   const firedId = await page.evaluate(() => {
     const app = (window as unknown as {
       app?: {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.13",
+  "version": "1.1.8-beta.14",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.13",
+  "version": "1.1.8-beta.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.13",
+      "version": "1.1.8-beta.14",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.13",
+  "version": "1.1.8-beta.14",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #492.

## What #492 revealed

Removing the keyboard from the connect path took the `palette never opened` failures with it — and exposed what they had been mixed in with. Every spec on #492's run now fails with:

```
findShadowVaultPath: no shadow vault entry appeared in obsidian.json within 15000 ms
  — connect command likely never fired
```

Same underlying fault, no longer disguised: **a connect driven before `onload` finished registering commands has nothing to run.**

Through the palette that is invisible. Typing a command name that is not registered still leaves *some other* suggestion highlighted, so Enter runs that one instead. No shadow vault appears, and the spec reports "connect command likely never fired" with no way to distinguish "the plugin was not ready" from "connect is broken".

## What this does

Wait for `remote-ssh:connect` to appear in the command registry (30 s, polled at 250 ms) before firing anything. When it is already there — the normal case — the check returns on the first poll and costs nothing.

If it never appears, the plugin did not load, and that is now what the error says:

```
driveConnectFlow: remote-ssh:connect never appeared in Obsidian's command registry within 30s
  — the plugin did not load.
  {"loadedPlugins":[...],"enabledPlugins":[...],"commandCount":123}
```

So the next red is diagnosable from the message instead of an artifact download.

## Note on the other reds in #492's run

Two of them are real signal that the run finally surfaced, and they are **not** addressed here — they belong to the #429 contract, and I will take them next:

- `readFileSync` of a remote-only note → ENOENT. This is now by design (#491: the synchronous surface serves only bytes already in the read cache), so the spec's assertion has to be re-stated as the contract we can actually keep.
- `getFullPath('remote_demo1.md')` → not the note that is on the remote. Same root: no synchronous fetch, so a never-read note has nothing to point at.

## Verification

`tsc --noEmit`, `npm run lint` (1 pre-existing warning) green locally; no unit-test surface changes. The check that matters is the E2E run on this branch.

No auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)