### PR TITLE
test(e2e): can we keep the tree and refuse the content?

### DIFF
--- a/manifest-beta.json
+++ b/manifest-beta.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.33",
+  "version": "1.1.8-beta.34",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/e2e/metadata-index-probe.spec.ts
+++ b/plugin/e2e/metadata-index-probe.spec.ts
@@ -8,6 +8,8 @@ import {
 import { scaffoldTestVault, type ScaffoldResult } from './helpers/vault-scaffold';
 import { assertSshdReachable } from './helpers/sshd';
 import { logPathFor } from './helpers/log-oracle';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 /**
  * CAPABILITY PROBE — can the link/tag index be served from the remote, instead
@@ -396,5 +398,118 @@ test.describe('capability probe: can the metadata index come from the remote? (#
       'no markdown in the vault model — the probe ran against an empty vault, so every ' +
       'number above is meaningless rather than reassuring',
     ).toBeGreaterThan(0);
+  });
+
+  /**
+   * Can we keep the TREE and refuse the CONTENT?
+   *
+   * That is the whole question, because the two are not equally expensive and
+   * they buy different things. `BackgroundIndexer.ts:55` records the half that
+   * is free: `metadataCache` resolves links against `fileMap` alone, so links,
+   * Quick Switcher and graph NODES need names and nothing else. Backlinks,
+   * search, tags/frontmatter and Dataview are the half that needs bytes.
+   *
+   * Registering a file is currently what triggers Obsidian to read it, so
+   * today those come as a package. Obsidian's own "Excluded files" setting is
+   * the one documented, user-facing lever that might separate them —
+   * `userIgnoreFilters` on disk, `isUserIgnored` / `updateUserIgnoreFilters`
+   * on the running `metadataCache`, both of which the shape probe above found.
+   *
+   * Unlike injecting `fileCache` / `metadataCache`, this is published
+   * behaviour, so a design resting on it is not a bet on internals.
+   *
+   * Set the filter, relaunch, and measure. Two things matter and they are
+   * separate: whether the content reads stop, and whether the files SURVIVE
+   * in the model — an exclusion that empties `fileMap` would take links and
+   * Quick Switcher with it and be no use at all.
+   */
+  test('PROBE — does excluding files stop Obsidian reading them?', async () => {
+    test.setTimeout(300_000);
+
+    const baseline = await measure(obsidian.page);
+
+    // Obsidian stores this in the vault's own `app.json`. `/…/` is its regex
+    // form; this one matches every markdown file. The plugin's
+    // `pullSharedObsidianConfig` logged `skipped [app.json, …]` for this
+    // fixture, so it will not overwrite what we write here — recorded because
+    // if that ever changes, this probe goes quietly meaningless.
+    const appJsonPath = path.join(shadowVaultPath, '.obsidian', 'app.json');
+    let existing: Record<string, unknown> = {};
+    try {
+      existing = JSON.parse(fs.readFileSync(appJsonPath, 'utf8')) as Record<string, unknown>;
+    } catch { /* absent or unparseable — start from empty */ }
+    fs.mkdirSync(path.dirname(appJsonPath), { recursive: true });
+    fs.writeFileSync(
+      appJsonPath,
+      JSON.stringify({ ...existing, userIgnoreFilters: ['/\\.md$/'] }, null, 2),
+      'utf8',
+    );
+
+    await obsidian.cleanup();
+    obsidian = await launchObsidian(shadowVaultPath);
+
+    // NOT `waitForShadowVaultLoaded`: it requires `getMarkdownFiles() >= 1`,
+    // and "the exclusion emptied the model" is one of the answers being
+    // measured, not a reason to abort before reporting it.
+    const modelHasFiles = await obsidian.page
+      .waitForFunction(
+        () => {
+          const v = (globalThis as unknown as { app?: { vault?: any } }).app?.vault;
+          return Object.keys(v?.fileMap ?? {}).length > 1;
+        },
+        undefined,
+        { timeout: 60_000 },
+      )
+      .then(() => true)
+      .catch(() => false);
+    await settle(obsidian.page);
+    const excluded = await measure(obsidian.page);
+
+    const notes = (r: Record<string, unknown>): number | null => {
+      const c = r.cost as { traffic?: { noteBytes?: number } } | undefined;
+      return typeof c?.traffic?.noteBytes === 'number' ? c.traffic.noteBytes : null;
+    };
+    const inModel = (r: Record<string, unknown>): number | null =>
+      (r.cost as { markdownInModel?: number } | undefined)?.markdownInModel ?? null;
+    const parsed = (r: Record<string, unknown>): number | null =>
+      (r.cost as { withParsedMetadata?: number } | undefined)?.withParsedMetadata ?? null;
+
+    const b = notes(baseline);
+    const e = notes(excluded);
+    const stoppedReading = b !== null && e !== null && b > 0 && e / b < 0.2;
+    const keptTheTree = (inModel(excluded) ?? 0) > 0;
+
+    const report = {
+      baseline: baseline.cost,
+      excluded: excluded.cost,
+      verdict: {
+        modelHasFiles,
+        baselineNoteBytes: b,
+        excludedNoteBytes: e,
+        markdownInModel: { baseline: inModel(baseline), excluded: inModel(excluded) },
+        withParsedMetadata: { baseline: parsed(baseline), excluded: parsed(excluded) },
+        stoppedReading,
+        keptTheTree,
+        reading: b === null || e === null
+          ? 'could not measure both runs'
+          : stoppedReading && keptTheTree
+            ? 'EXCLUSION SEPARATES THEM — the tree survives and the content is not read. '
+              + 'Links, Quick Switcher and graph nodes can be kept at zero transfer.'
+            : stoppedReading
+              ? 'reads stopped, but the files left the model too — links and Quick Switcher '
+                + 'would go with them, so this lever costs what it saves'
+              : 'exclusion did not stop the reads — the tree and the content are one '
+                + 'package, and lazy registration is the only dial left',
+      },
+    };
+
+    // eslint-disable-next-line no-console
+    console.log(`[e2e] exclusion probe:\n${JSON.stringify(report, null, 2)}`);
+    await test.info().attach('exclusion-probe.json', {
+      body: JSON.stringify(report, null, 2),
+      contentType: 'application/json',
+    });
+
+    expect(b, 'no baseline note traffic to compare against').not.toBeNull();
   });
 });

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "remote-ssh",
   "name": "Remote SSH",
-  "version": "1.1.8-beta.33",
+  "version": "1.1.8-beta.34",
   "minAppVersion": "1.5.0",
   "description": "Edit remote vaults over SSH/SFTP — VS Code Remote-SSH style.",
   "author": "souta shimozono",

--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.33",
+  "version": "1.1.8-beta.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-remote-ssh",
-      "version": "1.1.8-beta.33",
+      "version": "1.1.8-beta.34",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-remote-ssh",
-  "version": "1.1.8-beta.33",
+  "version": "1.1.8-beta.34",
   "description": "VS Code Remote SSH-like experience for Obsidian",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
Stacked on #512. First step of the lazy-filesystem direction — and it may cut how much has to be given up.

## Injecting the index is off the table

Measured on [run 30802603656](https://github.com/sotashimozono/obsidian-remote-ssh/actions/runs/30802603656), with all four alternatives closed:

| check | result |
|---|---|
| killed before it saved? | `indexingSettled: {firstRun: true, secondRun: true}` |
| does it persist? | **yes — 11 records in this vault's IndexedDB** |
| do we hand it a different `(mtime, size)`? | **no — `statStableAcrossLaunches: true`, `statChanged: []`** |
| re-reads anyway? | **yes — 929/929, ratio 1.000** |

> `persisted, identity stable, and re-read anyway — reuse is genuinely refused`

Seeding cannot help. The only route left was writing into undocumented internals. Full write-up in #513.

## But "give up on the index" concedes more than necessary

The tree and the content are not equally expensive and do not buy the same things. `BackgroundIndexer.ts:55` records the free half — `metadataCache` resolves links against **`fileMap` alone**:

| feature | needs |
|---|---|
| file tree, open, edit, write | **tree only** |
| `[[link]]` resolve / click / suggest | **tree only** |
| Quick Switcher | **tree only** |
| graph **nodes** | **tree only** |
| tags / frontmatter / link extraction | content |
| backlinks | content |
| global search | content |
| Dataview | content |

Today they arrive as a package, because *registering* a file is what makes Obsidian read it.

## The one documented lever that might separate them

Obsidian's own **"Excluded files"** setting — `userIgnoreFilters` on disk, `isUserIgnored` / `updateUserIgnoreFilters` on the running `metadataCache`, all three of which the shape probe already found in `ownKeys`/`protoMethods`.

Unlike writing to `fileCache` / `metadataCache`, **this is published, user-facing behaviour** — a design resting on it is not a bet on internals.

So: set the filter, relaunch, measure. **Two outcomes, reported separately:**

- did the content reads stop?
- did the files **survive in the model**? An exclusion that empties `fileMap` takes links and Quick Switcher with it and is worth nothing.

It deliberately does **not** use `waitForShadowVaultLoaded` — that requires `getMarkdownFiles() >= 1`, and "the exclusion emptied the model" is one of the answers being measured, not a reason to abort before reporting it.

## If it comes back positive

Links, Quick Switcher and graph nodes stay at **zero content transfer**, at GB scale, and only backlinks / search / Dataview need an α (daemon-side grep and reverse-index, shown in our own views). If it comes back negative, lazy registration is the only dial left and the scope question is how deep to go.

Either way `vault-features.spec.ts` 2, 6, 7, 9 are affected — that is a **spec change**, not a test to weaken, and it is yours to sanction.

Refs #429, #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)