### PR TITLE
test(e2e): require a receipt that connect actually ran

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.17",
+  "version": "1.1.8-beta.18",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -251,7 +251,16 @@ export async function driveConnectFlow(page: Page): Promise<void> {
     return registry.executeCommandById(id) ? id : null;
   });
 
-  if (firedId === null) {
+  // Fire-and-VERIFY. `executeCommandById` returning true means Obsidian found
+  // a command and called it — not that our plugin reacted. The last run
+  // proved the difference: the command reported success, the plugin's log
+  // stopped at "loaded", and no modal existed. So require the receipt that
+  // `promptConnect` actually ran (ConnectModal is the first thing it does),
+  // and fall through to the keyboard when it does not come.
+  const reacted = firedId !== null
+    && await page.locator('.modal').first().isVisible({ timeout: 3_000 }).catch(() => false);
+
+  if (!reacted) {
     let opened = false;
     for (let i = 0; i < 5 && !opened; i++) {
       await page.keyboard.press('Control+P');

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.17",
+  "version": "1.1.8-beta.18",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.17",
+  "version": "1.1.8-beta.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.17",
+      "version": "1.1.8-beta.18",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.17",
+  "version": "1.1.8-beta.18",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #498, and acting on what #498's diagnostics reported.

## The evidence

```
plugin log (tail): {"msg":"Plugin remote-ssh v1.1.8-beta.17 loaded"}   ← the only line
visible modal buttons: <none>
```

No `fixture missing:` — so the key and the daemon are fine. The plugin loaded. And then nothing: no `promptConnect`, no handshake, no modal.

So `executeCommandById` returning `true` meant only that **Obsidian found a command and called it** — not that our plugin reacted. The fire was never a receipt.

## The change

`promptConnect`'s first act is to open `ConnectModal`, so a modal appearing within 3 s is proof the plugin reacted. `driveConnectFlow` now requires that receipt, and falls through to the keyboard path when it does not come — instead of reporting a success it cannot back up.

This also makes the remaining failure honest: if neither route produces a modal, the error is about the plugin never reacting, which is where the next round of evidence should point.

## Verification

`tsc --noEmit` green locally. No auto-merge.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)