### PR TITLE
fix(e2e): the Settings window has no .modal-container

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.20",
+  "version": "1.1.8-beta.21",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -11,6 +11,32 @@ const CDP_PORT = Number(process.env.CDP_PORT ?? '9222');
 const PALETTE_INPUT = '.prompt input, input.prompt-input, .suggestion-container input';
 
 /**
+ * Obsidian's Settings UI, in either shape it takes.
+ *
+ * In its own window (1.13.4 under Xvfb) Settings is NOT wrapped in a
+ * `.modal-container` — run 30775609866's inventory reads
+ * `modals:0` while `.modal button` still returns
+ * `["Turn on and reload","Browse","Check for updates"]`. So `.modal-container`,
+ * which every sweep and assertion here anchored on, matches nothing in the
+ * window Settings is actually in: `dismissBlockingModals` called the workspace
+ * clean and smoke 2 reported "Settings did not open in any Obsidian window"
+ * with the dialog plainly up. The tab rail is the stable anchor.
+ */
+const SETTINGS_ROOT = '.vertical-tab-header, .modal-container .vertical-tab-nav-item';
+
+/**
+ * ConnectModal specifically — NOT any `.modal`.
+ *
+ * The Settings window carries its own `.modal`, so a bare `.modal` receipt is
+ * satisfied by a window ConnectModal was never in, and the button click that
+ * follows then finds nothing to click. Both panes are covered: the auth pane
+ * always renders `.remote-ssh-connect-button` (`ConnectModal.renderConnectButton`)
+ * and the multi-profile picker renders the "Connect to remote vault" heading.
+ */
+const CONNECT_MODAL =
+  '.modal .remote-ssh-connect-button, .modal h2:has-text("Connect to remote vault")';
+
+/**
  * Whether `locator` becomes visible within `timeoutMs`.
  *
  * NOT `locator.isVisible({ timeout })`: Playwright ignores that option and
@@ -161,6 +187,11 @@ async function describePageList(pages: Page[], driven?: Page): Promise<string> {
           title: document.title,
           size: `${window.innerWidth}x${window.innerHeight}`,
           modals: document.querySelectorAll('.modal-container').length,
+          // `.modal` separately from `.modal-container`: the standalone
+          // Settings window has the former and not the latter, and reading
+          // only the container is what made the sweep call it clean.
+          bareModals: document.querySelectorAll('.modal').length,
+          settingsTabs: document.querySelectorAll('.vertical-tab-nav-item').length,
           modalButtons: Array.from(document.querySelectorAll('.modal button'))
             .map((b) => (b.textContent ?? '').trim())
             .filter(Boolean),
@@ -365,8 +396,12 @@ export async function driveConnectFlow(page: Page): Promise<void> {
   // used `isVisible({ timeout })`, which Playwright documents as ignoring the
   // timeout — the check was instantaneous, so even in the right window it
   // would have raced ConnectModal's first paint.
+  //
+  // The receipt is ConnectModal, not `.modal`: the Settings window has one of
+  // those too, so a bare `.modal` would accept a window ConnectModal is not in
+  // and the click below would find nothing.
   const modalPage = firedId !== null
-    ? await findPageWith(page, '.modal', 5_000)
+    ? await findPageWith(page, CONNECT_MODAL, 5_000)
     : null;
 
   let flowPage = modalPage;
@@ -397,7 +432,7 @@ export async function driveConnectFlow(page: Page): Promise<void> {
     // Let the fuzzy filter settle on the matching command.
     await palettePage.waitForTimeout(600);
     await palettePage.keyboard.press('Enter');
-    flowPage = await findPageWith(page, '.modal', 5_000);
+    flowPage = await findPageWith(page, CONNECT_MODAL, 5_000);
   }
 
   // Click Connect, in whichever window ConnectModal rendered in.
@@ -862,31 +897,47 @@ export async function dismissBlockingModals(
 
 /**
  * Ask every window to close Obsidian's Settings dialog, and report how many
- * did. `app.setting.close()` is a no-op when Settings is not open, so this is
- * safe to call unconditionally on a clean workspace.
+ * did.
+ *
+ * Detection is on the settings TAB RAIL, not `.modal-container`. In the window
+ * Obsidian gives Settings there is no `.modal-container` at all, so the old
+ * probe answered "not open" about the one window it was open in — which is why
+ * the sweep reported a clean workspace and left it up.
+ *
+ * Escape is the fallback for exactly that window: it may have no `app` global
+ * to call `app.setting.close()` on (its inventory line reads `vault:null`), and
+ * a CDP key event is delivered to the target page without needing OS focus.
  */
 async function closeSettingsEverywhere(page: Page): Promise<number> {
   let closed = 0;
   for (const p of contextPages(page)) {
-    const didClose = await p
-      .evaluate(() => {
+    const wasOpen = await p
+      .evaluate((sel) => {
+        const open = Boolean(document.querySelector(sel));
         const setting = (window as unknown as {
-          app?: { setting?: { close?: () => void; containerEl?: HTMLElement } };
+          app?: { setting?: { close?: () => void } };
         }).app?.setting;
-        if (!setting?.close) return false;
-        const wasOpen = Boolean(document.querySelector('.modal-container .vertical-tab-header'));
-        setting.close();
-        return wasOpen;
-      })
+        setting?.close?.();
+        return open;
+      }, SETTINGS_ROOT)
       .catch(() => false);
-    if (didClose) {
-      console.warn(
-        '[e2e] dismissBlockingModals: closed Obsidian\'s Settings dialog (auto-opened by ' +
-        'the trust-dismiss path). Left up, it owns every later modal — that is how ' +
-        'ConnectModal ended up in a window no locator was looking at.',
-      );
-      closed++;
+    if (!wasOpen) continue;
+
+    // Still there? It is the standalone Settings window with no `app` to ask.
+    if (await isVisibleWithin(p.locator(SETTINGS_ROOT).first(), 1_000)) {
+      await p.keyboard.press('Escape').catch(() => { /* best effort */ });
+      await p
+        .locator(SETTINGS_ROOT)
+        .first()
+        .waitFor({ state: 'hidden', timeout: 3_000 })
+        .catch(() => { /* reported by the inventory if it matters */ });
     }
+    console.warn(
+      '[e2e] dismissBlockingModals: closed Obsidian\'s Settings dialog (auto-opened by ' +
+      'the trust-dismiss path). Left up, it owns every later modal — that is how ' +
+      'ConnectModal ended up in a window no locator was looking at.',
+    );
+    closed++;
   }
   return closed;
 }

--- a/plugin/e2e/smoke.spec.ts
+++ b/plugin/e2e/smoke.spec.ts
@@ -58,22 +58,27 @@ test.describe('Remote SSH E2E smoke', () => {
     // Assert it is reachable, in whichever window Obsidian put it; that
     // is what "accessible" means to a user. Requiring it in one specific
     // page asserted a fact about the harness, not about the product.
+    //
+    // Anchor on the tab itself, not `.modal-container`. In its own window
+    // Settings has no `.modal-container` — run 30775609866's inventory reads
+    // `modals:0` on the page titled "Settings - … - Obsidian 1.13.4" while
+    // `.modal button` there returns ["Turn on and reload","Browse","Check for
+    // updates"]. So the old locator reported "Settings did not open in any
+    // Obsidian window" about a window it was open in. What this test claims is
+    // that the Remote SSH tab is reachable, and the tab is its own evidence.
     await page.keyboard.press('Control+,');
-    const settingsPage = await findPageWith(page, '.modal-container', 10_000);
+    const pluginTabSel = '.vertical-tab-nav-item:has-text("Remote SSH")';
+    const settingsPage = await findPageWith(page, pluginTabSel, 10_000);
     expect(
       settingsPage,
-      `Settings did not open in any Obsidian window.\n  windows: ${await describePages(page)}`,
+      'the Remote SSH settings tab is not reachable in any Obsidian window ' +
+      `after Ctrl+,.\n  windows: ${await describePages(page)}`,
     ).not.toBeNull();
 
-    const settingsModal = settingsPage!.locator('.modal-container');
-    const pluginTab = settingsModal
-      .locator('.vertical-tab-nav-item:has-text("Remote SSH")')
-      .first();
-    await expect(pluginTab).toBeVisible({ timeout: 5_000 });
-
     // Close settings so subsequent tests start from a clean state.
+    const pluginTab = settingsPage!.locator(pluginTabSel).first();
     await settingsPage!.keyboard.press('Escape');
-    await expect(settingsModal).toBeHidden({ timeout: 5_000 });
+    await expect(pluginTab).toBeHidden({ timeout: 5_000 });
   });
 
   test('3 — command palette shows Remote SSH commands', async () => {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.20",
+  "version": "1.1.8-beta.21",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.20",
+  "version": "1.1.8-beta.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.20",
+      "version": "1.1.8-beta.21",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.20",
+  "version": "1.1.8-beta.21",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #501.

## The inventory from #500 paid for itself on its first run

From `E2E (core)` on [run 30775609866](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30775609866):

```
#0 (driven) vault=e2e-vault-PEhgGR  "New tab - … - Obsidian 1.13.4"   1024x800  modals:0
#1          vault=null              "Settings - … - Obsidian 1.13.4"   900x700  modals:0
                                    modalButtons:["Turn on and reload","Browse","Check for updates"]
```

Window #1 reports **`modals:0`** while `.modal button` on that same page returns three settings buttons. So the standalone Settings window has a `.modal` but **no `.modal-container`** — and `.modal-container` is exactly what every sweep and assertion in this file anchored on.

That single fact explains both remaining symptoms:

- `dismissBlockingModals` called the workspace clean **about the one window Settings was open in**, so it never closed it.
- smoke 2 reported "Settings did not open in any Obsidian window" — while printing an inventory showing it open.

## Changes

- **`SETTINGS_ROOT`** — anchor Settings on the tab rail, not `.modal-container`. smoke 2 now asserts the **Remote SSH tab** itself: that is what the test claims, and the tab is its own evidence.
- The sweep falls back to **Escape on that page** when `app.setting.close()` has no `app` to call — window #1's line reads `vault:null`, so it may not have one. A CDP key event reaches the target page without needing OS focus.
- **`CONNECT_MODAL`** — the receipt in `driveConnectFlow` was worse than useless as a bare `.modal`: the Settings window carries one, so a window ConnectModal was never in could satisfy the receipt, and the click that followed would find no button and report nothing wrong. Now it matches ConnectModal only (auth pane always renders `.remote-ssh-connect-button`; the multi-profile picker renders the "Connect to remote vault" heading).
- The inventory carries `bareModals` and `settingsTabs` alongside `modals`, so the next red says which shape it found rather than leaving the two indistinguishable.

## Already green

`smoke 3 — command palette shows Remote SSH commands` **passed** on #500's core run (714 ms). That half of the window split is fixed.

## Verification

- `tsc --noEmit` over `e2e/**` — clean (only the pre-existing `playwright.config.ts` `actionTimeout` complaint)
- `npm run lint` — 1 pre-existing warning, 0 errors

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)