### PR TITLE
test(e2e): print the cold-read evidence that Playwright was discarding

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.26",
+  "version": "1.1.8-beta.27",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/fs-visibility.spec.ts
+++ b/plugin/e2e/fs-visibility.spec.ts
@@ -520,8 +520,15 @@ test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429
     // Cold: nobody has asked for this note, so the synchronous surface
     // has nothing to hand over. This is the CONTRACT, not a defect —
     // the async test below is the half that fetches.
+    // `read.error ?? <describe the success>` rather than `read.error`: when the
+    // read SUCCEEDS this is null, and `toContain` on null raises Playwright's
+    // own "Matcher error: received value must not be null nor undefined" — which
+    // DISCARDS the custom message. #506 attached the whole materialisation dump
+    // here and run 30782633453 printed none of it, for exactly that reason. The
+    // assertion is unchanged in strength — a successful read still fails, because
+    // the description does not contain ENOENT — it just survives to be read.
     expect(
-      read.error,
+      read.error ?? `<no error: the read SUCCEEDED, returning ${JSON.stringify(read.body)}>`,
       'a synchronous read of a note nobody has asked for returned bytes. That means either ' +
       'the vault is being mirrored to disk — the design this plugin exists to avoid — or ' +
       'a blocking fetch crept back in, which deadlocks: the bridge that would serve the ' +
@@ -603,8 +610,10 @@ test.describe('a plugin\'s view of the filesystem must be the REMOTE vault (#429
       return { before, after: readSync() };
     }, COLD_NOTE);
 
+    // Same reason as `:494` above — null here discards the message with it.
     expect(
-      probe.before.error,
+      probe.before.error
+        ?? `<no error: the read SUCCEEDED, returning ${JSON.stringify(probe.before.body)}>`,
       'the note was already on disk before anything asked for it — something materialises ' +
       'eagerly, which is the mirror this design refuses\n' +
       `  ${await dumpMaterialisationState(obsidian.page, shadowVaultPath)}`,

--- a/plugin/e2e/helpers/obsidian.ts
+++ b/plugin/e2e/helpers/obsidian.ts
@@ -1477,8 +1477,13 @@ export async function dumpMaterialisationState(
       if (e.isDirectory()) {
         walk(path.join(dir, e.name), child);
       } else {
-        const size = fs.statSync(path.join(dir, e.name), { throwIfNoEntry: false })?.size ?? -1;
-        onDisk.push(`${child} (${size}b)`);
+        // mtime, not just size: "what is on disk" does not say WHEN it landed,
+        // and the whole question behind the cold-read reds is whether a file
+        // appeared before or after the thing that supposedly asked for it. The
+        // log lines below carry ISO timestamps, so these line up against them.
+        const st = fs.statSync(path.join(dir, e.name), { throwIfNoEntry: false });
+        const when = st ? new Date(st.mtimeMs).toISOString() : '?';
+        onDisk.push(`${child} (${st?.size ?? -1}b @${when})`);
       }
     }
   };
@@ -1503,26 +1508,36 @@ export async function dumpMaterialisationState(
     .catch((e: unknown) => `unreadable: ${String(e)}`);
 
   let watcher = '<no plugin log>';
+  let tail = '<no plugin log>';
   try {
     const logPath = path.join(
       shadowVaultPath, '.obsidian', 'plugins', 'remote-ssh', 'console.log',
     );
     if (fs.existsSync(logPath)) {
-      const lines = fs.readFileSync(logPath, 'utf8')
+      const all = fs.readFileSync(logPath, 'utf8')
         .replace(/\0/g, '')
         .split('\n')
-        .filter((l) => /LocalWriteWatcher|MaterializedCache|materialis/i.test(l));
-      watcher = lines.length ? lines.slice(-15).join(' | ') : '<no watcher/cache lines>';
+        .filter(Boolean);
+      const hits = all.filter((l) => /LocalWriteWatcher|MaterializedCache|materialis/i.test(l));
+      watcher = hits.length ? hits.slice(-15).join(' | ') : '<no watcher/cache lines>';
+      // The filtered view answers "did the watcher act". It cannot answer
+      // "then what DID put this file here", and for the cold-read reds that is
+      // the question — the writer may be `populateVaultFromRemote`,
+      // `preSpawnPull`, `installMissingShadowPlugins` or something unlooked-for.
+      // An unfiltered tail costs nothing and names it.
+      tail = all.slice(-10).join(' | ') || '<empty>';
     }
   } catch (e) {
     watcher = `<unreadable: ${String(e)}>`;
+    tail = watcher;
   }
 
   return (
     `on the real shadow disk (${onDisk.length}${onDisk.length >= 40 ? '+' : ''} files): ` +
     `${onDisk.length ? onDisk.join(', ') : '(empty)'}\n` +
     `  materialisation ledger: ${JSON.stringify(ledger)}\n` +
-    `  plugin log (watcher/cache): ${watcher}`
+    `  plugin log (watcher/cache): ${watcher}\n` +
+    `  plugin log (last 10): ${tail}`
   );
 }
 

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.26",
+  "version": "1.1.8-beta.27",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.26",
+  "version": "1.1.8-beta.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.26",
+      "version": "1.1.8-beta.27",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.26",
+  "version": "1.1.8-beta.27",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #507.

## My own instrumentation threw the evidence away

#506 attached the full materialisation dump to the two cold-read reds. [Run 30782633453](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30782633453) printed **none of it**. The reason is in the assertion:

```ts
expect(read.error, '<dump>').toContain('ENOENT');
```

When the read **succeeds** — which is the failure being investigated — `read.error` is `null`, and `toContain` on null raises Playwright's own:

```
Matcher error: received value must not be null nor undefined
Received has value: null
```

That error **discards the custom message**. So the one run that could have named the cause threw the evidence away, and the diagnostic I added to settle this looked like it had nothing to say. That is on me.

## The fix

Both sites now pass `read.error ?? '<no error: the read SUCCEEDED, returning …>'`.

Identical strength — a successful read still fails, because that description does not contain `ENOENT` — and the message survives. It also shows *what* came back, which distinguishes "the real note" from "something else at that path".

## The dump gained what it was missing for this question

- **mtime per file.** "What is on disk" does not say *when* it landed, and the whole question is whether a file appeared before or after the thing that supposedly asked for it. Rendered ISO, to line up against the log's timestamps.
- **an unfiltered 10-line log tail.** The filtered view answers *"did the watcher act"*. It cannot answer *"then what DID put this file here"* — and the writer may be `populateVaultFromRemote`, `preSpawnPull`, `installMissingShadowPlugins`, or something unlooked-for.

**No assertion, matcher or timeout is changed.**

## Where the stack stands

| shard | #507 |
|---|---|
| features | ✅ 27 passed |
| stress | 19 passed / **2 failed** (`:494`, `:578` — this PR's target) / 1 flaky |
| core | 18 passed / 2 failed (`fs-sync-bridge-probe`; `:419` shadow-vault-load flake) / 1 flaky |

#507 fixed the real one: `fs-visibility:773 REAL-PLUGIN REPRODUCTION` — a plugin's `fs.writeFileSync` in `onload()` now reaches the remote.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)