### PR TITLE
test(e2e): assert the fixture's preconditions, and say where connect stopped

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.16",
+  "version": "1.1.8-beta.17",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -338,10 +338,51 @@ export async function connectAndWaitForShadowVault(
       lastErr = e; // not registered yet — re-drive the connect command
     }
   }
+  // Three very different faults share this symptom: the fixture is not set
+  // up, the harness never reached the button, or connect genuinely failed.
+  // Attach the evidence that separates them — the plugin's own log says how
+  // far connect got, the visible modal buttons say whether the click landed.
+  const evidence = await collectConnectEvidence(page, scaffoldVaultPath);
   throw new Error(
     `connectAndWaitForShadowVault: no shadow vault after ${attempts} connect ` +
-    `attempt(s) in ${timeoutMs}ms — ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`,
+    `attempt(s) in ${timeoutMs}ms — ${lastErr instanceof Error ? lastErr.message : String(lastErr)}\n` +
+    `  plugin log (tail): ${evidence.logTail}\n` +
+    `  visible modal buttons: ${evidence.modalButtons}`,
   );
+}
+
+/**
+ * What the failure message needs in order to be diagnosable: how far the
+ * plugin itself got, and what the modal was showing when we gave up. Both
+ * are best-effort — a diagnostic that throws would replace the real error.
+ */
+async function collectConnectEvidence(
+  page: Page,
+  scaffoldVaultPath: string,
+): Promise<{ logTail: string; modalButtons: string }> {
+  let logTail = '<no plugin log>';
+  try {
+    const logPath = path.join(
+      scaffoldVaultPath, '.obsidian', 'plugins', 'remote-ssh', 'console.log',
+    );
+    if (fs.existsSync(logPath)) {
+      logTail = fs.readFileSync(logPath, 'utf8').trimEnd().split('\n').slice(-12).join(' | ');
+    }
+  } catch (e) {
+    logTail = `<unreadable: ${String(e)}>`;
+  }
+
+  let modalButtons = '<none>';
+  try {
+    const labels = await page.evaluate(() =>
+      [...document.querySelectorAll('.modal button')]
+        .map(b => (b.textContent ?? '').trim())
+        .filter(Boolean));
+    if (labels.length) modalButtons = labels.join(' / ');
+  } catch (e) {
+    modalButtons = `<unreadable: ${String(e)}>`;
+  }
+  return { logTail, modalButtons };
 }
 
 /**

--- a/plugin/e2e/helpers/vault-scaffold.ts
+++ b/plugin/e2e/helpers/vault-scaffold.ts
@@ -103,6 +103,33 @@ export function scaffoldTestVault(opts: ScaffoldOptions = {}): ScaffoldResult {
     pluginRoot, '..', 'docker', 'keys', 'id_test',
   );
 
+  // Assert what connect DEPENDS ON, before anything drives it.
+  //
+  // A missing key or an unstaged daemon produces exactly the same
+  // symptom as a broken product — "no shadow vault entry appeared,
+  // connect command likely never fired" — and that collapse cost three
+  // rounds of chasing the wrong cause. These throw as what they are:
+  // the fixture is not set up, not the product is broken.
+  if (!fs.existsSync(privateKeyPath)) {
+    throw new Error(
+      `fixture missing: the test private key is not at ${privateKeyPath}. ` +
+      'Connect cannot authenticate, and every spec would report it as a product failure. ' +
+      'Generate the docker fixture keys (docker/keys/id_test) before running the suite.',
+    );
+  }
+  if (transport === 'rpc') {
+    const stagedBinDir = path.join(pluginDir, 'server-bin');
+    const staged = fs.existsSync(stagedBinDir) ? fs.readdirSync(stagedBinDir) : [];
+    if (staged.length === 0) {
+      throw new Error(
+        `fixture missing: no daemon binary staged into ${stagedBinDir} (source: ` +
+        `${path.join(pluginRoot, 'server-bin')}). The 'rpc' transport needs one to ` +
+        'connect at all — build the server (go build ./server/...) or scaffold with ' +
+        "transport: 'sftp'.",
+      );
+    }
+  }
+
   // Write data.json with a pre-configured test profile
   const dataJson = {
     profiles: [

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.16",
+  "version": "1.1.8-beta.17",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.16",
+  "version": "1.1.8-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.16",
+      "version": "1.1.8-beta.17",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.16",
+  "version": "1.1.8-beta.17",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #495.

## The problem this fixes is diagnostic, not behavioural

Three different faults have been producing **one message**:

```
no shadow vault entry appeared in obsidian.json — connect command likely never fired
```

That collapse cost three rounds of fixing the wrong thing. The text stayed identical while its cause changed underneath: the palette was not interactive (#492), then the command might not have been registered (#493), then `ConnectModal`'s second pane was never clicked (#495). Each fix was right; none of them could be *known* to be right from the message.

## What now names itself

**The scaffold asserts what connect depends on** and throws as a fixture fault, not a product failure:

- the test private key exists — without it, auth cannot succeed;
- for the default `rpc` transport, a daemon binary was actually staged — without it there is nothing to connect to.

Either now reads `fixture missing: …` with the path and the fix, instead of surfacing as "connect is broken" in fifteen specs.

**`connectAndWaitForShadowVault` attaches the evidence** that separates the remaining two causes:

```
  plugin log (tail): <last 12 lines — how far connect actually got>
  visible modal buttons: <labels — whether the click landed>
```

Both are best-effort: a diagnostic that throws would replace the error it exists to explain.

## Why this instead of another guess

The last E2E run still fails connect nearly everywhere, and I have now twice mistaken this message for a cause I could name. The honest next step is to make the run answer the question rather than to patch a fourth hypothesis into it.

## Verification

`tsc --noEmit` green locally. No unit-test surface. No auto-merge.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)