### PR TITLE
fix(e2e): close the Settings window for real, and report it truthfully

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.22",
+  "version": "1.1.8-beta.23",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/fs-sync-bridge-probe.spec.ts
+++ b/plugin/e2e/fs-sync-bridge-probe.spec.ts
@@ -52,6 +52,14 @@ let remote: RemoteVerifier;
 let shadowVaultPath: string;
 
 test.beforeAll(async () => {
+  // Two Obsidian launches, a real SSH connect and a full shadow-vault load.
+  // The default 120 s budget never covered that; it only looked like it did
+  // because the hook used to fail in ~1 ms, before connect worked at all. Now
+  // that it runs, run 30778480180 reports "Test timeout of 120000ms exceeded /
+  // Fixture 'trace recording' timeout … during setup". Same budget
+  // `images.spec.ts` gives the same shape of work, for the same reason.
+  test.setTimeout(300_000);
+
   await assertSshdReachable();
   remote = new RemoteVerifier();
   if (!(await remote.connect())) throw new Error('RemoteVerifier could not connect to the test sshd');

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -945,37 +945,62 @@ export async function dismissBlockingModals(
  * a CDP key event is delivered to the target page without needing OS focus.
  */
 async function closeSettingsEverywhere(page: Page): Promise<number> {
-  let closed = 0;
-  for (const p of contextPages(page)) {
-    const wasOpen = await p
-      .evaluate((sel) => {
-        const open = Boolean(document.querySelector(sel));
-        const setting = (window as unknown as {
-          app?: { setting?: { close?: () => void } };
-        }).app?.setting;
-        setting?.close?.();
-        return open;
-      }, SETTINGS_ROOT)
-      .catch(() => false);
-    if (!wasOpen) continue;
+  if (await findPageWith(page, SETTINGS_ROOT, 0) === null) return 0;
+  const gone = await closeSettings(page);
+  console.warn(
+    `[e2e] dismissBlockingModals: Obsidian's Settings dialog was open (auto-opened by the ` +
+    `trust-dismiss path); ${gone ? 'closed it' : 'FAILED to close it'}. Left up, it owns ` +
+    'every later modal — that is how ConnectModal ended up in a window no locator was ' +
+    'looking at.',
+  );
+  return gone ? 1 : 0;
+}
 
-    // Still there? It is the standalone Settings window with no `app` to ask.
-    if (await isVisibleWithin(p.locator(SETTINGS_ROOT).first(), 1_000)) {
-      await p.keyboard.press('Escape').catch(() => { /* best effort */ });
-      await p
-        .locator(SETTINGS_ROOT)
-        .first()
-        .waitFor({ state: 'hidden', timeout: 3_000 })
-        .catch(() => { /* reported by the inventory if it matters */ });
-    }
-    console.warn(
-      '[e2e] dismissBlockingModals: closed Obsidian\'s Settings dialog (auto-opened by ' +
-      'the trust-dismiss path). Left up, it owns every later modal — that is how ' +
-      'ConnectModal ended up in a window no locator was looking at.',
-    );
-    closed++;
+/**
+ * Close Obsidian's Settings, wherever and whatever shape it is in, and report
+ * whether it actually went away.
+ *
+ * Three means, because one is not enough. Escape alone is what smoke 2 used,
+ * and run 30778480180 shows it does not work on the standalone window: the tab
+ * stayed `visible` for the full 5 s, resolving 14 times to
+ * `<div data-setting-id="remote-ssh" class="vertical-tab-nav-item tappable">`.
+ * `app.setting.close()` is the product's own path but needs an `app`, and that
+ * window's inventory line reads `vault:null`. So if the dialog is still up and
+ * it is a window of its own, the window is closed — it is a stray Obsidian
+ * surface the harness opened by clicking "Trust author and enable plugins",
+ * not a product assertion, and leaving it up has already cost this suite days.
+ *
+ * The driven page is never closed, whatever it is showing.
+ *
+ * Returns the truth. An earlier revision logged "closed" after merely trying,
+ * which is how a Settings window nobody could close read as one that had been.
+ */
+export async function closeSettings(page: Page, timeoutMs = 8_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  for (const p of contextPages(page)) {
+    await p
+      .evaluate(() => {
+        (window as unknown as {
+          app?: { setting?: { close?: () => void } };
+        }).app?.setting?.close?.();
+      })
+      .catch(() => { /* a window without `app` cannot be asked */ });
   }
-  return closed;
+
+  for (;;) {
+    const openOn = await findPageWith(page, SETTINGS_ROOT, 0);
+    if (openOn === null) return true;
+    if (Date.now() >= deadline) return false;
+
+    await openOn.keyboard.press('Escape').catch(() => { /* best effort */ });
+    if (await findPageWith(page, SETTINGS_ROOT, 1_000) === null) return true;
+
+    if (openOn !== page && !openOn.isClosed()) {
+      await openOn.close().catch(() => { /* best effort */ });
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
 }
 
 /** The original per-window Escape sweep. */

--- a/plugin/e2e/smoke.spec.ts
+++ b/plugin/e2e/smoke.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   launchObsidian,
   connectAndOpenShadow,
+  closeSettings,
   describePages,
   findPageWith,
   type ObsidianHandle,
@@ -75,10 +76,17 @@ test.describe('Remote SSH E2E smoke', () => {
       `after Ctrl+,.\n  windows: ${await describePages(page)}`,
     ).not.toBeNull();
 
-    // Close settings so subsequent tests start from a clean state.
-    const pluginTab = settingsPage!.locator(pluginTabSel).first();
-    await settingsPage!.keyboard.press('Escape');
-    await expect(pluginTab).toBeHidden({ timeout: 5_000 });
+    // Close settings so subsequent tests start from a clean state — and say so
+    // if it does not close. Escape alone does not: on the standalone Settings
+    // window the tab stayed visible for the full 5 s, resolving 14 times to
+    // `<div data-setting-id="remote-ssh" class="vertical-tab-nav-item tappable">`.
+    // `closeSettings` tries the product's own `app.setting.close()` first and
+    // closes the stray window as a last resort.
+    expect(
+      await closeSettings(page),
+      'Settings would not close by any means, so every later spec inherits it.\n' +
+      `  windows: ${await describePages(page)}`,
+    ).toBe(true);
   });
 
   test('3 — command palette shows Remote SSH commands', async () => {

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.22",
+  "version": "1.1.8-beta.23",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.22",
+  "version": "1.1.8-beta.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.22",
+      "version": "1.1.8-beta.23",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.22",
+  "version": "1.1.8-beta.23",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #503.

## #503 turned the suite over

| shard | #503 | before |
|---|---|---|
| **features** | **✅ 27 passed (36.3 s)** | 27 m 37 s, total loss |
| stress | 18 passed / 3 failed (2.2 m) | 25 m 36 s, total loss |
| core | 16 passed / 3 failed / 3 flaky (15.1 m) | 1 h 11 m, total loss |

The old wall-times were almost entirely timeout burn, not work.

Two of the three core failures are the harness, and **both are mine**.

## 1. smoke 2 — the tab is found, the dialog will not close

#502's half works: `.vertical-tab-nav-item[data-setting-id="remote-ssh"]` resolves. The failure is the teardown I added — Escape does **not** close the standalone Settings window:

```
Expected: hidden / Received: visible / Timeout: 5000ms
14 × locator resolved to <div data-setting-id="remote-ssh" class="vertical-tab-nav-item tappable">…
```

`app.setting.close()` is the product's own path, but it needs an `app`, and that window's inventory line reads `vault:null`.

`closeSettings` tries all three: the API on every window, Escape on the window holding the dialog, and finally **closing that window**. It is a stray Obsidian surface the harness itself opened by clicking "Trust author and enable plugins" — not a product assertion — and leaving it up has already cost this suite days. The driven page is never closed. smoke 2 asserts the result, because a Settings window nothing can close is inherited by every later spec.

**And it now returns the truth.** The version I wrote in #502 logged `closed` after merely *trying*, so a dialog nobody could close reported as one that had been. That is the same silent-failure shape this whole stack has been unpicking, and I put it in.

## 2. `fs-sync-bridge-probe` never had a hook budget

Its `beforeAll` does two Obsidian launches, a real SSH connect and a full shadow-vault load, with no `test.setTimeout`. That never fit in the default 120 s — it only *looked* like it did because the hook used to fail in ~1 ms, before connect worked at all. Now it reports:

```
Test timeout of 120000ms exceeded.
Fixture "trace recording" timeout of 120000ms exceeded during setup.
```

Given the same 300 s `images.spec.ts` gives the same shape of work, for the reason its own comment states. **No assertion is touched.**

## Left alone: the third failure is a product signal

`connect-lifecycle (SFTP)` fails with the plugin's own log line:

```
[error] Connect failed: Connection timed out  (original: "Connection timed out after 30000ms")
```

30 s to the millisecond after `installMissingShadowPlugins`, in the shadow vault's auto-connect. The three flaky specs (`connect-reconnect`, `plugin-code-roundtrip`, `restart-settings`) show the same line and pass on retry, so it is intermittent. Not touched here — it needs its own investigation, and it is exactly the kind of red this stack was built to expose.

`fs-visibility`'s remaining 3 in the stress shard are likewise product-side (#429 `getFullPath` / `getFilePath` materialisation), not harness.

## Verification

- `tsc --noEmit` over `e2e/**` — clean
- `npm run lint` — 1 pre-existing warning, 0 errors

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)