### PR TITLE
fix(watcher): scan what is already on disk when the write-back arms

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.25",
+  "version": "1.1.8-beta.26",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.25",
+  "version": "1.1.8-beta.26",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.25",
+  "version": "1.1.8-beta.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.25",
+      "version": "1.1.8-beta.26",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.25",
+  "version": "1.1.8-beta.26",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {

--- a/plugin/src/adapter/LocalWriteWatcher.ts
+++ b/plugin/src/adapter/LocalWriteWatcher.ts
@@ -38,6 +38,16 @@ export interface LocalWriteWatcherDeps {
    * never — a deployment without the disk cache is unaffected.
    */
   isMirroredCopy?(rel: string, stat: LocalFileStat): boolean;
+  /**
+   * Whether the remote already has this path. Consulted ONLY for files
+   * found by the startup scan, whose provenance is unknown: a note a
+   * plugin wrote while nothing was watching, or a materialised copy that
+   * outlived the disconnect that should have removed it. Absent from the
+   * remote means the former, and it is pushed; present means we cannot
+   * tell which side is newer, and the remote is left alone. Omitted →
+   * startup-seeded files are never pushed.
+   */
+  remoteExists?(rel: string): Promise<boolean>;
   /** Largest single file to push. Bigger files are skipped, loudly. */
   maxBytes: number;
   /** Coalesces a burst of writes; also the interval between stability samples. */
@@ -135,6 +145,8 @@ export class LocalWriteWatcher {
   private readonly pushed = new Map<string, string>();
   /** Paths already reported to the user, so one broken file is not a Notice storm. */
   private readonly reported = new Set<string>();
+  /** Paths the startup scan found, whose provenance is unknown until checked. */
+  private readonly seededAtStart = new Set<string>();
 
   constructor(private readonly deps: LocalWriteWatcherDeps) {}
 
@@ -142,6 +154,29 @@ export class LocalWriteWatcher {
     if (this.closer) return;
     this.closer = this.deps.watch((rel) => this.onEvent(rel));
     logger.info('LocalWriteWatcher: watching the shadow vault root for out-of-band writes');
+
+    // Anything already on disk gets no event, ever. `watch` only reports
+    // CHANGES, so a file that was written before this call was invisible to
+    // the write-back for the whole session — and the one case that matters
+    // most is exactly that: a plugin writing under `basePath` in its own
+    // `onload()`, which runs while we are still connecting. That is the
+    // field report this feature exists for ("Claudian creates .md files in
+    // the local folder instead of the remote vault"), and `e2e/fs-visibility`
+    // pins it.
+    //
+    // It looked like it worked, before: `scan()` used to read the PATCHED
+    // `readdirSync`, so a single filename-less event enumerated the whole
+    // virtual vault and swept such files up with it. That was the write
+    // storm #490 removed, and removing it showed the legitimate path had
+    // never covered them.
+    //
+    // Seeded paths carry unknown provenance and are gated in `flushOne`.
+    for (const rel of this.deps.scan()) {
+      if (this.deps.ignore(rel)) continue;
+      this.seededAtStart.add(rel);
+      this.dirty.add(rel);
+    }
+    if (this.dirty.size > 0) this.arm();
   }
 
   stop(): void {
@@ -156,6 +191,7 @@ export class LocalWriteWatcher {
     this.dirty.clear();
     this.sample.clear();
     this.reported.clear();
+    this.seededAtStart.clear();
   }
 
   /** Number of paths this session has pushed. Test/diagnostic hook. */
@@ -254,6 +290,30 @@ export class LocalWriteWatcher {
       // re-reported on every later event for it.
       this.pushed.set(rel, sig);
       return;
+    }
+
+    // Provenance gate for the startup scan, and only for it. A file that
+    // was already on disk when we armed is either an out-of-band write
+    // nothing was watching for, or a materialised copy that outlived the
+    // disconnect meant to remove it — and after a relaunch the ledger is
+    // empty, so `isMirroredCopy` above cannot tell them apart.
+    //
+    // Absent from the remote decides it: nothing we materialised can be
+    // missing there, so it is the user's. Present, and we do not know which
+    // side is newer; pushing on a guess would overwrite a remote that may
+    // have moved on, so it is left for a real edit to trigger the normal
+    // path. Said out loud, because a file silently not pushed is the shape
+    // of bug this whole area keeps producing.
+    if (this.seededAtStart.delete(rel)) {
+      const onRemote = await this.deps.remoteExists?.(rel) ?? true;
+      if (onRemote) {
+        this.pushed.set(rel, sig);
+        logger.info(
+          `LocalWriteWatcher: "${rel}" was already on disk at connect and the remote has ` +
+          'it too — provenance unknown, so it is not pushed. An edit from here on is.',
+        );
+        return;
+      }
     }
 
     const data = this.deps.read(rel);

--- a/plugin/src/main.ts
+++ b/plugin/src/main.ts
@@ -789,6 +789,11 @@ export default class RemoteSshPlugin extends Plugin {
           // content; pushing it back would be an echo.
           isMirroredCopy: (rel, st) =>
             this.adapterMgr.materialized?.isMirroredCopy(rel, st) ?? false,
+          // Provenance for the startup scan only. The ledger above is empty
+          // after a relaunch, so it cannot say whether a file already on
+          // disk is the user's or a stale mirror; the remote can, by not
+          // having it.
+          remoteExists: (rel) => da.exists(rel),
           maxBytes,
           debounceMs: 400,
           setTimer: (cb, ms) => window.setTimeout(cb, ms),

--- a/plugin/tests/LocalWriteWatcher.test.ts
+++ b/plugin/tests/LocalWriteWatcher.test.ts
@@ -26,6 +26,16 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   const onError = vi.fn((_rel: string, _msg: string) => {});
   /** Paths the disk cache currently claims as its own materialised copy. */
   const mirrored = new Set<string>();
+  /**
+   * Paths the remote already has. Only the startup scan consults this, and it
+   * is what tells a pre-existing file's provenance apart: absent there means
+   * an out-of-band write nothing was watching for.
+   *
+   * Empty by default, which is what every test here already means by its
+   * starting `files` — the user's own content, to be pushed. A test about a
+   * file the remote also has adds it explicitly.
+   */
+  const remote = new Set<string>();
 
   const w = new LocalWriteWatcher({
     watch: (cb) => { onChange = cb; return { close: () => { closed = true; } }; },
@@ -37,6 +47,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
     removeRemote,
     ignore: makeLocalWriteIgnore('.obsidian', ['.git', 'node_modules']),
     isMirroredCopy: (rel) => mirrored.has(rel),
+    remoteExists: (rel) => Promise.resolve(remote.has(rel)),
     maxBytes,
     debounceMs: 400,
     setTimer: (cb) => { pending = cb; return 1; },
@@ -45,7 +56,7 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
   });
 
   return {
-    w, push, removeRemote, onError, mirrored,
+    w, push, removeRemote, onError, mirrored, remote,
     trigger: (rel: string | null) => onChange?.(rel),
     /** Fire the pending debounce and let the async flush settle. */
     tick: async () => {
@@ -67,6 +78,46 @@ function harness(files: Record<string, string> = {}, maxBytes = 1024 * 1024) {
 }
 
 describe('LocalWriteWatcher', () => {
+  // `watch` reports CHANGES, so a file already on disk when we arm never
+  // produces an event and was invisible to the write-back for the whole
+  // session. The case that matters most is exactly that: a plugin writing
+  // under `basePath` in its own `onload()`, which runs while the connect is
+  // still in flight. `e2e/fs-visibility` pins it end-to-end; these two pin
+  // the decision the scan has to make.
+  it('pushes a file that was already on disk and is NOT on the remote (#429)', async () => {
+    // The remote does not have it, so nothing we materialised can be its
+    // source: it is the user's, written while nothing was watching.
+    const h = harness({ 'claudian.md': 'written in onload' });
+
+    h.w.start();
+    await h.tick();
+    expect(
+      h.push,
+      'pushed on the first sample — the stability rule does not apply to the startup scan',
+    ).not.toHaveBeenCalled();
+
+    await h.tick();
+    expect(h.push).toHaveBeenCalledTimes(1);
+    expect(h.push.mock.calls[0][0]).toBe('claudian.md');
+    expect(h.push.mock.calls[0][1].toString()).toBe('written in onload');
+  });
+
+  it('leaves a file that was already on disk AND on the remote alone', async () => {
+    // After a relaunch the materialisation ledger is empty, so
+    // `isMirroredCopy` cannot tell a stale mirror from the user's own file.
+    // Pushing on that guess would overwrite a remote that may have moved on.
+    const h = harness({ 'remote_demo1.md': 'the remote wrote this' });
+    h.remote.add('remote_demo1.md');
+
+    h.w.start();
+    await h.tick();
+    await h.tick();
+    expect(
+      h.push,
+      'pushed a file of unknown provenance back over the remote copy it may be a stale mirror of',
+    ).not.toHaveBeenCalled();
+  });
+
   it('pushes a file a plugin wrote under the vault root (#429)', async () => {
     const h = harness();
     h.w.start();


### PR DESCRIPTION
Stacked on #506. **Product fix.** #506's diagnostics named the fault in one round.

## The evidence

From `fs-visibility:773` on [run 30782633453](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30782633453):

```
on the real shadow disk (2 files): e2e-fs-mscoxhzg-claudian.md (67b), remote_demo1.md (198b)
materialisation ledger: {"entries":0,"bytes":0}
plugin log (watcher/cache):
  LocalWriteWatcher: watching the shadow vault root for out-of-band writes
  LocalWriteWatcher: watching the shadow vault root for out-of-band writes
```

The watcher is armed. The plugin's 67-byte note is sitting right there. And there is **not one `pushed out-of-band write` line** in the whole log.

## The fault

`start()` only registered a `watch` callback, and `watch` reports **changes**. A file already on disk when we arm produces no event, ever — so it was invisible to the write-back for the entire session.

The case that matters most is exactly that shape: **a plugin writing under `basePath` in its own `onload()`**, which runs while the connect is still in flight. That is the field report this feature exists for — *"Claudian creates .md files in the local folder instead of the remote vault"*.

It *looked* like it worked before, because `scan()` read the **patched** `readdirSync`: one filename-less platform event enumerated the whole virtual vault and swept such files up with it. That is the write storm #490 removed — and removing it revealed the legitimate path had never covered them.

| test | #504 (no #490) | #505 (with #490) | |
|---|---|---|---|
| `plugin-code-roundtrip:344 push:` | ✓ 3.8 s | ✘ | real regression — the storm was carrying it |
| `fs-visibility:773` | `-` did not run | ✘ | **not** a regression — this bug, running for the first time |

## The fix, and the judgement call in it

`start()` now seeds `dirty` from the same `scan()`.

Those paths carry unknown provenance, and after a relaunch the ledger is empty (`entries:0` above) so `isMirroredCopy` cannot tell the user's file from a materialised copy that outlived the disconnect meant to delete it. Pushing on that guess would **overwrite a remote that may have moved on**.

So seeded paths are gated on the remote — the option you picked:

- **absent on the remote** → nothing we materialised could be its source, so it is the user's → **pushed**
- **present on the remote** → we cannot tell which side is newer → **left alone**, and *logged*, because a file quietly not pushed is the exact shape of bug this area keeps producing

An edit from then on is an ordinary event and takes the ordinary path, ledger and all.

`remoteExists` is **optional** and defaults to "assume present", so a deployment that does not wire it keeps today's behaviour rather than gaining a push nobody asked for.

## Known limitation, stated rather than hidden

A file that exists on both sides and was genuinely edited out-of-band *while disconnected* is not pushed at connect. Distinguishing that from a stale mirror needs a persisted materialisation ledger (the ledger survives a clean disconnect but not a crash). Worth its own issue; not smuggled in here.

## Verification

- `tsc --noEmit` (src) — clean; `e2e/**` — clean
- `npm run lint` — 1 pre-existing warning, 0 errors
- vitest — **1317 passed**, 86/86 files, including 2 new `LocalWriteWatcher` cases pinning both halves of the gate

Two pre-existing watcher tests initially went red against a first draft of the harness default; the default was wrong, not them — their starting `files` mean "the user's content, to be pushed", and the harness now says so. **No existing assertion was changed.**

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)