### PR TITLE
test(e2e): make the #429 reds name the materialisation fault

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.24",
+  "version": "1.1.8-beta.25",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/fs-visibility.spec.ts
+++ b/plugin/e2e/fs-visibility.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import {
   launchObsidian,
   connectAndWaitForShadowVault,
+  dumpMaterialisationState,
   findShadowVaultPath,
   waitForShadowVaultLoaded,
   type ObsidianHandle,
@@ -524,7 +525,8 @@ test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429
       'a synchronous read of a note nobody has asked for returned bytes. That means either ' +
       'the vault is being mirrored to disk — the design this plugin exists to avoid — or ' +
       'a blocking fetch crept back in, which deadlocks: the bridge that would serve the ' +
-      'content runs on the very thread being blocked.',
+      'content runs on the very thread being blocked.\n' +
+      `  ${await dumpMaterialisationState(obsidian.page, shadowVaultPath)}`,
     ).toContain('ENOENT');
   });
 
@@ -604,7 +606,8 @@ test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429
     expect(
       probe.before.error,
       'the note was already on disk before anything asked for it — something materialises ' +
-      'eagerly, which is the mirror this design refuses',
+      'eagerly, which is the mirror this design refuses\n' +
+      `  ${await dumpMaterialisationState(obsidian.page, shadowVaultPath)}`,
     ).toContain('ENOENT');
 
     expect(
@@ -826,19 +829,29 @@ test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429
       `complete its write against a remote vault. Error: ${probe!.error}`,
     ).toBeNull();
 
-    await expect
-      .poll(() => remote.exists(REAL_PLUGIN_NOTE), {
-        message:
-          `#429, verbatim: the ${FS_PLUGIN_ID} plugin ran fs.writeFileSync(path.join(` +
-          `this.app.vault.adapter.basePath, '${REAL_PLUGIN_NOTE}')) in onload(), the write ` +
-          `SUCCEEDED (it wrote ${probe!.wrote}), and the note is nowhere on the remote ` +
-          'vault. This is exactly what users report: "Claudian creates .md files in the ' +
-          'local folder instead of the remote vault". The fix belongs in the product — ' +
-          'mirror the note tree and watch it, or give basePath / getFullPath / getFilePath ' +
-          'an FS-backed view of the remote — never in this assertion.',
-        timeout: 30_000,
-      })
-      .toBe(true);
+    // The dump goes on the FAILURE, not into `poll`'s message: that message is
+    // built once, up front, and the question here — did `LocalWriteWatcher`
+    // ever see this file — is only answerable after the wait has expired.
+    try {
+      await expect
+        .poll(() => remote.exists(REAL_PLUGIN_NOTE), {
+          message:
+            `#429, verbatim: the ${FS_PLUGIN_ID} plugin ran fs.writeFileSync(path.join(` +
+            `this.app.vault.adapter.basePath, '${REAL_PLUGIN_NOTE}')) in onload(), the write ` +
+            `SUCCEEDED (it wrote ${probe!.wrote}), and the note is nowhere on the remote ` +
+            'vault. This is exactly what users report: "Claudian creates .md files in the ' +
+            'local folder instead of the remote vault". The fix belongs in the product — ' +
+            'mirror the note tree and watch it, or give basePath / getFullPath / getFilePath ' +
+            'an FS-backed view of the remote — never in this assertion.',
+          timeout: 30_000,
+        })
+        .toBe(true);
+    } catch (e) {
+      throw new Error(
+        `${e instanceof Error ? e.message : String(e)}\n` +
+        `  ${await dumpMaterialisationState(obsidian.page, shadowVaultPath)}`,
+      );
+    }
 
     expect(
       await remote.readFile(REAL_PLUGIN_NOTE),

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -1437,6 +1437,96 @@ async function readShadowModel(
 }
 
 /**
+ * What is REALLY on the shadow disk, what the plugin thinks it put there, and
+ * what its write-back watcher did — the three answers the #429 reds need.
+ *
+ * Run 30781101691 left two questions unanswerable from CI output alone. A note
+ * nobody asked for read back synchronously (`fs-visibility:493`), and a
+ * plugin's `writeFileSync` under `basePath` succeeded locally and never
+ * reached the remote (`:770`, and `plugin-code-roundtrip:344` in the same
+ * shape). "Something materialised eagerly" and "the watcher did not push" are
+ * guesses until the disk and the log say so.
+ *
+ * The listing is taken from THIS process's `fs`, which is the real one:
+ * `FsModulePatcher` only ever replaces the module inside Obsidian's renderer,
+ * so the test runner sees the actual filesystem and cannot be told a virtual
+ * story about it. The log lines are the product's own
+ * (`LocalWriteWatcher: watching the shadow vault root …`,
+ * `LocalWriteWatcher: pushed out-of-band write …`,
+ * `MaterializedCache: … exceeds the cache limit`), so a push that never
+ * happened is distinguishable from one that was refused.
+ *
+ * Read-only and best-effort throughout.
+ */
+export async function dumpMaterialisationState(
+  page: Page,
+  shadowVaultPath: string,
+): Promise<string> {
+  const onDisk: string[] = [];
+  const walk = (dir: string, rel: string): void => {
+    if (onDisk.length >= 40) return;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      if (e.name === '.obsidian') continue;   // never the cache's to own (#488)
+      const child = `${rel}${rel ? '/' : ''}${e.name}`;
+      if (e.isDirectory()) {
+        walk(path.join(dir, e.name), child);
+      } else {
+        const size = fs.statSync(path.join(dir, e.name), { throwIfNoEntry: false })?.size ?? -1;
+        onDisk.push(`${child} (${size}b)`);
+      }
+    }
+  };
+  walk(shadowVaultPath, '');
+
+  const ledger = await page
+    .evaluate(() => {
+      const mc = (window as unknown as {
+        app?: {
+          plugins?: {
+            plugins?: Record<string, {
+              adapterMgr?: {
+                materialized?: { size?: () => number; bytes?: () => number } | null;
+              };
+            }>;
+          };
+        };
+      }).app?.plugins?.plugins?.['remote-ssh']?.adapterMgr?.materialized;
+      if (!mc) return 'unreachable';
+      return { entries: mc.size?.() ?? -1, bytes: mc.bytes?.() ?? -1 };
+    })
+    .catch((e: unknown) => `unreadable: ${String(e)}`);
+
+  let watcher = '<no plugin log>';
+  try {
+    const logPath = path.join(
+      shadowVaultPath, '.obsidian', 'plugins', 'remote-ssh', 'console.log',
+    );
+    if (fs.existsSync(logPath)) {
+      const lines = fs.readFileSync(logPath, 'utf8')
+        .replace(/\0/g, '')
+        .split('\n')
+        .filter((l) => /LocalWriteWatcher|MaterializedCache|materialis/i.test(l));
+      watcher = lines.length ? lines.slice(-15).join(' | ') : '<no watcher/cache lines>';
+    }
+  } catch (e) {
+    watcher = `<unreadable: ${String(e)}>`;
+  }
+
+  return (
+    `on the real shadow disk (${onDisk.length}${onDisk.length >= 40 ? '+' : ''} files): ` +
+    `${onDisk.length ? onDisk.join(', ') : '(empty)'}\n` +
+    `  materialisation ledger: ${JSON.stringify(ledger)}\n` +
+    `  plugin log (watcher/cache): ${watcher}`
+  );
+}
+
+/**
  * Diagnostic snapshot string: the in-page model + the shadow window's
  * structured-log tail (where `VaultModelBuilder: built Nf + Md` / its
  * per-entry errors land). Attached to assertion failures so a red

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.24",
+  "version": "1.1.8-beta.25",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.24",
+  "version": "1.1.8-beta.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.24",
+      "version": "1.1.8-beta.25",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.24",
+  "version": "1.1.8-beta.25",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #505.

## Where #505 left us

**#490 fixed what it claimed** — `getFullPath` and `getFilePath` are gone from the failure list. Three others took their place, and they split cleanly in two:

| | failure | symptom |
|---|---|---|
| **A** | `fs-visibility:493`, `:576` | a note nobody asked for reads back synchronously — `read.error` is `null` where the contract wants `ENOENT` |
| **B** | `fs-visibility:770`, `plugin-code-roundtrip:344` | a plugin's `writeFileSync` under `basePath` **succeeds locally and never reaches the remote** |

## There is an obvious story, and that is the problem

#490's own commit message says the patched `existsSync` made `materializeSync` *"report a file materialised when nothing is there"* — so before it, nothing was ever written and a cold read was `ENOENT` **for the wrong reason**. It also says the patched `readdirSync` made the watcher's rescan *"push the whole tree back to the remote"* — which would have carried the plugin's file with it.

If both hold, #490 removed a bug that was **accidentally satisfying B**, and made materialisation real enough to **expose A**.

That is a story, not evidence. This suite has already cost five rounds of confident wrong causes, and nothing in CI can currently settle it: these specs never attach the shadow vault's own log, so *"the watcher never saw the file"* and *"the watcher pushed and the remote rejected it"* look identical from the outside.

## What this adds

`dumpMaterialisationState` reports the three things that separate them:

1. **what is really on the shadow disk** — taken from the *test runner's* `fs`, which is the real one. `FsModulePatcher` only replaces the module inside Obsidian's renderer, so this is the one vantage point that cannot be told a virtual story.
2. **the materialisation ledger** — `adapterMgr.materialized` entry count and bytes, i.e. what the plugin believes it put there.
3. **the product's own log lines** — `LocalWriteWatcher: watching the shadow vault root …`, `LocalWriteWatcher: pushed out-of-band write …`, `MaterializedCache: … exceeds the cache limit`. A push that never happened becomes distinguishable from one that was refused.

For `:770` it is attached to the **failure**, not to `expect.poll`'s `message` — that message is built before the wait starts, and the question is what happened during it.

**No assertion, matcher or timeout is changed.** One CI round should name both faults.

## Verification

- `tsc --noEmit` over `e2e/**` — clean
- `npm run lint` — 1 pre-existing warning, 0 errors

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)