### PR TITLE
fix(e2e): never click a Connect button that is already connecting

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.21",
+  "version": "1.1.8-beta.22",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -436,26 +436,62 @@ export async function driveConnectFlow(page: Page): Promise<void> {
   }
 
   // Click Connect, in whichever window ConnectModal rendered in.
-  //
-  // The modal is one pane or two depending on the profile count
-  // (`ConnectModal.onOpen`): a single profile renders the auth pane straight
-  // away, several render a picker first whose per-row Connect opens that
-  // profile's pane. Either way `.remote-ssh-connect-button` is the button that
-  // fires the handshake, so prefer it and fall back to any Connect-labelled
-  // button for the picker row. A pane with nothing left to click is not an
-  // error — that is the shape of a profile needing no confirmation.
-  const clickPage = flowPage;
-  if (clickPage !== null) {
-    for (let stage = 0; stage < 2; stage++) {
-      const paneBtn = clickPage.locator('.modal .remote-ssh-connect-button').first();
-      const btn = (await isVisibleWithin(paneBtn, stage === 0 ? 5_000 : 2_000))
-        ? paneBtn
-        : clickPage.locator('.modal button:has-text("Connect")').first();
-      if (!(await isVisibleWithin(btn, 2_000))) break;
-      await btn.click().catch(() => { /* the pane may have closed under us */ });
-      await clickPage.waitForTimeout(400);   // let the next pane render
-    }
+  if (flowPage !== null) {
+    await clickConnect(flowPage);
   }
+}
+
+/**
+ * Click ConnectModal through to the handshake — once per pane, never twice.
+ *
+ * The two-stage loop this replaces spent whole test budgets clicking a button
+ * that could not be clicked. `ConnectModal.renderConnectButton`'s handler sets
+ * `btn.disabled = true` and relabels it "Connecting…" the moment the handshake
+ * starts; the second pass re-found that same `.remote-ssh-connect-button`, saw
+ * it was still visible, and called `click()` on it. Playwright's actionability
+ * check then waits for the button to become enabled — and it never does, so
+ * with no explicit timeout the call ate the rest of the test. That is the
+ * 120 s in smoke 4 and the 240 s in connect-lifecycle on run 30775609866,
+ * both reported at the `waitForTimeout(400)` immediately after the click.
+ *
+ * The pane count is a property of the profile list, not something to probe
+ * twice (`ConnectModal.onOpen`): one profile renders the auth pane directly,
+ * several render a picker whose per-row Connect opens that profile's pane.
+ * `.remote-ssh-connect-button` is the button that fires the handshake in both.
+ * A modal with nothing clickable is not an error — that is the shape of a
+ * profile needing no confirmation.
+ */
+async function clickConnect(page: Page): Promise<void> {
+  const paneBtn = page.locator('.modal .remote-ssh-connect-button').first();
+
+  if (!(await isVisibleWithin(paneBtn, 5_000))) {
+    // Multi-profile: choose a row first, which renders that profile's pane.
+    const rowBtn = page.locator('.modal button:has-text("Connect")').first();
+    if (!(await isVisibleWithin(rowBtn, 2_000))) return;
+    if (!(await clickIfEnabled(rowBtn))) return;
+    if (!(await isVisibleWithin(paneBtn, 5_000))) return;
+  }
+
+  await clickIfEnabled(paneBtn);
+}
+
+/**
+ * Click, but never block on a button that cannot be clicked.
+ *
+ * Both halves matter. A disabled button is checked for up front, because
+ * Playwright would otherwise wait for it to become enabled; and `click` gets
+ * an explicit timeout, because the default is the whole remaining test budget
+ * and a click that cannot land should cost seconds, not the run.
+ */
+async function clickIfEnabled(
+  locator: ReturnType<Page['locator']>,
+  timeoutMs = 5_000,
+): Promise<boolean> {
+  if (await locator.isDisabled().catch(() => true)) return false;
+  return locator
+    .click({ timeout: timeoutMs })
+    .then(() => true)
+    .catch(() => false); // the pane may have closed under us
 }
 
 /**

--- a/plugin/e2e/playwright.config.ts
+++ b/plugin/e2e/playwright.config.ts
@@ -27,14 +27,6 @@ export default defineConfig({
   // workflow sets E2E_DEMO=1 to opt it back in.
   testIgnore: process.env.E2E_DEMO ? [] : ['**/demo.spec.ts'],
   timeout: 120_000,
-  // Playwright's DEFAULT actionTimeout is 0 — wait FOREVER. With Obsidian's
-  // virtualised File Explorer under Xvfb a node can be *attached but never
-  // actionable* (hover popovers swallow pointer events, rows paint lazily), so
-  // a bare `.click()` blocked until the whole test timed out: three minutes
-  // burned with NO message, which reads as "the product hung" when in fact the
-  // harness was waiting. Bound it — an unactionable element now fails with
-  // Playwright's own locator diagnostic, well inside the 120 s test budget.
-  actionTimeout: 30_000,
   retries: 1,
   // Obsidian is a single-instance app, so a machine can only ever drive ONE
   // window: `workers: 1` is not tunable. But that constraint is PER MACHINE —
@@ -101,6 +93,20 @@ export default defineConfig({
       : []),
   ],
   use: {
+    // Playwright's DEFAULT actionTimeout is 0 — wait FOREVER. With Obsidian's
+    // virtualised File Explorer under Xvfb a node can be *attached but never
+    // actionable* (hover popovers swallow pointer events, rows paint lazily), so
+    // a bare `.click()` blocks until the whole test times out: minutes burned
+    // with NO message, which reads as "the product hung" when in fact the
+    // harness was waiting. Bound it — an unactionable element fails with
+    // Playwright's own locator diagnostic, well inside the 120 s test budget.
+    //
+    // This lived at the config's TOP LEVEL, where `actionTimeout` is not an
+    // option at all, so the bound it describes had never once applied — `tsc`
+    // says so directly ("'actionTimeout' does not exist in type 'Config<…>'").
+    // Every unbounded click in the suite could still eat a whole budget, and
+    // several did on run 30775609866.
+    actionTimeout: 30_000,
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
   },

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.21",
+  "version": "1.1.8-beta.22",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.21",
+  "version": "1.1.8-beta.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.21",
+      "version": "1.1.8-beta.22",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.21",
+  "version": "1.1.8-beta.22",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #502.

Two forms of one defect: **a click that cannot land was allowed to cost the whole test.**

## 1. The second click on a disabled button

`ConnectModal.renderConnectButton`'s handler sets `btn.disabled = true` and relabels the button `Connecting…` as soon as the handshake starts. The two-stage click loop then re-found that same `.remote-ssh-connect-button`, saw it was still *visible*, and clicked it again. Playwright's actionability check waits for a disabled button to become enabled — and this one never does — so with no explicit timeout the call ate the remaining budget.

That is exactly what [run 30775609866](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30775609866) reports:

| spec | budget | reported at |
|---|---|---|
| `smoke 4 — connect to remote vault via command palette` | 120 s exceeded | `helpers/obsidian.ts:415` — the `waitForTimeout(400)` right after the click |
| `connect-lifecycle` | 240 s exceeded | `helpers/obsidian.ts:446` — the retry sleep in `connectAndWaitForShadowVault` |

Which made the harness look like a product hang.

`clickConnect` replaces the loop. The pane count is a property of the profile list, not something to probe twice (`ConnectModal.onOpen`): one profile renders the auth pane directly, several render a picker whose per-row Connect opens that pane. `clickIfEnabled` checks `isDisabled()` first and passes an explicit timeout, so a button that cannot be clicked costs seconds.

## 2. The general form — `actionTimeout` was in the wrong place

```ts
timeout: 120_000,
// Playwright's DEFAULT actionTimeout is 0 — wait FOREVER. […] a bare `.click()`
// blocked until the whole test timed out: three minutes burned with NO message,
// which reads as "the product hung" when in fact the harness was waiting.
actionTimeout: 30_000,   // ← top level, where this is not an option
retries: 1,
```

`actionTimeout` is a **`use`** option. At the config's top level it is not an option at all — `tsc` says so outright:

```
error TS2769: … 'actionTimeout' does not exist in type 'Config<PlaywrightTestOptions …>'
```

So the bound its own comment describes had **never once applied**, and every unbounded click in the suite could still take a whole budget. Moved into `use`; the `e2e/**` typecheck is now completely clean, which is the confirmation it is in a valid position.

## Checked and left alone

`.github/workflows/e2e.yml:44` lists `plugin/playwright.config.ts`, which does not exist — the file is at `plugin/e2e/playwright.config.ts`. It is **not** a coverage gap: `plugin/e2e/**` on the line above already covers it. Redundant, not broken, so out of scope here.

## Verification

- `tsc --noEmit` over `e2e/**` — **clean, no errors at all** (previously had the `actionTimeout` one)
- `npm run lint` — 1 pre-existing warning, 0 errors

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)