### PR TITLE
test(e2e): capture the server's side of the connect timeout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,6 +174,28 @@ jobs:
         # nothing is dropped, it is just spread across runners.
         run: npx playwright test --config e2e/playwright.config.ts --project=${{ matrix.shard }}
 
+      # `Connect failed: Connection timed out after 30000ms` is the last
+      # standing flake and it has now appeared in all three shards. The plugin
+      # log goes quiet after `TOFU: Trusting new host key` and says nothing
+      # more — from the client side there is no way to tell a handshake the
+      # server never answered from one it refused, or from one it never
+      # received. sshd runs with `-e`, so its account of the same seconds is
+      # one `docker logs` away. Without it the next round of this is guesswork,
+      # and this suite has already paid for enough of that.
+      - name: Capture test sshd log on failure
+        if: failure()
+        run: |
+          docker logs --timestamps obsidian-remote-ssh-test-sshd > /tmp/sshd.log 2>&1 || true
+          echo "--- captured $(wc -l < /tmp/sshd.log) lines ---"
+
+      - name: Upload test sshd log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-sshd-log-${{ matrix.shard }}-${{ github.run_id }}
+          path: /tmp/sshd.log
+          retention-days: 14
+
       - name: Tear down test sshd
         if: always()
         run: npm run sshd:stop

--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.32",
+  "version": "1.1.8-beta.33",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.32",
+  "version": "1.1.8-beta.33",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.32",
+  "version": "1.1.8-beta.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.32",
+      "version": "1.1.8-beta.33",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.32",
+  "version": "1.1.8-beta.33",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #511.

## The flake that is now blocking everything else

`Connect failed: Connection timed out after 30000ms` hit **all three shards in one run** ([30801676889](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30801676889)) — core ×2, stress ×1, features ×1. It is what took the metadata probe down before it could print its verdict, and it is behind `plugin-code-roundtrip:419`, `vault-features:307` and several of the "flaky" entries in earlier runs.

## The client's account stops dead

```
SftpClient: connecting to 127.0.0.1:2222 as tester
Auth: using private key /<REDACTED>
TOFU: Trusting new host key for 127.0.0.1:2222
   ← 30 seconds of nothing
Connect failed: Connection timed out after 30000ms
runAutoConnect(layout-ready): connect did not reach CONNECTED state; skipping populate
```

I checked the obvious suspect and it is not guilty: host verification returns `true` promptly via the no-handler auto-TOFU branch, and `SftpClient`'s `hostVerifier` is wired to ssh2's async overload correctly — `verify` is called on both the resolve and reject paths. So the stall is **after** verification.

And from the client side, three very different failures look identical — silence:

- the connection never reached sshd
- sshd dropped it (`MaxStartups` defaults are in play; the image sets only `PasswordAuthentication`, `PubkeyAuthentication` and `StrictModes`)
- auth began and stalled

## What this adds

sshd already runs with `-e`, and `plugin/scripts/start-test-sshd.mjs:75` already reaches for `docker logs obsidian-remote-ssh-test-sshd` on its own failure path. The same log, for the same seconds, distinguishes all three. Captured per shard, **on failure only**, and uploaded as `e2e-sshd-log-<shard>-<run_id>`.

No step, matrix entry or trigger is touched.

## Stated plainly

**I do not have a cause for this yet.** This is the check that stops the next attempt from being a guess — the same move that turned the `:773` write-back bug from a story into a one-round diagnosis in #506 → #507.

Refs #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)