### PR TITLE
test(e2e): find out whose fault the metadata re-read is

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.31",
+  "version": "1.1.8-beta.32",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/metadata-index-probe.spec.ts
+++ b/plugin/e2e/metadata-index-probe.spec.ts
@@ -160,11 +160,26 @@ async function measure(page: ObsidianHandle['page']): Promise<Record<string, unk
         });
       }
 
+      // Obsidian validates a cached metadata entry against the file's identity.
+      // If OUR side reports a different `(mtime, size)` on each launch, every
+      // entry looks stale and the re-read is our own doing — fixable, and it
+      // would make seeding the cache work after all. If the identity is stable
+      // and Obsidian re-reads anyway, reuse is genuinely refused and only
+      // runtime injection is left. Those two cost very different amounts to
+      // build, so the difference is worth one map.
+      const fingerprint: Record<string, string> = {};
+      for (const f of md.slice(0, 200) as any[]) {
+        if (typeof f?.path === 'string') {
+          fingerprint[f.path] = `${f?.stat?.mtime ?? '?'}:${f?.stat?.size ?? '?'}`;
+        }
+      }
+
       out.cost = {
         readCache: stats ?? 'unreachable',
         filesInModel: files.length,
         markdownInModel: md.length,
         totalMdBytes,
+        statFingerprint: fingerprint,
         traffic: { noteEntries, noteBytes, configEntries, configBytes },
         // THE scaling number: note bytes pulled over note bytes that exist.
         noteBytesOverTotal: totalMdBytes > 0
@@ -312,6 +327,18 @@ test.describe('capability probe: can the metadata index come from the remote? (#
     const rec2 = totalRecords(recordsOf(secondRun));
     const reused = n1 !== null && n2 !== null && n1 > 0 && n2 / n1 < 0.2;
 
+    // Did the files keep the same identity across the two launches?
+    const fpOf = (r: Record<string, unknown>): Record<string, string> =>
+      ((r.cost as { statFingerprint?: Record<string, string> } | undefined)
+        ?.statFingerprint) ?? {};
+    const fp1 = fpOf(firstRun);
+    const fp2 = fpOf(secondRun);
+    const changed = Object.keys(fp1)
+      .filter((p) => fp2[p] !== fp1[p])
+      .slice(0, 10)
+      .map((p) => ({ path: p, firstRun: fp1[p], secondRun: fp2[p] ?? '<absent>' }));
+    const statStable = Object.keys(fp1).length > 0 && changed.length === 0;
+
     const report = {
       firstRun,
       secondRun,
@@ -323,9 +350,15 @@ test.describe('capability probe: can the metadata index come from the remote? (#
           ? Number((n2 / n1).toFixed(3))
           : null,
         cachedRecordsOnSecondRun: rec2,
-        // Three outcomes, not two. "Re-read every start" and "never saved in
-        // the first place" look identical in a byte count and need entirely
-        // different fixes, which is why the record count is here.
+        // Whose fault the re-read is. Obsidian validates a cached entry
+        // against the file's identity, so an identity that changes on every
+        // launch would invalidate everything — and that would be ours to fix,
+        // not a property of Obsidian.
+        statStableAcrossLaunches: statStable,
+        statChanged: changed,
+        // Four outcomes. "Re-read every start", "never saved", and "we kept
+        // handing Obsidian a different file" look identical in a byte count
+        // and need entirely different fixes.
         reading: n1 === null || n2 === null
           ? 'could not measure both runs'
           : reused
@@ -333,8 +366,12 @@ test.describe('capability probe: can the metadata index come from the remote? (#
             : rec2 === 0 || rec2 === null
               ? 'nothing was persisted — cannot yet tell refused-reuse from never-saved; ' +
                 'see indexingSettled before reading anything into this'
-              : 'persisted but re-read anyway — reuse is refused, so seeding alone will ' +
-                'not help and the index must be injected at runtime',
+              : !statStable
+                ? 'persisted, but WE changed the files\' (mtime, size) between launches, so ' +
+                  'every cached entry looked stale. Ours to fix — and seeding becomes ' +
+                  'viable once it is'
+                : 'persisted, identity stable, and re-read anyway — reuse is genuinely ' +
+                  'refused, so seeding cannot help and the index must be injected at runtime',
       },
     };
 

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.31",
+  "version": "1.1.8-beta.32",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.31",
+  "version": "1.1.8-beta.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.31",
+      "version": "1.1.8-beta.32",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.31",
+  "version": "1.1.8-beta.32",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #510.

## Where the probe got to

With `indexingSettled: true` on **both** runs — so no more "we killed it before it saved":

```json
"firstRunNoteBytes": 929, "secondRunNoteBytes": 929, "secondOverFirst": 1,
"cachedRecordsOnSecondRun": 11
```

`totalMdBytes` is also 929, so the ratio is exactly **1.000** once `.obsidian` traffic is separated out: **Obsidian reads 100% of note content on every start.** And it does so despite having 11 records persisted in this vault's IndexedDB.

The verdict called that *"reuse is refused, so the index must be injected at runtime"*.

## That skips a possibility — and it is the cheap one

Obsidian validates a cached entry against the file's **identity**. If **our** side reports a different `(mtime, size)` on each launch, every entry looks stale and the re-read is **our own doing**. That is fixable, and seeding the cache would then work — a much smaller build than runtime injection into `fileCache` / `metadataCache` / `resolvedLinks`.

So the probe now fingerprints `TFile.stat` per markdown file and compares the two launches:

- `statStableAcrossLaunches` — did the identities hold
- `statChanged` — what moved, capped at ten entries
- the verdict grows a **fourth** outcome, one that names us rather than Obsidian

**This is not a claim that this is the cause.** It is the check that has to happen before "runtime injection" is treated as settled, because the two answers cost very different amounts to build.

## Verification

- `tsc --noEmit` over `e2e/**` — clean
- `npm run lint` — 1 pre-existing warning, 0 errors

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)