### PR TITLE
test(e2e): verify #490 against a working E2E

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.23",
+  "version": "1.1.8-beta.24",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.23",
+  "version": "1.1.8-beta.24",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.23",
+  "version": "1.1.8-beta.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.23",
+      "version": "1.1.8-beta.24",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.11",
+      "version": "1.1.8-beta.12",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.11",
+  "version": "1.1.8-beta.12",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.23",
+  "version": "1.1.8-beta.24",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/AdapterManager.ts
+++ b/plugin/src/adapter/AdapterManager.ts
@@ -26,6 +26,7 @@ import { logger } from '../util/logger';
 import { errorMessage } from '../util/errorMessage';
 import * as path from 'path';
 import * as fs from 'fs';
+import { nativeFs } from '../util/nativeFs';
 
 /**
  * The set of FileSystemAdapter methods that get monkey-patched onto
@@ -270,11 +271,11 @@ export class AdapterManager {
       writeFile: (abs, data) => {
         fs.mkdirSync(path.dirname(abs), { recursive: true });
         fs.writeFileSync(abs, data);
-        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        const s = nativeFs.statSync(abs, { throwIfNoEntry: false });
         return s ? { size: s.size, mtimeMs: s.mtimeMs } : null;
       },
       statFile: (abs) => {
-        const s = fs.statSync(abs, { throwIfNoEntry: false });
+        const s = nativeFs.statSync(abs, { throwIfNoEntry: false });
         return s?.isFile() ? { size: s.size, mtimeMs: s.mtimeMs } : null;
       },
       deleteFile: (abs) => fs.rmSync(abs, { force: true }),

--- a/plugin/src/adapter/SftpDataAdapter.ts
+++ b/plugin/src/adapter/SftpDataAdapter.ts
@@ -22,6 +22,7 @@ function isThumbnailEligible(vaultPath: string): boolean {
   return THUMBNAIL_EXTENSIONS.has(vaultPath.slice(dot + 1).toLowerCase());
 }
 import * as fs from 'fs';
+import { nativeFs } from '../util/nativeFs';
 import * as nodePath from 'path';
 import { pathToFileURL } from 'url';
 import type { MaterializedCache } from './MaterializedCache';
@@ -247,13 +248,13 @@ export class SftpDataAdapter {
     if (this.isConfigTree(normalizedPath)) {
       // Never ours (see isConfigTree); answer from the real disk only.
       return Boolean(this.shadowBasePath)
-        && fs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath));
+        && nativeFs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath));
     }
     if (cache.has(normalizedPath)) return true;
     // Already real on disk — materialised earlier, or written by
     // somebody. One stat, no network.
     if (this.shadowBasePath
-      && fs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath))) {
+      && nativeFs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath))) {
       return true;
     }
 
@@ -1059,7 +1060,7 @@ export class SftpDataAdapter {
       // Skipping costs nothing: the remote write already succeeded, and for
       // plugin CODE the local copy is owned by the pull/push binary
       // round-trip (`PLUGIN_BINARY_FILES`), not by this cache.
-      if (fs.lstatSync(abs, { throwIfNoEntry: false })?.isSymbolicLink()) {
+      if (nativeFs.lstatSync(abs, { throwIfNoEntry: false })?.isSymbolicLink()) {
         logger.warn(`writeThroughConfig: "${rel}" is a symlink — not mirrored (would clobber its target)`);
         return;
       }
@@ -1067,7 +1068,7 @@ export class SftpDataAdapter {
       // whole-dir plugin symlink from an older build) would redirect the
       // write out of the shadow root even though `abs` looked contained.
       const dir = nodePath.dirname(abs);
-      const realDir = fs.existsSync(dir) ? fs.realpathSync(dir) : null;
+      const realDir = nativeFs.existsSync(dir) ? nativeFs.realpathSync(dir) : null;
       if (realDir && realDir !== root && !realDir.startsWith(root + nodePath.sep)) {
         logger.warn(`writeThroughConfig: "${rel}" resolves outside the shadow root via a symlinked parent — not mirrored`);
         return;

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -34,6 +34,7 @@ import { SharedConfigWatcher } from './shadow/SharedConfigWatcher';
 import { LocalWriteWatcher, makeLocalWriteIgnore } from './adapter/LocalWriteWatcher';
 import { FsModulePatcher } from './adapter/FsModulePatcher';
 import { watchTree, listTreeFiles } from './util/watchTree';
+import { nativeFs } from './util/nativeFs';
 import { ShadowVaultManager } from './shadow/ShadowVaultManager';
 import { WindowSpawner } from './shadow/WindowSpawner';
 import { ShadowStartupCoordinator } from './shadow/ShadowStartupCoordinator';
@@ -763,11 +764,11 @@ export default class RemoteSshPlugin extends Plugin {
           watch: (onChange) => watchTree(vaultRoot, onChange, ignore),
           scan: () => listTreeFiles(vaultRoot, ignore),
           stat: (rel) => {
-            const s = fs.statSync(abs(rel), { throwIfNoEntry: false });
+            const s = nativeFs.statSync(abs(rel), { throwIfNoEntry: false });
             return s?.isFile() ? { size: s.size, mtimeMs: s.mtimeMs } : null;
           },
           read: (rel) => {
-            try { return fs.readFileSync(abs(rel)); } catch { return null; }
+            try { return nativeFs.readFileSync(abs(rel)); } catch { return null; }
           },
           push: async (rel, data) => {
             // `.md` goes through the text path so a mid-air collision

--- a/plugin/src/util/nativeFs.ts
+++ b/plugin/src/util/nativeFs.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+
+/**
+ * Node's real filesystem, captured before anything can replace it.
+ *
+ * `FsModulePatcher` takes over `fs.readFileSync`, `readdirSync`,
+ * `existsSync`, `statSync` and `lstatSync` on the SHARED module object,
+ * so that plugins reading the vault through Node see the remote tree
+ * (#429). That module is shared with this plugin too — and our own code
+ * asking "is this file really on disk?" must get the truth, not the
+ * virtual answer we manufacture for everyone else.
+ *
+ * Left unguarded, the patch feeds itself:
+ *
+ *  - the disk cache's `statFile` would see a synthesised stat for a
+ *    file it never wrote, conclude the copy had been "changed on disk",
+ *    and refuse to evict it — so the cache budget would stop working;
+ *  - `materializeSync` would see `existsSync` say yes and report a file
+ *    materialised when nothing is there;
+ *  - worst of all, the write-back watcher's rescan would list every note
+ *    in the vault as a local file and start pushing the whole tree back
+ *    to the remote.
+ *
+ * These bindings are taken at module evaluation — plugin load, long
+ * before a connect installs any patch — so they stay pristine. Internal
+ * callers use these; the patched module is for plugins.
+ */
+export const nativeFs = {
+  existsSync: fs.existsSync.bind(fs),
+  statSync: fs.statSync.bind(fs),
+  lstatSync: fs.lstatSync.bind(fs),
+  readdirSync: fs.readdirSync.bind(fs),
+  readFileSync: fs.readFileSync.bind(fs),
+  realpathSync: fs.realpathSync.bind(fs),
+} as const;

--- a/plugin/src/util/watchTree.ts
+++ b/plugin/src/util/watchTree.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { nativeFs } from './nativeFs';
 import { logger } from './logger';
 import { errorMessage } from './errorMessage';
 
@@ -45,7 +46,7 @@ const nodeDeps: WatchTreeDeps = {
   },
   listDirs: (dir) => {
     try {
-      return fs.readdirSync(dir, { withFileTypes: true })
+      return nativeFs.readdirSync(dir, { withFileTypes: true })
         .filter(e => e.isDirectory())
         .map(e => e.name);
     } catch {
@@ -173,7 +174,7 @@ export function listTreeFiles(
     const relDir = stack.pop()!;
     let entries: fs.Dirent[];
     try {
-      entries = fs.readdirSync(relDir === '' ? root : path.join(root, relDir), { withFileTypes: true });
+      entries = nativeFs.readdirSync(relDir === '' ? root : path.join(root, relDir), { withFileTypes: true });
     } catch {
       continue;                       // vanished or unreadable — nothing to report
     }

--- a/plugin/tests/nativeFs.test.ts
+++ b/plugin/tests/nativeFs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { nativeFs } from '../src/util/nativeFs';
+
+/**
+ * The invariant: `FsModulePatcher` replaces functions on the shared `fs`
+ * module so plugins see the remote vault, and our own code must keep
+ * seeing the real disk. If these ever start following the patch, the
+ * disk cache stops evicting and the write-back watcher starts pushing
+ * files that were never there.
+ *
+ * The end-to-end version of that — patch the module, then call
+ * `nativeFs` — is not reproducible here: in the shipped bundle `fs` is a
+ * plain CommonJS object and assignment works, but under vitest's ESM
+ * interop the namespace is frozen and neither assignment nor `vi.spyOn`
+ * can redefine a builtin's export. So this pins the two halves that ARE
+ * observable: the technique (a bound copy is detached from later
+ * mutation of the object it came from) and the result (nativeFs reads
+ * the real disk, and covers every function the patcher takes over).
+ */
+describe('nativeFs', () => {
+  const made: string[] = [];
+
+  afterEach(() => {
+    for (const f of made.splice(0)) fs.rmSync(f, { force: true });
+  });
+
+  it('reads the real disk', () => {
+    const file = path.join(os.tmpdir(), `nativefs-${process.pid}.txt`);
+    fs.writeFileSync(file, 'real bytes');
+    made.push(file);
+
+    expect(nativeFs.existsSync(file)).toBe(true);
+    expect(nativeFs.existsSync(path.join(os.tmpdir(), `nativefs-${process.pid}-absent.txt`))).toBe(false);
+    expect(nativeFs.readFileSync(file).toString()).toBe('real bytes');
+    expect(nativeFs.statSync(file).size).toBe('real bytes'.length);
+  });
+
+  it('covers every function the patcher takes over', () => {
+    for (const k of ['existsSync', 'statSync', 'lstatSync', 'readdirSync', 'readFileSync'] as const) {
+      expect(typeof (nativeFs as unknown as Record<string, unknown>)[k], `nativeFs.${k} is missing`)
+        .toBe('function');
+    }
+  });
+
+  it('a bound copy is detached from later mutation of its module object', () => {
+    // Exactly how nativeFs is built, against a stand-in we CAN mutate.
+    const mod: { existsSync: (p: string) => boolean } = { existsSync: () => false };
+    const snapshot = mod.existsSync.bind(mod);
+
+    mod.existsSync = () => true;                 // the patch lands
+
+    expect(mod.existsSync('anything'), 'the stand-in was not actually patched').toBe(true);
+    expect(
+      snapshot('anything'),
+      'the bound copy followed the patch — the snapshot technique does not hold',
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Stacked on #504. **This one is the product fix — it merges #490 in so the suite can adjudicate it.**

## The remaining stress failures are #490's bug, verbatim

#490's commit message, third bullet:

> `materializeSync` sees `existsSync` say yes and reports a file materialised when nothing is there, so **`getFullPath` hands back a path to nothing while claiming success**.

[Run 30779545596](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30779545596), stress shard:

```
getFullPath('remote_demo1.md') → /home/runner/.obsidian-remote/vaults/E2E Test--vault (5)/remote_demo1.md
<<unreadable: Error: ENOENT: no such file or directory, open '…/remote_demo1.md'>>
```

The mechanism is visible in the source. `materializeSync` short-circuits on

```ts
// Already real on disk — materialised earlier, or written by somebody. One stat, no network.
if (this.shadowBasePath && fs.existsSync(nodePath.join(this.shadowBasePath, normalizedPath))) {
  return true;   // ← returns success without writing anything
}
```

and that `fs` is the **shared** module, whose `existsSync` this plugin's own `FsModulePatcher` has replaced with one that answers from `vault.fileMap`. So it says yes for every note in the model, `materializeSync` reports success, `getFullPath` returns the path, and the patched `readFileSync` — reaching the same short-circuit — falls through to the real filesystem and ENOENTs.

That is precisely the observed pair: `existsSync` true, `readFileSync` ENOENT, nothing on disk.

## Why it was never caught

`fix/native-fs-snapshot` (#490) is a **sibling** of this stack off `next`, not an ancestor. No E2E run in this whole sequence has included it. It was also written while every connect-dependent spec died before reaching any product code, so it has never been verified by anything but unit tests.

## What is in this PR

The merge, and a version bump. **No code of mine on top.** If the two `fs-visibility` failures go green, #490 is the fix; if they do not, the cause is elsewhere and we will have learned that without guessing.

## Verification so far

- `tsc --noEmit` (src) — clean; `e2e/**` — clean
- `npm run lint` — 1 pre-existing warning, 0 errors
- vitest — **1315 passed**, 86/86 files (including `nativeFs.test.ts` from #490; the `ShadowVaultBootstrap` parallel-run flake was green this time)

## Still open, not addressed here

`fs-sync-bridge-probe` (core) still reports `Test timeout of 120000ms exceeded / Fixture "trace recording" timeout … during setup` even with the 300 s hook budget #504 gave it — so the time is going somewhere other than the hook. That spec probes whether a **synchronous** XHR can reach the daemon, which is the self-deadlock the design line forbids; it needs its own look rather than a bigger number.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)